### PR TITLE
feat(System): introduce new switch leader button

### DIFF
--- a/packages/ui/src/shared/constants/yt-api-id.ts
+++ b/packages/ui/src/shared/constants/yt-api-id.ts
@@ -166,4 +166,5 @@ export enum YTApiId {
     removeMaintenance,
     maintenanceRequests,
     getQueryTrackerInfo,
+    switchLeader,
 }

--- a/packages/ui/src/ui/components/Icon/importGravityIcons.ts
+++ b/packages/ui/src/ui/components/Icon/importGravityIcons.ts
@@ -4,7 +4,7 @@ import CircleXmark from '@gravity-ui/icons/svgs/circle-xmark.svg';
 import FolderArrowDown from '@gravity-ui/icons/svgs/folder-arrow-down.svg';
 import FolderOpen from '@gravity-ui/icons/svgs/folder-open.svg';
 import LayoutSideContent from '@gravity-ui/icons/svgs/layout-side-content.svg';
-import {AbbrSql} from '@gravity-ui/icons';
+import {AbbrSql, CrownDiamond} from '@gravity-ui/icons';
 
 export const iconNames = {
     ['lock']: Lock,
@@ -14,4 +14,5 @@ export const iconNames = {
     ['folder-open']: FolderOpen,
     ['layout-side-content']: LayoutSideContent,
     ['sql']: AbbrSql,
+    ['crowndiamond']: CrownDiamond,
 };

--- a/packages/ui/src/ui/constants/accounts/accounts.ts
+++ b/packages/ui/src/ui/constants/accounts/accounts.ts
@@ -1,5 +1,4 @@
-import {createPrefix} from './../utils';
-import createActionTypes from '../../constants/utils';
+import createActionTypes, {createPrefix} from './../utils';
 import type {ValueOf} from '../../types';
 
 const ACCOUNTS_PREFIX = createPrefix('ACCOUNTS');

--- a/packages/ui/src/ui/pages/components/SwitchLeaderShortInfo/SwitchLeaderShortInfo.scss
+++ b/packages/ui/src/ui/pages/components/SwitchLeaderShortInfo/SwitchLeaderShortInfo.scss
@@ -1,0 +1,13 @@
+.switch-leader-short-info {
+    &__state {
+        text-transform: capitalize;
+
+        &_state_complete {
+            color: var(--success-color);
+        }
+    }
+
+    &__value {
+        text-transform: capitalize;
+    }
+}

--- a/packages/ui/src/ui/pages/components/SwitchLeaderShortInfo/SwitchLeaderShortInfo.tsx
+++ b/packages/ui/src/ui/pages/components/SwitchLeaderShortInfo/SwitchLeaderShortInfo.tsx
@@ -1,0 +1,89 @@
+import React, {useEffect, useRef, useState} from 'react';
+import cn from 'bem-cn-lite';
+
+import MetaTable from '../../../components/MetaTable/MetaTable';
+// @ts-ignore
+import format from '../../../common/hammer/format';
+import {getStateForHost, loadMasters} from '../../../store/actions/system/masters';
+import {useDispatch} from 'react-redux';
+import moment from 'moment';
+import './SwitchLeaderShortInfo.scss';
+
+const block = cn('switch-leader-short-info');
+
+interface Props {
+    newLeaderAddress: string;
+}
+
+export function SwitchLeaderShortInfo(props: Props) {
+    const startTime = useRef(moment.now());
+    const [currentTime, setCurrentTime] = useState<any>(moment());
+    const [finishTime, setFinishTime] = useState<any>();
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        const intervalId = setInterval(() => {
+            setCurrentTime(moment());
+
+            if (finishTime) {
+                clearInterval(intervalId);
+            }
+        }, 1 * 1000);
+
+        return () => {
+            clearInterval(intervalId);
+        };
+    }, []);
+
+    useEffect(() => {
+        let stillMounted = true;
+
+        const waitForState = async () => {
+            try {
+                const hostState = await getStateForHost(props.newLeaderAddress);
+
+                if (hostState === 'leading') {
+                    setFinishTime(moment());
+                    dispatch(loadMasters());
+                }
+            } catch {
+                if (stillMounted) {
+                    waitForState();
+                }
+            }
+        };
+
+        waitForState();
+
+        return () => {
+            stillMounted = false;
+        };
+    }, [props.newLeaderAddress]);
+
+    return (
+        <div className={block()}>
+            <MetaTable
+                items={[
+                    {
+                        key: 'Duration',
+                        value: format.TimeDuration(
+                            (finishTime || currentTime).diff(startTime.current),
+                        ),
+                    },
+                    {
+                        key: 'Status',
+                        value: (
+                            <SwitchLeaderShortInfoStatus
+                                state={finishTime ? 'complete' : 'in progress'}
+                            />
+                        ),
+                    },
+                ]}
+            />
+        </div>
+    );
+}
+
+function SwitchLeaderShortInfoStatus({state}: {state: string}) {
+    return <span className={block('state', {state})}>{state}</span>;
+}

--- a/packages/ui/src/ui/pages/system/Masters/MasterGroup.js
+++ b/packages/ui/src/ui/pages/system/Masters/MasterGroup.js
@@ -1,7 +1,6 @@
 import React, {Component, Fragment} from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import block from 'bem-cn-lite';
 import {Text} from '@gravity-ui/uikit';
 
@@ -14,6 +13,8 @@ import ypath from '../../../common/thor/ypath';
 import Icon from '../../../components/Icon/Icon';
 import {Tooltip} from '../../../components/Tooltip/Tooltip';
 import NodeQuad from '../NodeQuad/NodeQuad';
+import {SwitchLeaderButton} from './SwitchLeader';
+import _ from 'lodash';
 
 import './MasterGroup.scss';
 
@@ -134,7 +135,7 @@ class MasterGroup extends Component {
     };
 
     renderQuorum() {
-        const {quorum, cellTag} = this.props;
+        const {quorum, cellTag, cellId, instances} = this.props;
         const status = quorum ? quorum.status : 'unknown';
         const quorumTitle = quorum && `Leader committed version: ${quorum.leaderCommitedVersion}`;
         const cellTitle = `Cell tag: ${cellTag}`;
@@ -150,6 +151,14 @@ class MasterGroup extends Component {
             'no-quorum': 'missing',
             unknown: 'unknown',
         };
+        let leadingHost = '';
+        const hosts = instances.map(({$address, state}) => {
+            if (state === 'leading') {
+                leadingHost = $address;
+            }
+
+            return $address;
+        });
 
         return (
             <Fragment>
@@ -181,6 +190,13 @@ class MasterGroup extends Component {
                     <div className={b('quorum-cell')} title={cellTitle}>
                         {cellTag && <Icon className={b('icon-glyph')} face="solid" awesome="tag" />}
                         {hammer.format['Hex'](cellTag)}
+                        {cellId && (
+                            <SwitchLeaderButton
+                                cellId={cellId}
+                                hosts={hosts}
+                                leadingHost={leadingHost}
+                            />
+                        )}
                     </div>
                 </div>
             </Fragment>

--- a/packages/ui/src/ui/pages/system/Masters/SwitchLeader.tsx
+++ b/packages/ui/src/ui/pages/system/Masters/SwitchLeader.tsx
@@ -1,0 +1,147 @@
+import React, {useState} from 'react';
+import Icon from '../../../components/Icon/Icon';
+import Button from '../../../components/Button/Button';
+import {YTApiId, ytApiV4Id} from '../../../rum/rum-wrap-api';
+import {wrapApiPromiseByToaster} from '../../../utils/utils';
+import {YTDFDialog, makeErrorFields} from '../../../components/Dialog/Dialog';
+import {SwitchLeaderShortInfo} from '../../../pages/components/SwitchLeaderShortInfo/SwitchLeaderShortInfo';
+import {AppStoreProvider} from '../../../containers/App/AppStoreProvider';
+
+type SwitchLeaderDialogProps = {
+    cancel: () => void;
+    confirm: (newLeader: string) => Promise<void>;
+    visible: boolean;
+    cellId: string;
+    hosts: string[];
+    leadingHost: string;
+};
+
+type FormValues = {
+    leading_primary_master: string[];
+};
+
+const SwitchLeaderDialog = (props: SwitchLeaderDialogProps) => {
+    const [error, setError] = useState(undefined);
+
+    const selectLeadingHostOptions = props.hosts.map((host) => {
+        return {
+            value: host,
+            content: host,
+        };
+    });
+
+    return (
+        <YTDFDialog<FormValues>
+            visible={props.visible}
+            headerProps={{
+                title: `Switch leader for ${props.cellId}`,
+            }}
+            initialValues={{
+                leading_primary_master: [props.leadingHost],
+            }}
+            fields={[
+                {
+                    type: 'select',
+                    caption: ' Leading primary master',
+                    name: 'leading_primary_master',
+                    required: true,
+                    extras: {
+                        options: selectLeadingHostOptions,
+                        placeholder: 'New leading primary master',
+                        width: 'max',
+                        filterable: true,
+                    },
+                },
+                ...makeErrorFields([error]),
+            ]}
+            footerProps={{
+                textApply: 'Switch leader',
+            }}
+            onAdd={(form) => {
+                const {leading_primary_master} = form.getState().values;
+
+                return props
+                    .confirm(leading_primary_master[0])
+                    .then(() => {
+                        setError(undefined);
+                    })
+                    .catch((e) => {
+                        setError(e);
+                        throw e;
+                    });
+            }}
+            onClose={props.cancel}
+            pristineSubmittable={true}
+        />
+    );
+};
+
+type SwitchLeaderButtonProps = {
+    className: string;
+    cellId: string;
+    hosts: string[];
+    leadingHost: string;
+};
+
+export const SwitchLeaderButton = ({
+    cellId,
+    hosts,
+    leadingHost,
+    className,
+}: SwitchLeaderButtonProps) => {
+    const [visible, setVisible] = useState(false);
+
+    const handleClick = () => {
+        setVisible(true);
+    };
+
+    const handleConfirm = async (newLeader: string) => {
+        const switchLeader = () => {
+            return ytApiV4Id.switchLeader(YTApiId.switchLeader, {
+                cell_id: cellId,
+                new_leader_address: newLeader,
+            });
+        };
+
+        wrapApiPromiseByToaster(switchLeader(), {
+            toasterName: 'switch-leader',
+            successContent() {
+                return (
+                    <AppStoreProvider>
+                        <SwitchLeaderShortInfo newLeaderAddress={newLeader} />
+                    </AppStoreProvider>
+                );
+            },
+            successTitle: 'Leader switch initiated',
+            autoHide: false,
+        });
+
+        setVisible(false);
+    };
+
+    const handleCancel = () => {
+        setVisible(false);
+    };
+
+    return (
+        <React.Fragment>
+            <Button
+                className={className}
+                view="flat-secondary"
+                onClick={handleClick}
+                withTooltip
+                tooltipProps={{content: 'Switch leader'}}
+            >
+                <Icon awesome="crowndiamond" />
+            </Button>
+            <SwitchLeaderDialog
+                cellId={cellId}
+                hosts={hosts}
+                leadingHost={leadingHost}
+                confirm={handleConfirm}
+                cancel={handleCancel}
+                visible={visible}
+            />
+        </React.Fragment>
+    );
+};

--- a/packages/ui/src/ui/rum/rum-wrap-api.ts
+++ b/packages/ui/src/ui/rum/rum-wrap-api.ts
@@ -81,6 +81,10 @@ type YTApiV4WithId = {
         access_control_objects: string[];
         supported_features: {access_control: boolean};
     }>;
+    switchLeader(
+        id: YTApiId,
+        ...args: ApiMethodParameters<{cell_id: string; new_leader_address: string}>
+    ): Promise<any>;
     [method: string]: (id: YTApiId, ...args: ApiMethodParameters<any>) => Promise<any>;
 };
 

--- a/packages/ui/src/ui/store/reducers/system/masters.ts
+++ b/packages/ui/src/ui/store/reducers/system/masters.ts
@@ -164,6 +164,7 @@ export interface MasterGroupData {
         leaderCommitedVersion?: string;
     };
     cellTag?: number;
+    cellId?: string;
 }
 
 const initialState: MastersState = {
@@ -181,6 +182,7 @@ const initialState: MastersState = {
         leader: undefined,
         quorum: undefined,
         cellTag: undefined,
+        cellId: undefined,
     },
     secondary: [],
     providers: {
@@ -212,6 +214,7 @@ export interface ResponseItem {
 export interface ResponseItemsGroup {
     addresses?: Array<ResponseItem>;
     cellTag?: number;
+    cellId?: string;
 }
 
 export interface MastersConfigResponse {
@@ -238,6 +241,7 @@ function processMastersConfig(
                 return new MasterInstance(address, 'primary', primaryMaster.cellTag);
             }),
             cellTag: primaryMaster.cellTag,
+            cellId: primaryMaster.cellId,
         },
         secondary: _.map(secondaryMasters, (master) => {
             return {
@@ -311,6 +315,7 @@ function processMastersData(
     const primary: Required<MasterGroupData> = {
         instances: _.orderBy(primaryInstances, (instance) => instance.$address),
         cellTag: state.primary.cellTag!,
+        cellId: state.primary.cellId!,
         quorum: getQuorum(primaryInstances),
         leader: getLeader(primaryInstances),
     };
@@ -324,6 +329,7 @@ function processMastersData(
         const res: Required<MasterGroupData> = {
             instances: _.orderBy(instances, (instance) => instance.$address),
             cellTag: master.cellTag!,
+            cellId: master.cellId!,
             quorum: getQuorum(instances),
             leader: getLeader(instances),
         };


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/EnPm76mE75u5a4
<!-- nda-end -->In this PR I introduce a new button and dialog which switch leader for primary masters.
 
You can find this new button on the /system page, in masters section:
<img width="585" alt="330418244-d1a5c91a-e719-4ba7-9515-d27f8e1d3316" src="https://github.com/ytsaurus/ytsaurus-ui/assets/2428161/9107b0d2-07eb-4bec-aa89-d3a5362e153f">

The feature was developed and tested only for primary masters because I don't have a cluster with secondary masters. 

PS: that my first meaningful PR in this project, so please give as much feedback as possible, I need to know how to develop things in right way.