### PR TITLE
fix(YQLTable): fix appearance of truncated value in cell

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLTable/YQLTable.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLTable/YQLTable.scss
@@ -20,14 +20,6 @@
 
         max-width: var(--qt-result-table-cell-max-width);
 
-        & .incomplete {
-            background-color: initial;
-
-            &::after {
-                content: none;
-            }
-        }
-
         video {
             max-width: var(--qt-result-table-cell-max-width);
         }


### PR DESCRIPTION
I find out that truncated values shown incorrectly at queries page - not it's shown as empty cell.

The content of truncated cells should be shown [via that unipika css](https://github.com/gravity-ui/unipika/blob/af46643f184e955b87de5a992c1ebaa204e9dc8a/styles/unipika.scss#L121). 

In the same time, at YQLTable.scss I find the styles which override that behavior. It's not clear why we got these styles at the first place, I tried to remove them and it's fixed the issue.

Before patch: 
<img width="149" alt="before-patch" src="https://github.com/ytsaurus/ytsaurus-ui/assets/2428161/eb81a865-603e-41fe-8dca-6e4cb8b7a32d">

After patch:
<img width="211" alt="after-patch" src="https://github.com/ytsaurus/ytsaurus-ui/assets/2428161/a7d9c952-c50d-4314-91fe-c56b0f62a5ff">

PS: probably I should create an issue about the "cell size limit" for table cell? Right now the cells on queries page will always contain `[truncated]` value because we request data with default cell size limit.
