### PR TITLE
fix(Host): add ellipsis text in host

### DIFF
--- a/packages/ui/src/ui/containers/Host/Host.scss
+++ b/packages/ui/src/ui/containers/Host/Host.scss
@@ -3,16 +3,10 @@
     overflow: hidden;
     align-items: center;
 
-    &__link {
-        display: inline-block;
+    &__tooltip {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        width: 100%;
-    }
-
-    &__tooltip {
-        width: 100%;
     }
 
     &_hidden {

--- a/packages/ui/src/ui/containers/Host/Host.scss
+++ b/packages/ui/src/ui/containers/Host/Host.scss
@@ -3,6 +3,18 @@
     overflow: hidden;
     align-items: center;
 
+    &__link {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 100%;
+    }
+
+    &__tooltip {
+        width: 100%;
+    }
+
     &_hidden {
         visibility: hidden;
     }

--- a/packages/ui/src/ui/containers/Host/Host.tsx
+++ b/packages/ui/src/ui/containers/Host/Host.tsx
@@ -72,11 +72,7 @@ export function Host({
                 {useText ? (
                     host
                 ) : (
-                    <Link
-                        className={block('link')}
-                        url={`/${cluster}/components/nodes/${address}`}
-                        routed
-                    >
+                    <Link url={`/${cluster}/components/nodes/${address}`} routed>
                         {host}
                     </Link>
                 )}

--- a/packages/ui/src/ui/containers/Host/Host.tsx
+++ b/packages/ui/src/ui/containers/Host/Host.tsx
@@ -68,11 +68,15 @@ export function Host({
             onClick={onClick}
         >
             {prefix}
-            <Tooltip content={address}>
+            <Tooltip className={block('tooltip')} content={address}>
                 {useText ? (
                     host
                 ) : (
-                    <Link url={`/${cluster}/components/nodes/${address}`} routed>
+                    <Link
+                        className={block('link')}
+                        url={`/${cluster}/components/nodes/${address}`}
+                        routed
+                    >
                         {host}
                     </Link>
                 )}


### PR DESCRIPTION
Fix rendering long host in dynamic tables

**Before**
<img width="1630" alt="Screenshot 2024-04-23 at 5 49 29 PM" src="https://github.com/ytsaurus/ytsaurus-ui/assets/47900126/78b0b198-34d0-457e-817f-d0f004cf183d">

**After**
<img width="1645" alt="Screenshot 2024-04-23 at 5 49 03 PM" src="https://github.com/ytsaurus/ytsaurus-ui/assets/47900126/8ce030c7-d5d9-448e-aafc-107f919dd75c">
