### PR TITLE
fix(layout): the left menu disappears on long tables [#225]

### DIFF
--- a/packages/ui/src/ui/containers/AppNavigation/AppNavigation.scss
+++ b/packages/ui/src/ui/containers/AppNavigation/AppNavigation.scss
@@ -33,6 +33,7 @@
 
         &__content {
             padding-left: var(--gn-aside-header-size);
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
This is a follow-up to fixing issue #225. It fixes the padding for pages that stretch across the whole screen.