### PR TITLE
fix: request for settings is made without a cluster

### DIFF
--- a/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
+++ b/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
@@ -150,6 +150,9 @@ class ClusterPage extends Component {
         } = this.props;
 
         return Promise.resolve().then(() => {
+            initClusterParams(cluster);
+            updateTitle({cluster});
+
             // todo: get rid of redirectToBetaSwitched setting.
             // It`s exist for set default value of redirectToBeta setting, when settings document is empty yet.
             // Set redirectToBeta on server after get all user settings (home.js). Or get rid of this logic at all.
@@ -162,11 +165,9 @@ class ClusterPage extends Component {
                 setSetting(SettingName.DEVELOPMENT.REDIRECT_TO_BETA, NAMESPACES.DEVELOPMENT, true);
             }
 
-            initClusterParams(cluster);
             this._initMenuCollection('cluster');
             this._initMenuCollection('page');
             trackVisit('cluster', cluster);
-            updateTitle({cluster});
         });
     };
 


### PR DESCRIPTION
Sometimes, the cluster doesn't have enough time to be set, and requests go through without a cluster.