### PR TITLE
fix(login): user still see the login page after click to browser navigation back

### DIFF
--- a/packages/ui/src/ui/store/reducers/global/index.js
+++ b/packages/ui/src/ui/store/reducers/global/index.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import {LOCATION_POP} from 'redux-location-state/lib/constants';
 
 import MaintenancePage from '../../../containers/MaintenancePage/MaintenancePage';
 import {
@@ -229,6 +230,9 @@ export default (state = initialState, action) => {
 
         case GLOBAL_PARTIAL:
             return {...state, ...action.data};
+
+        case LOCATION_POP:
+            return {...state, showLoginDialog: false};
 
         default:
             return state;


### PR DESCRIPTION
Reproduce:

- Login to some cluster
- Switch to another cluster where you are not logged, see login page
- Try to go back using browser “back” button

Actual result: You are still on login page

Expected result: You should see the cluster page 