### PR TITLE
feat: added ability to show custom tab in navigation view

### DIFF
--- a/packages/ui/src/ui/UIFactory.tsx
+++ b/packages/ui/src/ui/UIFactory.tsx
@@ -99,6 +99,19 @@ export type AclRoleActionsType = Partial<Omit<PreparedAclSubject | PreparedRole,
     type?: string;
 };
 
+export type TabName = string;
+
+export type ExtraTab = {
+    value: `extra_${TabName}`;
+    title: string;
+    text?: string;
+    caption?: string;
+    hotkey?: string;
+    component: React.ComponentType;
+    isSupported: (attributes: Record<string, any>) => boolean;
+    position: {before: TabName} | {after: TabName};
+};
+
 export interface UIFactory {
     getClusterAppearance(cluster?: string): undefined | ClusterAppearance;
 
@@ -389,6 +402,8 @@ export interface UIFactory {
     getAclPermissionsSettings(): typeof PERMISSIONS_SETTINGS;
 
     onChytAliasSqlClick(params: {alias: string; cluster: string}): void;
+
+    getNavigationExtraTabs(): Array<ExtraTab>;
 }
 
 const experimentalPages: string[] = [];
@@ -662,6 +677,10 @@ const uiFactory: UIFactory = {
     },
 
     onChytAliasSqlClick() {},
+
+    getNavigationExtraTabs() {
+        return [];
+    },
 };
 
 function configureUIFactoryItem<K extends keyof UIFactory>(k: K, redefinition: UIFactory[K]) {

--- a/packages/ui/src/ui/pages/navigation/Navigation/ContentViewer/helpers/getComponentByMode.ts
+++ b/packages/ui/src/ui/pages/navigation/Navigation/ContentViewer/helpers/getComponentByMode.ts
@@ -11,23 +11,35 @@ import UserAttributes from '../../../../../pages/navigation/tabs/UserAttributes/
 import TableMountConfig from '../../../../../pages/navigation/tabs/TableMountConfig/TableMountConfig';
 import {Tab} from '../../../../../constants/navigation';
 import {Fragment} from 'react';
+import UIFactory from '../../../../../UIFactory';
 
-const supportedAttributeTypes = {
-    acl: ACL,
-    locks: Locks,
-    schema: Schema,
-    tablets: Tablets,
-    attributes: Attributes,
-    tablet_errors: TabletErrors,
-    user_attributes: UserAttributes,
-    [Tab.ACCESS_LOG]: AccessLog,
-    [Tab.AUTO]: Fragment,
-    [Tab.CONSUMER]: Consumer,
-    [Tab.MOUNT_CONFIG]: TableMountConfig,
-    [Tab.QUEUE]: Queue,
+const getSupportedAttributeTypes = () => {
+    const supportedAttributeTypes: Record<string, React.ComponentType> = {
+        acl: ACL,
+        locks: Locks,
+        schema: Schema,
+        tablets: Tablets,
+        attributes: Attributes,
+        tablet_errors: TabletErrors,
+        user_attributes: UserAttributes,
+        [Tab.ACCESS_LOG]: AccessLog,
+        [Tab.AUTO]: Fragment,
+        [Tab.CONSUMER]: Consumer,
+        [Tab.MOUNT_CONFIG]: TableMountConfig,
+        [Tab.QUEUE]: Queue,
+    };
+
+    UIFactory.getNavigationExtraTabs().forEach((tab) => {
+        supportedAttributeTypes[tab.value] = tab.component;
+    });
+
+    return supportedAttributeTypes;
 };
 
-export default (mode: string) =>
-    mode in supportedAttributeTypes
+export default (mode: string) => {
+    const supportedAttributeTypes = getSupportedAttributeTypes();
+
+    return mode in supportedAttributeTypes
         ? supportedAttributeTypes[mode as keyof typeof supportedAttributeTypes]
         : undefined;
+};

--- a/packages/ui/src/ui/store/actions/navigation/index.js
+++ b/packages/ui/src/ui/store/actions/navigation/index.js
@@ -6,7 +6,6 @@ import {RumMeasureTypes} from '../../../rum/rum-measure-types';
 
 import {isPathAutoCorrectionSettingEnabled} from '../../../store/selectors/settings';
 import {getPath, getTransaction} from '../../../store/selectors/navigation';
-import {getDefaultMode} from '../../../store/selectors/navigation/navigation';
 
 import {
     autoCorrectPath,
@@ -35,6 +34,7 @@ import {checkPermissions} from '../../../utils/acl/acl-api';
 import {getAnnotation} from './tabs/annotation';
 import {loadTabletErrorsCount} from './tabs/tablet-errors';
 import {isSupportedEffectiveExpiration} from '../../../store/selectors/thor/support';
+import {getTabs} from '../../../store/selectors/navigation/navigation';
 
 export function updateView(settings = {}) {
     return (dispatch, getState) => {
@@ -216,11 +216,11 @@ export function updateView(settings = {}) {
 
 export function setMode(mode) {
     return (dispatch, getState) => {
-        const defaultMode = getDefaultMode(getState());
+        const [firstTab] = getTabs(getState());
 
         dispatch({
             type: SET_MODE,
-            data: mode === defaultMode ? Tab.AUTO : mode,
+            data: mode === firstTab?.value ? Tab.AUTO : mode,
         });
     };
 }

--- a/packages/ui/src/ui/store/selectors/navigation/navigation.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/navigation.ts
@@ -6,13 +6,14 @@ import unipika from '../../../common/thor/unipika';
 
 import type {RootState} from '../../../store/reducers';
 import type {ValueOf, YTError} from '../../../types';
-import {getParsedPath, getPath, getTransaction} from './index';
+import {getAttributes, getParsedPath, getPath, getTransaction} from './index';
 import {ParsedPath, prepareNavigationState} from '../../../utils/navigation';
 import {Tab} from '../../../constants/navigation/index';
 
 import {getTableMountConfigHasData} from '../../../store/selectors/navigation/content/table-mount-config';
 import {getAccessLogBasePath} from '../../../config';
 import {getTabletErrorsCount} from '../../../store/selectors/navigation/tabs/tablet-errors';
+import UIFactory from '../../../UIFactory';
 
 export function getNavigationPathAttributesLoadState(state: RootState) {
     return state.navigation.navigation.loadState;
@@ -110,14 +111,213 @@ export const getSupportedTabs = createSelector(
             supportedTabletErrors = [Tab.TABLET_ERRORS];
         }
 
-        return new Set([...alwaysSupportedTabs, ...supportedByAttribute, ...supportedTabletErrors]);
+        const supportedTabs = new Set<string>([
+            ...alwaysSupportedTabs,
+            ...supportedByAttribute,
+            ...supportedTabletErrors,
+        ]);
+
+        UIFactory.getNavigationExtraTabs().forEach((tab) => {
+            if (tab.isSupported(attributes)) {
+                supportedTabs.add(tab.value);
+            }
+        });
+
+        return supportedTabs;
     },
 );
 
-export const getDefaultMode = createSelector([getSupportedTabs], (supportedTabs) =>
-    supportedTabs.has(Tab.CONSUMER) ? Tab.CONSUMER : Tab.CONTENT,
+export const getTabs = createSelector(
+    [getSupportedTabs, getTabletErrorsCount, getAttributes],
+    (supportedTabs, tabletErrorsCount, attributes) => {
+        const isACO = attributes?.type === 'access_control_object';
+
+        const tabs: {
+            value: string;
+            title: string;
+            hotkey?: {
+                keys: string;
+                tab: string;
+                scope: string;
+            }[];
+            text?: string;
+            caption?: string;
+            counter?: number;
+        }[] = [
+            {
+                value: Tab.CONSUMER,
+                title: 'Go to consumer [Alt+R]',
+                hotkey: [
+                    {
+                        keys: 'alt+r',
+                        tab: Tab.CONSUMER,
+                        scope: 'all',
+                    },
+                ],
+            },
+            {
+                value: Tab.CONTENT,
+                title: 'Go to content [Alt+C]',
+                text: isACO ? 'Principal ACL' : undefined,
+                hotkey: [
+                    {
+                        keys: 'alt+c',
+                        tab: Tab.CONTENT,
+                        scope: 'all',
+                    },
+                ],
+            },
+            {
+                value: Tab.QUEUE,
+                title: 'Go to queue [Alt+Q]',
+                hotkey: [
+                    {
+                        keys: 'alt+q',
+                        tab: Tab.QUEUE,
+                        scope: 'all',
+                    },
+                ],
+            },
+            {
+                value: Tab.ATTRIBUTES,
+                title: 'Go to attributes [Alt+A]',
+                hotkey: [
+                    {
+                        keys: 'alt+a',
+                        tab: Tab.ATTRIBUTES,
+                        scope: 'all',
+                    },
+                ],
+                caption: 'Attributes',
+            },
+            {
+                value: Tab.USER_ATTRIBUTES,
+                title: 'Go to user attributes [Alt+U]',
+                hotkey: [
+                    {
+                        keys: 'alt+u',
+                        tab: Tab.USER_ATTRIBUTES,
+                        scope: 'all',
+                    },
+                ],
+                caption: 'User Attributes',
+            },
+            {
+                value: Tab.MOUNT_CONFIG,
+                title: 'Go to mount config',
+                hotkey: [
+                    {
+                        keys: 'alt+m',
+                        tab: Tab.MOUNT_CONFIG,
+                        scope: 'all',
+                    },
+                ],
+            },
+            {
+                value: Tab.ACL,
+                title: 'Go to ACL [Alt+P]',
+                hotkey: [
+                    {
+                        keys: 'alt+p',
+                        tab: Tab.ACL,
+                        scope: 'all',
+                    },
+                ],
+                caption: 'ACL',
+            },
+            {
+                value: Tab.ACCESS_LOG,
+                title: 'Access log',
+            },
+            {
+                value: Tab.LOCKS,
+                title: 'Go to locks [Alt+L]',
+                hotkey: [
+                    {
+                        keys: 'alt+l',
+                        tab: Tab.LOCKS,
+                        scope: 'all',
+                    },
+                ],
+                counter: ypath.getValue(attributes, '/lock_count'),
+            },
+            {
+                value: Tab.ANNOTATION,
+                title: 'Go to annotation [Alt+N]',
+                hotkey: [
+                    {
+                        keys: 'alt+n',
+                        tab: Tab.ACL,
+                        scope: 'all',
+                    },
+                ],
+                caption: 'Annotation',
+            },
+            {
+                value: Tab.SCHEMA,
+                title: 'Go to schema [Alt+S]',
+                hotkey: [
+                    {
+                        keys: 'alt+s',
+                        tab: Tab.SCHEMA,
+                        scope: 'all',
+                    },
+                ],
+            },
+            {
+                value: Tab.TABLETS,
+                title: 'Go to tablets [Alt+T]',
+                hotkey: [
+                    {
+                        keys: 'alt+t',
+                        tab: Tab.TABLETS,
+                        scope: 'all',
+                    },
+                ],
+            },
+            {
+                value: Tab.TABLET_ERRORS,
+                title: 'Go to tablets errors',
+                counter: tabletErrorsCount,
+            },
+        ];
+
+        UIFactory.getNavigationExtraTabs().forEach((extraTab) => {
+            for (let i = 0; i < tabs.length; i++) {
+                let indexOffset = 0;
+                let tabToFind;
+
+                if ('before' in extraTab.position) {
+                    tabToFind = extraTab.position.before;
+                }
+
+                if ('after' in extraTab.position) {
+                    tabToFind = extraTab.position.after;
+                    indexOffset = 1;
+                }
+
+                if (tabs[i].value === tabToFind) {
+                    const newTab = {
+                        value: extraTab.value,
+                        title: extraTab.title,
+                        hotkey: extraTab.hotkey
+                            ? [{keys: extraTab.hotkey, tab: extraTab.value, scope: 'all'}]
+                            : undefined,
+                        text: extraTab.text,
+                        caption: extraTab.caption,
+                    };
+                    tabs.splice(i + indexOffset, 0, newTab);
+                    break;
+                }
+            }
+        });
+
+        return tabs.filter((tab) => supportedTabs.has(tab.value));
+    },
 );
 
-export const getEffectiveMode = createSelector([getMode, getDefaultMode], (mode, defaultMode) =>
-    mode === Tab.AUTO ? defaultMode : mode,
-);
+export const getEffectiveMode = createSelector([getMode, getTabs], (mode, tabs) => {
+    const [firstTab] = tabs;
+
+    return mode === Tab.AUTO ? firstTab.value : mode;
+});


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/atP5j4Lb76WCss
<!-- nda-end -->With this PR, custom yt installations can add their own tabs for navigation.

Here is an example - we added a new tab based on attributes:

<img width="1721" alt="Screenshot 2024-06-18 at 10 31 29" src="https://github.com/ytsaurus/ytsaurus-ui/assets/2428161/d6314eeb-8abe-4d6e-9efc-c648ea34b701">


### Factory overrides:

``` typescript
const productionOverrides: Partial<UIFactory> = {
    getNavigationExtention() {
        const TAB_KEY = 'cutsom_tab_with_custom_tab';
        return {
            extendSupportedTabs({supportedTabs, attributes}) {
                if (attributes.ui_flag_for_custom_ui) {
                    supportedTabs.add(TAB_KEY);
                }
            },

            getDefaultMode(supportedTabs: Set<string>) {
                if (supportedTabs.has(TAB_KEY)) {
                    return TAB_KEY;
                }
                return supportedTabs.has(NavigationTab.CONSUMER)
                    ? NavigationTab.CONSUMER
                    : NavigationTab.CONTENT;
            },

            getSupportedAttributeTypes() {
                function Stub() {
                    return <div>Here will be custom react component</div>;
                }

                return {
                    [TAB_KEY]: Stub,
                };
            },
            extendNavigationTabs(tabs) {
                tabs.unshift({
                    value: TAB_KEY,
                    title: 'Go to custom tab',
                });
            },
        };
    },
};
```