### PR TITLE
#209 - Switching from "result" tab to "progress" and back makes controls disappear

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useQueryResultTabs.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useQueryResultTabs.tsx
@@ -35,7 +35,7 @@ type ResultCurrentState = {
 
 export const useQueryResultTabs = (
     query?: QueryItem,
-): [TabsItemProps[], (tab: string) => void, ResultCurrentState] => {
+): [TabsItemProps[], (tab: string, queryId?: string) => void, ResultCurrentState] => {
     const [tab, setTab] = useState<QueryResultTab>(QueryResultTab.META);
     const [activeResultParams, setResultParams] =
         useState<ResultCurrentState['activeResultParams']>(undefined);

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/index.tsx
@@ -47,7 +47,8 @@ export const QueryResults = React.memo(function QueryResults({
     toolbar: React.ReactChild;
     minimized: boolean;
 }) {
-    const [tabs, setTab, {activeTabId, category, activeResultParams}] = useQueryResultTabs(query);
+    const [tabs, setActiveTab, {activeTabId, category, activeResultParams}] = useQueryResultTabs(query);
+    const setTab = (tabId: string) => setActiveTab(tabId, query.id);
     const resultIndex = activeResultParams?.resultIndex;
     return query ? (
         <div className={b(null, className)}>
@@ -61,7 +62,7 @@ export const QueryResults = React.memo(function QueryResults({
                         className={b('tabs')}
                         items={tabs}
                         activeTab={activeTabId}
-                        onSelectTab={(tabId: string) => setTab(tabId)}
+                        onSelectTab={setTab}
                     />
                     {category === QueryResultTab.RESULT && Number.isInteger(resultIndex) && (
                         <div className={b('tab_actions')}>


### PR DESCRIPTION
resolves #209
* passing query id to tab switching