### PR TITLE
Query results with more than 50 columns are not shown properly #208

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/module/api.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/api.ts
@@ -301,6 +301,7 @@ export function readQueryResults(
                         value_format: 'yql',
                         field_weight_limit: settings?.cellsSize,
                         encode_utf8: 'false',
+                        max_selected_column_count: 3000,
                     },
                 },
             },


### PR DESCRIPTION
According to issue #208, this PR addresses the difference between two queries: read_query_result and read_table.