### PR TITLE
refactor(NodeCount): migrate module to typescript

### DIFF
--- a/packages/ui/src/ui/pages/components/tabs/Shards/NodeCount.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/Shards/NodeCount.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import hammer from '../../../../common/hammer';
-import {connect} from 'react-redux';
+import {ResolveThunks, connect} from 'react-redux';
 
 import Button from '../../../../components/Button/Button';
 
@@ -18,7 +18,18 @@ NodeCount.propTypes = {
     openAttributesModal: PropTypes.func.isRequired,
 };
 
-function NodeCount({id, name, count, className, openAttributesModal}) {
+type OwnProps = {
+    count: number;
+    className: string;
+    id: string;
+    name: string;
+};
+
+type DispatchProps = ResolveThunks<typeof mapDispatchToProps>;
+
+type NodeCountProps = OwnProps & DispatchProps;
+
+function NodeCount({id, name, count, className, openAttributesModal}: NodeCountProps) {
     const handleClick = () =>
         openAttributesModal({
             title: name,
@@ -41,4 +52,6 @@ function NodeCount({id, name, count, className, openAttributesModal}) {
     );
 }
 
-export default connect(null, {openAttributesModal})(NodeCount);
+const mapDispatchToProps = {openAttributesModal};
+
+export default connect(null, mapDispatchToProps)(NodeCount);


### PR DESCRIPTION
I would like to start an long-term activity of migration javascript files to typescript.

In a sake of easy code review I will try:

1. Change only 1 module per PR.
2. Do not change the logic of module unless it is necessary for correct types.