### PR TITLE
fix: nodejs error during logout

### DIFF
--- a/packages/ui/src/server/controllers/login.ts
+++ b/packages/ui/src/server/controllers/login.ts
@@ -98,7 +98,7 @@ export async function handleLogout(req: Request, res: Response) {
             return throwAuthDisabled();
         }
         res.setHeader('set-cookie', `${YT_CYPRESS_COOKIE_NAME}=deleted; Path=/; Max-Age=0;`);
-        res.sendStatus(401).send('Logout');
+        res.status(401).send('Logout');
     } catch (e: any) {
         sendAndLogError(req.ctx, res, 500, e);
     }


### PR DESCRIPTION
I get an error during logout

```
[11:31:26 UTC] ERROR: [Express POST] [handleLogout] Error [61626bd4-50e3-4a00-9bac-883324230dec]
    extra: {}
    err: {
      "type": "Object",
      "message": "Cannot set headers after they are sent to the client",
      "stack":
          Error: Cannot set headers after they are sent to the client
              at new NodeError (node:internal/errors:405:5)
              at ServerResponse.setHeader (node:_http_outgoing:648:11)
```

According to the documentation https://expressjs.com/ru/api.html#res.sendStatus the response status is sent along with the body