### PR TITLE
fix(AccountsGeneralTab): do not show TabletAccountingNotice if enable_per_account_tablet_accounting is enabled

### DIFF
--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
@@ -724,7 +724,7 @@ class AccountsGeneralTab extends Component {
 
         return (
             <div className={b('content', 'elements-section')}>
-                {isTCBRelative && <TabletAccountingNotice className={b('tcb-resource-notice')} />}
+                {!allowTable && <TabletAccountingNotice className={b('tcb-resource-notice')} />}
                 {allowTable && <VisibilityNotice mode={dashboardVisibilityMode} />}
                 {allowTable && (
                     <ElementsTableWithHeaderAndFooter


### PR DESCRIPTION
By default user can see the warning that tablet resource accounting was moved to tablet cell bundles:
<img width="553" alt="image" src="https://github.com/ytsaurus/ytsaurus-ui/assets/2428161/68fbde1d-3ffa-4fa5-a512-73591d6f39b7">

The problem is: user still sees it even if he manually switched enable_per_account_tablet_accounting flag in `//sys/@ui_config`.

