### PR TITLE
fix: btoa method for NodeJS environment

### DIFF
--- a/packages/javascript-wrapper/lib/utils/setup.js
+++ b/packages/javascript-wrapper/lib/utils/setup.js
@@ -131,24 +131,19 @@ setup.createOption('requestHeaders', 'object', {});
 
 setup.createOption('suppressAccessTracking', 'boolean', false);
 
-var btoa = function (string) {
-    return Buffer(string).toString('base64');
-};
-
-if (typeof window !== 'undefined') {
-    btoa = window.btoa;
-}
-
 setup.encodeForYt = function (str) {
-    return unescape(encodeURIComponent(str));
+    if (typeof window !== 'undefined') {
+        // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
+        return window.btoa(unescape(encodeURIComponent(str)));
+    }
+    return Buffer.from(str).toString('base64');
 };
 
 setup.createOption('encodedParametersSettings', 'object', {
     maxSize: 64 * 1024,
     maxCount: 2,
     encoder: function (string) {
-        // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
-        return btoa(setup.encodeForYt(string));
+        return setup.encodeForYt(string);
     },
 });
 

--- a/packages/javascript-wrapper/test/encoder-jsdom.test.js
+++ b/packages/javascript-wrapper/test/encoder-jsdom.test.js
@@ -1,0 +1,5 @@
+/** @jest-environment jsdom */
+
+const { encoderTest } = require("./encoder.test.js");
+
+encoderTest("JSDOM");

--- a/packages/javascript-wrapper/test/encoder.test.js
+++ b/packages/javascript-wrapper/test/encoder.test.js
@@ -1,0 +1,21 @@
+const encoderTest = (ENV) => {
+  describe(`encoder ${ENV}`, () => {
+    const yt = require("../lib")({ exportBrowserModule: false });
+
+    test.each([
+      { str: "Hello World", expected: "SGVsbG8gV29ybGQ=" },
+      { str: "Привет Мир", expected: "0J/RgNC40LLQtdGCINCc0LjRgA==" },
+      { str: "你好世界", expected: "5L2g5aW95LiW55WM" },
+    ])("encoder('$str')", ({ str, expected }) => {
+      var settings = yt.setup.getOption(yt.setup, "encodedParametersSettings");
+      var encoded = settings.encoder(str);
+      expect(encoded).toBe(expected);
+    });
+  });
+};
+
+encoderTest("NodeJS");
+
+module.exports = {
+  encoderTest,
+};


### PR DESCRIPTION
### Problem:
When _yt-javascript-wrapper_ request query contains some cyrillic symbols:
`* from [//home/someTable] where x = "привет"`
the result of this request might be incorrect in NodeJs projects, but it works fine with browser environment.
_yt-javascript-wrapper_ library has redefinition of `btoa` method which takes effect only for NodeJS projects.
Redefined method works differently as `window.btoa`