### PR TITLE
feat: introduce poc of adhoc visualization on query results (641)

### DIFF
--- a/packages/ui/src/ui/UIFactory.tsx
+++ b/packages/ui/src/ui/UIFactory.tsx
@@ -31,6 +31,7 @@ import {UISettingsMonitoring} from '../shared/ui-settings';
 import {DefaultSubjectCard, type SubjectCardProps} from './components/SubjectLink/SubjectLink';
 import type {QueryItem} from './pages/query-tracker/module/api';
 import type {DropdownMenuItem} from '@gravity-ui/uikit';
+import {CUSTOM_QUERY_REQULT_TAB} from './pages/query-tracker/QueryResultsVisualization';
 
 type HeaderItemOrPage =
     | {
@@ -653,7 +654,7 @@ const uiFactory: UIFactory = {
     },
 
     getCustomQueryResultTab() {
-        return undefined;
+        return CUSTOM_QUERY_REQULT_TAB;
     },
 
     getExternalSettings() {

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/ChartErrorBoundary/ChartErrorBoundary.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/ChartErrorBoundary/ChartErrorBoundary.scss
@@ -1,0 +1,9 @@
+.chart-error-boundary {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    text-align: center;
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/ChartErrorBoundary/ChartErrorBoundary.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/ChartErrorBoundary/ChartErrorBoundary.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+import {ChartKitError} from '@gravity-ui/chartkit';
+import {Button} from '@gravity-ui/uikit';
+
+import './ChartErrorBoundary.scss';
+
+const renderError = ({
+    error,
+    refreshClick,
+}: {
+    error: ChartKitError | Error;
+    refreshClick(): void;
+}) => {
+    return (
+        <div className="chart-error-boundary">
+            <div>
+                <p>
+                    {error?.message}
+                    <br />
+                </p>
+                <Button view="action" onClick={refreshClick}>
+                    Try again
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+interface ChartErrorBoundaryProps {
+    deps: Record<string, unknown>;
+    children: (args: {handleError({error}: {error: ChartKitError}): void}) => React.ReactElement;
+}
+
+export const ChartErrorHandler = ({children, deps}: ChartErrorBoundaryProps) => {
+    const [error, setError] = useState<ChartKitError>();
+
+    const handleError = ({error}: {error: ChartKitError}) => {
+        setError(error);
+    };
+
+    const handleRefreshClick = () => {
+        setError(undefined);
+    };
+
+    useEffect(() => {
+        setError(undefined);
+    }, [deps]);
+
+    if (error) {
+        return renderError({error, refreshClick: handleRefreshClick});
+    }
+
+    return children({handleError});
+};
+
+export class ChartErrorBoundary extends React.Component<
+    React.PropsWithChildren<Readonly<{}>>,
+    {error?: Error | ChartKitError}
+> {
+    static getDerivedStateFromError(error: Error) {
+        return {error};
+    }
+
+    constructor(props: React.PropsWithChildren<Readonly<{}>>) {
+        super(props);
+
+        this.state = {error: undefined};
+    }
+
+    componentDidCatch() {}
+
+    handleRefreshClick = () => {
+        this.setState({error: undefined});
+    };
+
+    render() {
+        if (this.state.error) {
+            return renderError({
+                error: this.state.error,
+                refreshClick: this.handleRefreshClick,
+            });
+        }
+
+        return this.props.children;
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/EmptyPlaceholdersMessage/EmptyPlaceholdersMessage.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/EmptyPlaceholdersMessage/EmptyPlaceholdersMessage.scss
@@ -1,0 +1,8 @@
+.empty-placeholders-message {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    text-align: center;
+    width: 100%;
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/EmptyPlaceholdersMessage/EmptyPlaceholdersMessage.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/EmptyPlaceholdersMessage/EmptyPlaceholdersMessage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import block from 'bem-cn-lite';
+import './EmptyPlaceholdersMessage.scss';
+
+const b = block('empty-placeholders-message');
+
+export function EmptyPlaceholdersMessage() {
+    return <div className={b()}>Add fields in X and Y placeholders</div>;
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/Chart/Chart.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/Chart/Chart.tsx
@@ -1,0 +1,44 @@
+import React, {useMemo} from 'react';
+import ChartKit from '../../../../../components/YagrChartKit/YagrChartKit';
+import {settings} from '@gravity-ui/chartkit';
+import type {ChartKitRef} from '@gravity-ui/chartkit';
+import {prepareWidgetData} from '../../preparers/prepareWidgetData';
+import {useSelector} from 'react-redux';
+import {
+    selectIsPlaceholdersMissSomeFields,
+    selectQueryResultVisualization,
+} from '../../store/selectors';
+import type {QueryResult} from '../../preparers/types';
+import {ChartErrorHandler} from '../../components/ChartErrorBoundary/ChartErrorBoundary';
+import {EmptyPlaceholdersMessage} from '../../components/EmptyPlaceholdersMessage/EmptyPlaceholdersMessage';
+import {D3Plugin} from '@gravity-ui/chartkit/d3';
+
+settings.set({plugins: [...settings.get('plugins'), D3Plugin]});
+
+type LineBasicProps = {
+    result: QueryResult;
+};
+
+export const BaseChart = React.forwardRef<ChartKitRef | undefined, LineBasicProps>(
+    function BaseChartComponent({result}, ref) {
+        const visualization = useSelector(selectQueryResultVisualization);
+        const isPlaceholdersMissSomeFields = useSelector(selectIsPlaceholdersMissSomeFields);
+        const widgetData = useMemo(() => {
+            return prepareWidgetData({result, visualization});
+        }, [result, visualization]);
+
+        if (isPlaceholdersMissSomeFields) {
+            return <EmptyPlaceholdersMessage />;
+        }
+
+        return (
+            <ChartErrorHandler deps={widgetData}>
+                {({handleError}) => (
+                    <ChartKit type="d3" data={widgetData} ref={ref} onError={handleError} />
+                )}
+            </ChartErrorHandler>
+        );
+    },
+);
+
+export const Chart = React.memo(BaseChart);

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartSettings/ChartSettings.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartSettings/ChartSettings.tsx
@@ -1,0 +1,185 @@
+import React, {useCallback, useState} from 'react';
+import {Gear} from '@gravity-ui/icons';
+import {Icon} from '@gravity-ui/uikit';
+import Button from '../../../../../components/Button/Button';
+import {
+    DialogField,
+    DialogTabField,
+    FormApi,
+    YTDFDialog,
+} from '../../../../../components/Dialog/Dialog';
+import type {ChartSettings} from '../../types';
+import {useSelector} from 'react-redux';
+import {selectQueryResultChartSettings} from '../../store/selectors';
+import {useThunkDispatch} from '../../../../../store/thunkDispatch';
+
+type FormValues = ChartSettings;
+
+function pixelIntervalValidator(value: string) {
+    return !value || /^\d+$/.test(value) ? undefined : 'Should be a number';
+}
+
+const xAxisTab: DialogTabField<DialogField<FormValues>> = {
+    type: 'tab',
+    name: 'xAxis',
+    title: 'X axis',
+    fields: [
+        {
+            name: 'legend',
+            caption: 'Legend',
+            type: 'radio',
+            extras: {
+                options: [
+                    {
+                        value: 'on',
+                        label: 'On',
+                    },
+                    {
+                        value: 'off',
+                        label: 'Off',
+                    },
+                ],
+            },
+        },
+        {
+            name: 'labels',
+            caption: 'Labels',
+            type: 'radio',
+            extras: {
+                options: [
+                    {
+                        value: 'on',
+                        label: 'On',
+                    },
+                    {
+                        value: 'off',
+                        label: 'Off',
+                    },
+                ],
+            },
+        },
+        {
+            caption: 'Title',
+            name: 'title',
+            type: 'text',
+        },
+        {
+            name: 'grid',
+            caption: 'Grid',
+            type: 'radio',
+            extras: {
+                options: [
+                    {
+                        value: 'on',
+                        label: 'On',
+                    },
+                    {
+                        value: 'off',
+                        label: 'Off',
+                    },
+                ],
+            },
+        },
+        {
+            caption: 'Grid step, px',
+            name: 'pixelInterval',
+            type: 'text',
+            validator: pixelIntervalValidator,
+        },
+    ],
+};
+
+const yAxisTab: DialogTabField<DialogField<FormValues>> = {
+    type: 'tab',
+    name: 'yAxis',
+    title: 'Y axis',
+    fields: [
+        {
+            name: 'labels',
+            caption: 'Labels',
+            type: 'radio',
+            extras: {
+                options: [
+                    {
+                        value: 'on',
+                        label: 'On',
+                    },
+                    {
+                        value: 'off',
+                        label: 'Off',
+                    },
+                ],
+            },
+        },
+        {
+            caption: 'Title',
+            name: 'title',
+            type: 'text',
+        },
+        {
+            name: 'grid',
+            caption: 'Grid',
+            type: 'radio',
+            extras: {
+                options: [
+                    {
+                        value: 'on',
+                        label: 'On',
+                    },
+                    {
+                        value: 'off',
+                        label: 'Off',
+                    },
+                ],
+            },
+        },
+        {
+            caption: 'Grid step, px',
+            name: 'pixelInterval',
+            type: 'text',
+            validator: pixelIntervalValidator,
+        },
+    ],
+};
+
+const fields: DialogTabField<DialogField<FormValues>>[] = [xAxisTab, yAxisTab];
+
+export function ChartSettingsComponent() {
+    const [visible, setVisilbility] = useState(false);
+    const chartSettings = useSelector(selectQueryResultChartSettings);
+    const dispatch = useThunkDispatch();
+
+    const handleOnOpen = useCallback(() => {
+        setVisilbility(true);
+    }, [setVisilbility]);
+
+    const handleOnClose = useCallback(() => {
+        setVisilbility(false);
+    }, [setVisilbility]);
+
+    const handleOnAdd = useCallback((form: FormApi<FormValues, Partial<FormValues>>) => {
+        const data = form.getState().values;
+
+        dispatch({
+            type: 'set-chart-settings',
+            data,
+        });
+
+        return Promise.resolve();
+    }, []);
+
+    return (
+        <span>
+            <Button onClick={handleOnOpen}>
+                <Icon data={Gear} size={16} />
+            </Button>
+            <YTDFDialog<FormValues>
+                visible={visible}
+                initialValues={chartSettings}
+                onClose={handleOnClose}
+                onAdd={handleOnAdd}
+                fields={fields}
+            />
+        </span>
+    );
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartValidation/ChartValidation.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartValidation/ChartValidation.scss
@@ -1,0 +1,18 @@
+.chart-validation {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &__alert {
+        padding: 12px;
+        font-size: 10px;
+    }
+
+    &__icon {
+        &_invalid {
+            color: var(--g-color-line-warning);
+        }
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartValidation/ChartValidation.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartValidation/ChartValidation.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import {useState} from 'react';
+import {useSelector} from 'react-redux';
+import type {AlertProps} from '@gravity-ui/uikit';
+import {Alert, Button, Icon} from '@gravity-ui/uikit';
+import block from 'bem-cn-lite';
+import {resultsPlaceholdersValidation} from '../../store/selectors';
+import {CircleExclamation as CircleExclamationIcon} from '@gravity-ui/icons';
+
+import './ChartValidation.scss';
+
+const b = block('chart-validation');
+
+const Msg = () => (
+    <span
+        dangerouslySetInnerHTML={{
+            __html: 'Your data contains duplicate values for one or more points. </br> This can lead to incorrect graph plotting. Please ensure that each point has a unique value.',
+        }}
+    />
+);
+
+const ALERT_PROPS = {
+    title: 'Duplicate Values',
+    theme: 'warning' as AlertProps['theme'],
+    message: <Msg />,
+    icon: (
+        <Icon className={b('field-icon', {invalid: true})} data={CircleExclamationIcon} size={16} />
+    ),
+};
+
+export const ChartValidation: React.FC<React.PropsWithChildren<{}>> = ({children}) => {
+    const [isErrorHidden, hideError] = useState(false);
+    const placeholdersValidation = useSelector(resultsPlaceholdersValidation);
+    const hasError = placeholdersValidation?.x?.invalid || placeholdersValidation?.y?.invalid;
+    const showBigAlert = hasError && !isErrorHidden;
+    const showSmallAlert = isErrorHidden;
+
+    if (showBigAlert) {
+        return (
+            <div className={b()}>
+                <Alert
+                    {...ALERT_PROPS}
+                    actions={
+                        <Alert.Actions>
+                            <Button onClick={() => hideError(true)}>Show chart</Button>
+                        </Alert.Actions>
+                    }
+                />
+            </div>
+        );
+    }
+
+    if (showSmallAlert) {
+        return (
+            <>
+                <div className={b('alert')}>
+                    <Alert {...ALERT_PROPS} />
+                </div>
+                {children}
+            </>
+        );
+    }
+
+    return children;
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/Placeholder/Placeholder.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/Placeholder/Placeholder.scss
@@ -1,0 +1,49 @@
+.placeholder {
+    width: 200px;
+    padding: 12px 0;
+    border-top: 1px solid var(--g-color-line-generic);
+
+    &__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    &__name {
+        font-weight: bold;
+    }
+
+    &__field {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        cursor: pointer;
+        height: 32px;
+        margin-top: 4px;
+
+        background-color: var(--g-color-base-misc-light);
+
+        &:hover {
+            background-color: var(--g-color-base-simple-hover);
+        }
+    }
+
+    &__field-spacer {
+        display: flex;
+        margin-left: 12px;
+    }
+
+    &__field-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-left: 8px;
+    }
+
+    &__field:hover &__field-actions {
+        visibility: visible;
+    }
+
+    &__field-actions {
+        visibility: hidden;
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/Placeholder/Placeholder.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/Placeholder/Placeholder.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import block from 'bem-cn-lite';
+import './Placeholder.scss';
+import {Field, Placeholder} from '../../../types';
+import {Button, Icon, Select} from '@gravity-ui/uikit';
+import {Plus as PlusIcon, Xmark as XmarkIcon} from '@gravity-ui/icons';
+import {useThunkDispatch} from '../../../../../../store/thunkDispatch';
+
+const b = block('placeholder');
+
+type PlaceholderComponentProps = {
+    placeholder: Placeholder;
+    availableFields: Field[];
+};
+
+export const PlaceholderComponent = ({placeholder, availableFields}: PlaceholderComponentProps) => {
+    const {id, fields} = placeholder;
+    const dispatch = useThunkDispatch();
+
+    const addField = React.useCallback(
+        ({field, placeholder}: {field: Field; placeholder: Placeholder}) => {
+            dispatch({
+                type: 'set-fields',
+                data: {
+                    fields: [field],
+                    placeholderId: placeholder.id,
+                },
+            });
+        },
+        [dispatch],
+    );
+
+    const removeField = React.useCallback(
+        ({field, placeholder}: {field: Field; placeholder: Placeholder}) => {
+            dispatch({
+                type: 'remove-field',
+                data: {
+                    field,
+                    placeholderId: placeholder.id,
+                },
+            });
+        },
+        [dispatch],
+    );
+
+    const onSelectUpdate = React.useCallback(
+        (value: string[]) => {
+            addField({
+                placeholder,
+                field: availableFields.find((field) => field.name === value[0])!,
+            });
+        },
+        [addField],
+    );
+
+    return (
+        <div className={b()}>
+            <div className={b('header')}>
+                <div className={b('name')}>{id}</div>
+                <Select
+                    value={[]}
+                    filterable={true}
+                    options={availableFields.map((field) => ({
+                        content: field.name,
+                        value: field.name,
+                        data: field,
+                    }))}
+                    onUpdate={onSelectUpdate}
+                    renderControl={({onClick, ref}) => {
+                        return (
+                            <Button onClick={onClick} ref={ref}>
+                                <Icon data={PlusIcon} size={16} />
+                            </Button>
+                        );
+                    }}
+                />
+            </div>
+
+            {fields.map((field) => {
+                return (
+                    <div key={field.name} className={b('field')}>
+                        <div className={b('field-spacer')}></div>
+                        <div className={b('field-title')} title={field.name}>
+                            {field.name}
+                        </div>
+                        <div className={b('field-actions')}>
+                            <Button onClick={removeField.bind(null, {field, placeholder})}>
+                                <Icon data={XmarkIcon} size={16} />
+                            </Button>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/PlaceholdersContainer.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/PlaceholdersContainer.scss
@@ -1,0 +1,7 @@
+.placeholders-container {
+    &__placeholder-wrapper {
+        &:first-child {
+            margin-top: 12px;
+        }
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/PlaceholdersContainer.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/PlaceholdersContainer.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {PlaceholderComponent} from './Placeholder/Placeholder';
+import {Field} from '../../types';
+import block from 'bem-cn-lite';
+import './PlaceholdersContainer.scss';
+import {useSelector} from 'react-redux';
+import {selectQueryResultVisualizationPlaceholders} from '../../store/selectors';
+
+const b = block('placeholders-container');
+
+type PlaceholdersContainerProps = {
+    availableFields: Field[];
+};
+
+export const PlaceholdersContainer = (props: PlaceholdersContainerProps) => {
+    const placeholders = useSelector(selectQueryResultVisualizationPlaceholders);
+
+    return (
+        <div className={b()}>
+            {placeholders.map((placeholder) => (
+                <div className={b('placeholder-wrapper')} key={placeholder.id}>
+                    <PlaceholderComponent placeholder={placeholder} {...props} />
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/VisualizationSelector/VisualizationSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/PlaceholdersContainer/VisualizationSelector/VisualizationSelector.tsx
@@ -1,0 +1,38 @@
+import React, {useCallback, useMemo} from 'react';
+import {Select} from '@gravity-ui/uikit';
+import type {VisualizationId} from '../../../types';
+import {useSelector} from 'react-redux';
+import {selectQueryResultVisualizationId} from '../../../store/selectors';
+import {useThunkDispatch} from '../../../../../../store/thunkDispatch';
+
+const options = [
+    {
+        value: 'line',
+        content: 'Line chart',
+    },
+    {
+        value: 'bar-x',
+        content: 'Bar chart',
+    },
+];
+
+export function VisualizationSelector() {
+    const visualizationId = useSelector(selectQueryResultVisualizationId);
+    const dispatch = useThunkDispatch();
+
+    const value = useMemo(() => {
+        return [visualizationId];
+    }, [visualizationId]);
+
+    const onUpdate = useCallback(
+        ([visualization]: string[]) => {
+            dispatch({
+                type: 'set-visualization',
+                data: visualization as VisualizationId,
+            });
+        },
+        [dispatch],
+    );
+
+    return <Select<VisualizationId> value={value} options={options} onUpdate={onUpdate} />;
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/QueryResultsVisualization/QueryResultsVisualization.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/QueryResultsVisualization/QueryResultsVisualization.scss
@@ -1,0 +1,34 @@
+.query-result-visualization {
+    height: 100%;
+    display: flex;
+    border-bottom: 1px solid var(--g-color-line-generic);
+
+    &__loader-wrapper {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    &__controls-wrapper {
+        border-right: 1px solid var(--g-color-line-generic);
+        padding-right: 8px;
+    }
+
+    &__chartkit-wrapper {
+        min-height: 200px;
+        width: 100%;
+    }
+
+    &__group-wrapper {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        &:first-child {
+            padding-top: 0px;
+        }
+
+        padding-top: 8px;
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/QueryResultsVisualization/QueryResultsVisualization.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/QueryResultsVisualization/QueryResultsVisualization.tsx
@@ -1,0 +1,117 @@
+import React, {useEffect} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import throttle from 'lodash/throttle';
+import block from 'bem-cn-lite';
+import {type ChartKitRef} from '@gravity-ui/chartkit';
+import {Chart} from '../Chart/Chart';
+import {QueryItem} from '../../../module/api';
+import useResizeObserver from '../../../../../hooks/useResizeObserver';
+import {Loader} from '@gravity-ui/uikit';
+import {PlaceholdersContainer} from '../PlaceholdersContainer/PlaceholdersContainer';
+import './QueryResultsVisualization.scss';
+import {newbiusLoadQueryResults, saveQueryChartConfig} from '../../store/actions';
+import {
+    selectAvailableFields,
+    selectQueryId,
+    selectQueryResult,
+    selectQueryResultAllVisualizations,
+    selectQueryResultIndex,
+} from '../../store/selectors';
+import {QueryResultSelect} from '../VisualizationSelect/VisualizationSelect';
+import {ChartSettingsComponent} from '../ChartSettings/ChartSettings';
+import {VisualizationSelector} from '../VisualizationSelector/VisualizationSelector';
+import {SavingIndicator} from '../SavingIndicator/SavingIndicator';
+import {ChartErrorBoundary} from '../../components/ChartErrorBoundary/ChartErrorBoundary';
+import {ChartValidation} from '../ChartValidation/ChartValidation';
+
+const b = block('query-result-visualization');
+
+type QueryResultsVisualizationProps = {
+    query: QueryItem;
+    index: number;
+};
+
+export function QueryResultsVisualization({query}: QueryResultsVisualizationProps) {
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const chartKitRef = React.useRef<ChartKitRef>();
+    const allVisualizations = useSelector(selectQueryResultAllVisualizations);
+    const resultIndex = useSelector(selectQueryResultIndex);
+    const queryResult = useSelector(selectQueryResult);
+    const queryId = useSelector(selectQueryId);
+    const availableFields = useSelector(selectAvailableFields);
+
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        const weRecievedNewQuery = query.id !== queryId;
+
+        if (weRecievedNewQuery) {
+            dispatch({
+                type: 'set-query',
+                data: {
+                    query,
+                },
+            });
+        }
+    }, [query.id, queryId]);
+
+    useEffect(() => {
+        dispatch(
+            newbiusLoadQueryResults({
+                queryId: query.id,
+                resultIndex,
+            }),
+        );
+    }, [query.id, resultIndex, dispatch]);
+
+    useEffect(() => {
+        dispatch(
+            saveQueryChartConfig({
+                queryId: query.id,
+                visualizations: allVisualizations,
+            }),
+        );
+    }, [query.id, allVisualizations]);
+
+    const debouncedChartResize = React.useMemo(() => {
+        return throttle(() => {
+            chartKitRef.current?.reflow();
+        }, 300);
+    }, [chartKitRef.current]);
+
+    useResizeObserver({
+        element: containerRef.current ?? undefined,
+        onResize: debouncedChartResize,
+    });
+
+    if (!queryResult) {
+        return (
+            <div className={b('loader-wrapper')}>
+                <Loader className={b('loader')} />
+            </div>
+        );
+    }
+
+    return (
+        <div className={b()} ref={containerRef}>
+            <div className={b('controls-wrapper')}>
+                <div className={b('group-wrapper')}>
+                    <QueryResultSelect resultCount={query.result_count} />
+                </div>
+                <div className={b('group-wrapper')}>
+                    <VisualizationSelector />
+                    <ChartSettingsComponent />
+                    <SavingIndicator />
+                </div>
+                <PlaceholdersContainer availableFields={availableFields} />
+            </div>
+            <div className={b('chartkit-wrapper')}>
+                <ChartErrorBoundary>
+                    <ChartValidation>
+                        <Chart result={queryResult} ref={chartKitRef} />
+                    </ChartValidation>
+                </ChartErrorBoundary>
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/SavingIndicator/SavingIndicator.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/SavingIndicator/SavingIndicator.scss
@@ -1,0 +1,9 @@
+.saving-indicator {
+    width: 28px;
+
+    &_saved {
+        color: var(--g-color-line-positive);
+    }
+
+    color: var(--g-color-line-warning);
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/SavingIndicator/SavingIndicator.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/SavingIndicator/SavingIndicator.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {useSelector} from 'react-redux';
+import {selectQueryResultChartSaved} from '../../store/selectors';
+import {ArrowsRotateRight, CircleCheck} from '@gravity-ui/icons';
+import {Icon, Tooltip} from '@gravity-ui/uikit';
+import block from 'bem-cn-lite';
+import './SavingIndicator.scss';
+
+const b = block('saving-indicator');
+
+export function SavingIndicator() {
+    const saved = useSelector(selectQueryResultChartSaved);
+    const tooltipContent = saved ? 'Saved' : 'Saving in progress';
+
+    return (
+        <Tooltip content={tooltipContent}>
+            <Icon className={b({saved})} data={saved ? CircleCheck : ArrowsRotateRight} size={16} />
+        </Tooltip>
+    );
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/VisualizationSelect/VisualizationSelect.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/VisualizationSelect/VisualizationSelect.tsx
@@ -1,0 +1,41 @@
+import React, {useCallback, useMemo} from 'react';
+import {Select, SelectOption} from '@gravity-ui/uikit';
+import {selectQueryResultIndex} from '../../store/selectors';
+import {useSelector} from 'react-redux';
+import {useThunkDispatch} from '../../../../../store/thunkDispatch';
+
+type QueryResultSelectProps = {
+    resultCount: number;
+};
+
+export function QueryResultSelect({resultCount}: QueryResultSelectProps) {
+    const resultIndex = useSelector(selectQueryResultIndex);
+    const dispatch = useThunkDispatch();
+
+    const options = useMemo(() => {
+        const result: SelectOption[] = [];
+
+        for (let i = 0; i < resultCount; i++) {
+            result.push({
+                value: String(i),
+                content: `Result #${i + 1}`,
+            });
+        }
+        return result;
+    }, [resultCount]);
+
+    const onUpdate = useCallback(([value]: string[]) => {
+        dispatch({
+            type: 'set-result-index',
+            data: Number(value),
+        });
+    }, []);
+
+    const value = [String(resultIndex)];
+
+    if (options.length === 1) {
+        return null;
+    }
+
+    return <Select width="max" value={value} options={options} onUpdate={onUpdate} />;
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/VisualizationSelector/VisualizationSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/VisualizationSelector/VisualizationSelector.tsx
@@ -1,0 +1,44 @@
+import React, {useCallback, useMemo} from 'react';
+import {Select} from '@gravity-ui/uikit';
+import type {VisualizationId} from '../../types';
+import {useSelector} from 'react-redux';
+import {selectQueryResultVisualizationId} from '../../store/selectors';
+import {useThunkDispatch} from '../../../../../store/thunkDispatch';
+
+const options = [
+    {
+        value: 'line',
+        content: 'Line chart',
+    },
+    {
+        value: 'bar-x',
+        content: 'Bar chart',
+    },
+    {
+        value: 'scatter',
+        content: 'Scatter chart',
+    },
+];
+
+export function VisualizationSelector() {
+    const visualizationId = useSelector(selectQueryResultVisualizationId);
+    const dispatch = useThunkDispatch();
+
+    const value = useMemo(() => {
+        return [visualizationId];
+    }, [visualizationId]);
+
+    const onUpdate = useCallback(
+        ([visualization]: string[]) => {
+            dispatch({
+                type: 'set-visualization',
+                data: visualization as VisualizationId,
+            });
+        },
+        [dispatch],
+    );
+
+    return (
+        <Select<VisualizationId> width={125} value={value} options={options} onUpdate={onUpdate} />
+    );
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import {QueryResultsVisualization} from './containers/QueryResultsVisualization/QueryResultsVisualization';
+
+export const CUSTOM_QUERY_REQULT_TAB = {
+    title: 'Chart',
+    renderContent: (props: any) => <QueryResultsVisualization {...props} />,
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/__tests__/buildD3Config.spec.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/__tests__/buildD3Config.spec.ts
@@ -1,0 +1,193 @@
+import type {ChartKitWidgetData} from '@gravity-ui/chartkit';
+import {buildD3Config} from '../d3config';
+import {PrepareLineArgs} from '../types';
+
+type ChartSettings = PrepareLineArgs['visualization']['chartSettings'];
+
+describe('buildD3Config', () => {
+    it('should build the correct D3 config based on the given chart settings', () => {
+        const mockChartSettings: ChartSettings = {
+            xAxis: {
+                legend: 'on',
+                labels: 'on',
+                title: 'Sample X Axis',
+                grid: 'on',
+                pixelInterval: '100',
+            },
+            yAxis: {
+                labels: 'on',
+                title: 'Sample Y Axis',
+                grid: 'on',
+                pixelInterval: '80',
+            },
+        };
+
+        const args: PrepareLineArgs = {
+            visualization: {
+                id: 'line',
+                placeholders: [],
+                chartSettings: mockChartSettings,
+            },
+            result: [],
+        };
+
+        const expectedConfig: Partial<ChartKitWidgetData> = {
+            tooltip: {enabled: true},
+            legend: {enabled: true},
+            xAxis: {
+                type: 'category',
+                labels: {
+                    enabled: true,
+                },
+                title: {
+                    text: 'Sample X Axis',
+                },
+                grid: {
+                    enabled: true,
+                },
+                ticks: {
+                    pixelInterval: 100,
+                },
+            },
+            yAxis: [
+                {
+                    type: 'linear',
+                    lineColor: 'transparent',
+                    labels: {
+                        enabled: true,
+                    },
+                    title: {
+                        text: 'Sample Y Axis',
+                    },
+                    grid: {
+                        enabled: true,
+                    },
+                    ticks: {
+                        pixelInterval: 80,
+                    },
+                },
+            ],
+            series: {
+                data: [],
+                options: {
+                    'bar-x': {
+                        barMaxWidth: 50,
+                        barPadding: 0.05,
+                        groupPadding: 0.4,
+                        dataSorting: {
+                            direction: 'desc',
+                            key: 'name',
+                        },
+                    },
+                    line: {
+                        lineWidth: 2,
+                    },
+                },
+            },
+            chart: {
+                margin: {
+                    top: 10,
+                    left: 10,
+                    right: 10,
+                    bottom: 15,
+                },
+            },
+        };
+
+        const result = buildD3Config(args);
+        expect(result).toEqual(expectedConfig);
+    });
+
+    it('should set default pixel intervals if not specified', () => {
+        const mockChartSettings: ChartSettings = {
+            xAxis: {
+                legend: 'off',
+                labels: 'off',
+                title: '',
+                grid: 'on',
+                pixelInterval: '',
+            },
+            yAxis: {
+                labels: 'off',
+                title: '',
+                grid: 'on',
+                pixelInterval: '',
+            },
+        };
+
+        const args: PrepareLineArgs = {
+            visualization: {
+                id: 'line',
+                placeholders: [],
+                chartSettings: mockChartSettings,
+            },
+            result: [],
+        };
+
+        const expectedConfig: Partial<ChartKitWidgetData> = {
+            tooltip: {enabled: true},
+            legend: {enabled: false},
+            xAxis: {
+                type: 'category',
+                labels: {
+                    enabled: false,
+                },
+                title: {
+                    text: '',
+                },
+                grid: {
+                    enabled: true,
+                },
+                ticks: {
+                    pixelInterval: 120,
+                },
+            },
+            yAxis: [
+                {
+                    type: 'linear',
+                    lineColor: 'transparent',
+                    labels: {
+                        enabled: false,
+                    },
+                    title: {
+                        text: '',
+                    },
+                    grid: {
+                        enabled: true,
+                    },
+                    ticks: {
+                        pixelInterval: 120,
+                    },
+                },
+            ],
+            series: {
+                data: [],
+                options: {
+                    'bar-x': {
+                        barMaxWidth: 50,
+                        barPadding: 0.05,
+                        groupPadding: 0.4,
+                        dataSorting: {
+                            direction: 'desc',
+                            key: 'name',
+                        },
+                    },
+                    line: {
+                        lineWidth: 2,
+                    },
+                },
+            },
+            chart: {
+                margin: {
+                    top: 10,
+                    left: 10,
+                    right: 10,
+                    bottom: 15,
+                },
+            },
+        };
+
+        const result = buildD3Config(args);
+        expect(result).toEqual(expectedConfig);
+    });
+});

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/bar.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/bar.ts
@@ -1,0 +1,160 @@
+import uniq from 'lodash/uniq';
+import map from 'lodash/map';
+import type {ChartKitWidgetData} from '@gravity-ui/chartkit';
+import type {PrepareLineArgs, QueryResult} from './types';
+import {Field, VisualizationId} from '../types';
+import {splitDataByColor} from './splitDataByColor';
+import {getPointValue} from './getPointData';
+import {getVisualizationPlaceholders} from './utils';
+
+// Inspired by datalens ql chart
+// https://github.com/datalens-tech/datalens-ui/blob/e978d82ce785d4321057942d0ff05a163c12ade7/src/server/modes/charts/plugins/ql/preparers/line.ts#L82
+
+interface PrepareColoredSeriesDataArgs {
+    rows: QueryResult;
+    xField: Field;
+    yField: Field;
+    colorField: Field;
+    visualizationId: VisualizationId;
+}
+
+function prepareColoredSeriesData({
+    rows,
+    xField,
+    yField,
+    colorField,
+    visualizationId,
+}: PrepareColoredSeriesDataArgs): ChartKitWidgetData {
+    const xFieldPath = `${xField.name}.$rawValue`;
+
+    return {
+        series: {
+            data: splitDataByColor({
+                rows,
+                xFieldName: xField.name,
+                yFieldName: yField.name,
+                colorFieldName: colorField?.name,
+            }).map((item) => {
+                return {
+                    type: visualizationId,
+                    stacking: 'normal',
+                    name: item.name,
+                    data: item.data,
+                };
+            }),
+        },
+        xAxis: {
+            type: 'category',
+            categories: uniq(map(rows, xFieldPath) as unknown as string[]),
+        },
+    };
+}
+
+interface PrepareSeriesDataArgs {
+    rows: QueryResult;
+    xField: Field;
+    yField: Field;
+    visualizationId: VisualizationId;
+    yFields: Field[];
+}
+
+function prepareSeriesData({
+    xField,
+    yField,
+    yFields,
+    rows,
+    visualizationId,
+}: PrepareSeriesDataArgs): ChartKitWidgetData {
+    const result: Record<any, any> = {};
+
+    let xValues: (string | number)[] = [];
+
+    const dataMatrix: Record<string, any> = {};
+
+    rows.forEach((row) => {
+        const xRowItem = row[xField.name];
+        const xValue = xRowItem.$rawValue;
+
+        xValues.push(xValue);
+
+        yFields.forEach((field) => {
+            dataMatrix[xValue] = getPointValue(row[field.name]);
+        });
+    });
+
+    xValues = Array.from(new Set(xValues));
+
+    result.categories = xValues.map((value) => value);
+
+    result.graphs = [];
+
+    yFields.forEach(() => {
+        const graph = {
+            data: xValues.map((xValue) => {
+                return dataMatrix[String(xValue)];
+            }),
+        };
+
+        result.graphs?.push(graph);
+    });
+
+    return {
+        series: {
+            data: [
+                {
+                    type: visualizationId,
+                    data: result.graphs[0].data.map((item: string, index: number) => {
+                        return {
+                            x: result.categories[index],
+                            y: Number(item),
+                        };
+                    }),
+                    name: yField.name,
+                },
+            ],
+        },
+        xAxis: {
+            type: 'category',
+            categories: result.categories,
+        },
+    };
+}
+
+export function prepareBar(args: PrepareLineArgs): ChartKitWidgetData {
+    const {visualization} = args;
+    const visualizationId = visualization.id;
+    const rows = args.result;
+    const {xPlaceholder, yPlaceholder, colorPlaceholder} =
+        getVisualizationPlaceholders(visualization);
+
+    const [xField] = xPlaceholder?.fields || [];
+    const yFields = yPlaceholder?.fields || [];
+    const [yField] = yFields;
+    const [colorField] = colorPlaceholder?.fields || [];
+
+    if (!xField || !yField) {
+        return {
+            series: {
+                data: [],
+            },
+        };
+    }
+
+    if (colorField) {
+        return prepareColoredSeriesData({
+            rows,
+            yField,
+            xField,
+            colorField,
+            visualizationId,
+        });
+    }
+
+    return prepareSeriesData({
+        rows,
+        yField,
+        xField,
+        yFields,
+        visualizationId,
+    });
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/d3config.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/d3config.ts
@@ -1,0 +1,93 @@
+import type {ChartKitWidgetAxisType, ChartKitWidgetData} from '@gravity-ui/chartkit';
+import type {PrepareLineArgs} from './types';
+import {VisualizationId} from '../types';
+
+// Inspired by
+// https://github.com/datalens-tech/datalens-ui/blob/e978d82ce785d4321057942d0ff05a163c12ade7/src/server/modes/charts/plugins/datalens/d3/index.ts#L24
+
+export function buildD3Config(args: PrepareLineArgs) {
+    const chartSettings = args.visualization.chartSettings;
+
+    const xAxisGridEnabled = chartSettings.xAxis.grid === 'on';
+    const xAxisIsLegendEnabled = chartSettings.xAxis.legend === 'on';
+    const xAxisEnableLabels = chartSettings.xAxis.labels === 'on';
+    const xAxisTitle = chartSettings.xAxis.title;
+    const xAxisPixelInterval = Number(chartSettings.xAxis.pixelInterval || '120');
+
+    const yAxisEnableLabels = chartSettings.yAxis.labels === 'on';
+    const yAxisTitle = chartSettings.yAxis.title;
+    const yAxisGridEnabled = chartSettings.yAxis.grid === 'on';
+    const yAxisPixelInterval = Number(chartSettings.yAxis.pixelInterval || '120');
+
+    const chartWidgetData: Partial<ChartKitWidgetData> = {
+        tooltip: {enabled: true},
+        legend: {enabled: xAxisIsLegendEnabled},
+        xAxis: {
+            type: getAxisType(args.visualization.id),
+            labels: {
+                enabled: xAxisEnableLabels,
+            },
+            title: {
+                text: xAxisTitle,
+            },
+            grid: {
+                enabled: xAxisGridEnabled,
+            },
+            ticks: {
+                pixelInterval: xAxisPixelInterval,
+            },
+        },
+        yAxis: [
+            {
+                // todo: the axis type should depend on the type of field
+                type: 'linear',
+                lineColor: 'transparent',
+                labels: {
+                    enabled: yAxisEnableLabels,
+                },
+                title: {
+                    text: yAxisTitle,
+                },
+                grid: {
+                    enabled: yAxisGridEnabled,
+                },
+                ticks: {
+                    pixelInterval: yAxisPixelInterval,
+                },
+            },
+        ],
+        series: {
+            data: [],
+            options: {
+                'bar-x': {
+                    barMaxWidth: 50,
+                    barPadding: 0.05,
+                    groupPadding: 0.4,
+                    dataSorting: {
+                        direction: 'desc',
+                        key: 'name',
+                    },
+                },
+                line: {
+                    lineWidth: 2,
+                },
+            },
+        },
+        chart: {
+            margin: {
+                top: 10,
+                left: 10,
+                right: 10,
+                bottom: 15,
+            },
+        },
+    };
+
+    return chartWidgetData;
+}
+
+// Write this function, using reference:
+// https://github.com/datalens-tech/datalens-ui/blob/e978d82ce785d4321057942d0ff05a163c12ade7/src/server/modes/charts/plugins/datalens/preparers/helpers/axis.ts
+function getAxisType(visualizationId: VisualizationId): ChartKitWidgetAxisType {
+    return visualizationId === 'scatter' ? 'linear' : 'category';
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/getPointData.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/getPointData.ts
@@ -1,0 +1,21 @@
+import {FieldObject} from './types';
+
+export const getPointValue = (value: FieldObject) => {
+    switch (value.$type) {
+        case 'yql.interval': {
+            return Number(value.$value);
+        }
+
+        case 'yql.int32':
+        case 'yql.int64':
+        case 'yql.uint8':
+        case 'yql.uint32':
+        case 'yql.uint64':
+        case 'yql.float':
+        case 'yql.double':
+        case 'yql.decimal':
+            return Number(value.$value);
+        default:
+            return value.$rawValue;
+    }
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/prepareWidgetData.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/prepareWidgetData.ts
@@ -1,0 +1,24 @@
+import _ from 'lodash';
+import type {ChartKitWidgetData} from '@gravity-ui/chartkit';
+import {prepareBar} from './bar';
+import {prepareScatter} from './scatter';
+import type {PrepareLineArgs} from './types';
+import {buildD3Config} from './d3config';
+
+export const prepareWidgetData = (args: PrepareLineArgs): ChartKitWidgetData => {
+    const d3Config = buildD3Config(args);
+
+    let data;
+
+    switch (args.visualization.id) {
+        case 'scatter': {
+            data = prepareScatter(args);
+            break;
+        }
+        default: {
+            data = prepareBar(args);
+        }
+    }
+
+    return _.merge(data, d3Config);
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/scatter.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/scatter.ts
@@ -1,0 +1,62 @@
+import type {ChartKitWidgetData} from '@gravity-ui/chartkit';
+import type {PrepareLineArgs} from './types';
+import {splitDataByColor} from './splitDataByColor';
+import {getVisualizationPlaceholders} from './utils';
+
+export function prepareScatter(args: PrepareLineArgs): ChartKitWidgetData {
+    const {visualization} = args;
+    const rows = args.result;
+    const {xPlaceholder, yPlaceholder, colorPlaceholder} =
+        getVisualizationPlaceholders(visualization);
+    const [xField] = xPlaceholder?.fields || [];
+    const yFields = yPlaceholder?.fields || [];
+    const [yField] = yFields;
+    const [colorField] = colorPlaceholder?.fields || [];
+
+    if (!xField || !yField) {
+        return {
+            series: {
+                data: [],
+            },
+        };
+    }
+
+    if (colorField) {
+        return {
+            series: {
+                data: splitDataByColor({
+                    rows,
+                    yFieldName: yField.name,
+                    xFieldName: xField.name,
+                    colorFieldName: colorField?.name,
+                }).map((item) => ({
+                    data: item.data.map(({x, y}) => ({
+                        x: Number(x),
+                        y: Number(y),
+                    })),
+                    name: item.name,
+                    type: 'scatter',
+                })),
+            },
+        };
+    }
+
+    const widgetData: ChartKitWidgetData = {
+        series: {
+            data: [
+                {
+                    type: 'scatter',
+                    data: rows.map((row) => {
+                        return {
+                            x: Number(row[xField.name].$rawValue),
+                            y: Number(row[yField.name].$rawValue),
+                        };
+                    }),
+                    name: `${xField.name} x ${yField.name}`,
+                },
+            ],
+        },
+    };
+
+    return widgetData;
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/splitDataByColor.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/splitDataByColor.ts
@@ -1,0 +1,50 @@
+import transform from 'lodash/transform';
+import groupBy from 'lodash/groupBy';
+import type {QueryResult} from './types';
+import {getPointValue} from './getPointData';
+
+export const splitDataByColor = ({
+    rows,
+    colorFieldName,
+    xFieldName,
+    yFieldName,
+}: {
+    rows: QueryResult;
+    xFieldName: string;
+    yFieldName: string;
+    colorFieldName: string;
+}) => {
+    const xFieldPath = `${xFieldName}.$rawValue`;
+    const colorFieldPath = `${colorFieldName}.$rawValue`;
+
+    return transform<
+        Record<string, QueryResult>,
+        Array<{name: string; data: {x: string; y: number}[]}>
+    >(
+        groupBy(rows, colorFieldPath),
+        (result, value, key) => {
+            const data = transform<Record<string, QueryResult>, {x: string; y: number}[]>(
+                groupBy(value, xFieldPath),
+                (acc, y, x) => {
+                    const point = Array.isArray(y) ? y[0] : y;
+
+                    acc.push({
+                        x,
+                        y: Number(getPointValue(point[yFieldName])),
+                    });
+
+                    return acc;
+                },
+                [],
+            );
+
+            result.push({
+                name: key,
+                data,
+            });
+
+            return result;
+        },
+        [],
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/types.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/types.ts
@@ -1,0 +1,14 @@
+import type {Visualization} from '../types';
+
+export type PrepareLineArgs = {
+    result: QueryResult;
+    visualization: Visualization;
+};
+
+export type FieldObject = {
+    $type: string;
+    $value: unknown;
+    $rawValue: string;
+};
+
+export type QueryResult = Record<string, FieldObject>[];

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/utils.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/utils.ts
@@ -1,0 +1,34 @@
+import type {Placeholder, Visualization} from '../types';
+
+type VisualizationPlaceholders = {
+    xPlaceholder: Placeholder | undefined;
+    yPlaceholder: Placeholder | undefined;
+    colorPlaceholder: Placeholder | undefined;
+};
+
+export function getVisualizationPlaceholders(
+    visualization: Visualization,
+): VisualizationPlaceholders {
+    return visualization.placeholders.reduce(
+        (acc: VisualizationPlaceholders, placeholder) => {
+            if (placeholder.id === 'x') {
+                acc.xPlaceholder = placeholder;
+            }
+
+            if (placeholder.id === 'y') {
+                acc.yPlaceholder = placeholder;
+            }
+
+            if (placeholder.id === 'colors') {
+                acc.colorPlaceholder = placeholder;
+            }
+
+            return acc;
+        },
+        {
+            xPlaceholder: undefined,
+            yPlaceholder: undefined,
+            colorPlaceholder: undefined,
+        },
+    );
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/store/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/store/actions.ts
@@ -1,0 +1,129 @@
+import {YTApiId, ytApiV4Id} from '../../../../rum/rum-wrap-api';
+import {Visualization} from '../types';
+import _ from 'lodash';
+import type {QueryResultVisualizationAction} from './reducer';
+import {QueryResultMetaScheme, getQueryResultMeta, readQueryResults} from '../../module/api';
+import {getPrimitiveTypesMap} from '../../../../store/selectors/global/supported-features';
+import thorYPath from '../../../../common/thor/ypath';
+import {getType} from '../../../../components/SchemaDataType/dataTypes';
+import {Type, parseV3Type} from '../../../../components/SchemaDataType/dateTypesV3';
+import {getQueryResultGlobalSettings} from '../../module/query_result/selectors';
+import {prepareFormattedValue} from '../../module/query_result/utils/format';
+import {selectQueryResult} from './selectors';
+import {RootState} from '../../../../store/reducers/index';
+import {AppThunkDispatch} from '../../../../store/thunkDispatch';
+import {wrapApiPromiseByToaster} from '../../../../utils/utils';
+
+type SaveQueryChartConfig = {
+    visualizations: Visualization[];
+    queryId: string;
+};
+
+const DELAY = 5 * 1000;
+
+const debouncedSaveQueryChartConfig = _.debounce(
+    (dispatch: AppThunkDispatch<QueryResultVisualizationAction>, payload: SaveQueryChartConfig) => {
+        const promise = ytApiV4Id
+            .alterQuery(YTApiId.alterQuery, {
+                parameters: {
+                    query_id: payload.queryId,
+                    annotations: {
+                        ui_chart_config: payload.visualizations,
+                    },
+                },
+            })
+            .then(() => {
+                dispatch({
+                    type: 'set-visualization-saved',
+                    data: {
+                        saved: true,
+                    },
+                });
+            });
+
+        wrapApiPromiseByToaster(promise, {
+            toasterName: 'saveQueryChartConfig',
+            skipSuccessToast: true,
+            errorContent: 'Failed to save query chart config',
+        });
+    },
+    DELAY,
+);
+
+export function saveQueryChartConfig(payload: SaveQueryChartConfig) {
+    return (dispatch: AppThunkDispatch<QueryResultVisualizationAction>) => {
+        dispatch({
+            type: 'set-visualization-saved',
+            data: {
+                saved: false,
+            },
+        });
+
+        debouncedSaveQueryChartConfig(dispatch, payload);
+    };
+}
+
+export function newbiusLoadQueryResults({
+    queryId,
+    resultIndex,
+}: {
+    queryId: string;
+    resultIndex: number;
+}) {
+    return async (dispatch: AppThunkDispatch<any>, getState: () => RootState) => {
+        const queryResultAlreadyExist = selectQueryResult(getState());
+
+        if (queryResultAlreadyExist) {
+            return;
+        }
+
+        const meta = await dispatch(getQueryResultMeta(queryId, resultIndex));
+
+        if (meta?.error) throw meta.error;
+
+        const typeMap = getPrimitiveTypesMap(getState());
+        const scheme: QueryResultMetaScheme[] = thorYPath.getValue(meta?.schema) || [];
+        const columns =
+            scheme.map(({name, type_v3: typeV3}) => {
+                return {
+                    name,
+                    type: getType(parseV3Type(typeV3 as Type, typeMap)),
+                    displayName: name,
+                };
+            }) || [];
+
+        const settings = getQueryResultGlobalSettings();
+
+        const result = await dispatch(
+            readQueryResults(
+                queryId,
+                resultIndex,
+                {
+                    start: 0,
+                    end: Infinity,
+                },
+                columns.map(({name}) => name),
+                {cellsSize: settings.cellSize},
+            ),
+        );
+
+        const {rows, yql_type_registry: types} = result;
+
+        const queryResult = rows.map((v) => {
+            return Object.entries(v).reduce(
+                (acc, [k, [value, typeIndex]]) => {
+                    acc[k] = prepareFormattedValue(value, types[Number(typeIndex)]);
+                    return acc;
+                },
+                {} as Record<string, {$type: string; $value: unknown}>,
+            );
+        });
+
+        dispatch({
+            type: 'set-query-result',
+            data: {
+                queryResult,
+            },
+        });
+    };
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/store/reducer.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/store/reducer.tsx
@@ -1,0 +1,213 @@
+import type {
+    ChartSettings,
+    ExtendedQueryItem,
+    Field,
+    Visualization,
+    VisualizationId,
+} from '../types';
+import type {ActionD} from '../../../../../ui/types';
+import {QueryResult} from '../preparers/types';
+
+export interface QueryResultsVisualizationState {
+    saved: boolean;
+    query: ExtendedQueryItem | undefined;
+    queryResults: Record<number, QueryResult>;
+    resultIndex: number;
+    visualizations: Visualization[];
+}
+
+function getInitialVisualization(): Visualization {
+    return {
+        id: 'line',
+        placeholders: [
+            {
+                id: 'x',
+                fields: [],
+            },
+            {
+                id: 'y',
+                fields: [],
+            },
+            {
+                id: 'colors',
+                fields: [],
+            },
+        ],
+        chartSettings: {
+            xAxis: {
+                legend: 'on',
+                labels: 'on',
+                title: '',
+                grid: 'on',
+                pixelInterval: '',
+            },
+            yAxis: {
+                labels: 'on',
+                title: '',
+                grid: 'on',
+                pixelInterval: '',
+            },
+        },
+    };
+}
+
+export const initialState: QueryResultsVisualizationState = {
+    saved: true,
+    query: undefined,
+    queryResults: {},
+    resultIndex: 0,
+    visualizations: [getInitialVisualization()],
+};
+
+export type QueryResultVisualizationAction =
+    | ActionD<'set-fields', {placeholderId: string; fields: Field[]}>
+    | ActionD<'remove-field', {placeholderId: string; field: Field}>
+    | ActionD<'set-chart-settings', ChartSettings>
+    | ActionD<'set-visualization', VisualizationId>
+    | ActionD<'set-query', {query: ExtendedQueryItem}>
+    | ActionD<'set-result-index', number>
+    | ActionD<'set-visualization-saved', {saved: boolean}>
+    | ActionD<'set-query-result', {queryResult: QueryResult}>;
+
+export function queryResultsVisualization(
+    state: QueryResultsVisualizationState = initialState,
+    action: QueryResultVisualizationAction,
+): QueryResultsVisualizationState {
+    switch (action.type) {
+        case 'set-visualization-saved': {
+            const {saved} = action.data;
+
+            return {
+                ...state,
+                saved,
+            };
+        }
+        case 'set-query': {
+            const {query} = action.data;
+
+            const queryVisualizations = query.annotations?.ui_chart_config || [];
+
+            const visualizations = [];
+
+            for (let i = 0; i < query.result_count; i++) {
+                visualizations.push(queryVisualizations[i] || getInitialVisualization());
+            }
+
+            return {
+                ...state,
+                query,
+                queryResults: {},
+                visualizations,
+            };
+        }
+        case 'set-query-result': {
+            const {queryResult} = action.data;
+
+            return {
+                ...state,
+                queryResults: {
+                    ...state.queryResults,
+                    [state.resultIndex]: queryResult,
+                },
+            };
+        }
+        case 'set-fields': {
+            const visualizations = state.visualizations.map((visualization, index) => {
+                if (index !== state.resultIndex) {
+                    return visualization;
+                }
+
+                return {
+                    ...visualization,
+                    placeholders: visualization.placeholders.map((placeholder) => {
+                        if (placeholder.id === action.data.placeholderId) {
+                            return {
+                                ...placeholder,
+                                fields: action.data.fields,
+                            };
+                        }
+
+                        return placeholder;
+                    }),
+                };
+            });
+
+            return {
+                ...state,
+                visualizations,
+            };
+        }
+        case 'remove-field': {
+            const visualizations = state.visualizations.map((visualization, index) => {
+                if (index !== state.resultIndex) {
+                    return visualization;
+                }
+
+                const placeholders = visualization.placeholders.map((placeholder) => {
+                    if (placeholder.id === action.data.placeholderId) {
+                        return {
+                            ...placeholder,
+                            fields: placeholder.fields.filter(
+                                (field) => field.name !== action.data.field.name,
+                            ),
+                        };
+                    }
+
+                    return placeholder;
+                });
+
+                return {
+                    ...visualization,
+                    placeholders,
+                };
+            });
+
+            return {
+                ...state,
+                visualizations,
+            };
+        }
+        case 'set-chart-settings': {
+            const visualizations = state.visualizations.map((visualization, index) => {
+                if (index !== state.resultIndex) {
+                    return visualization;
+                }
+
+                return {
+                    ...visualization,
+                    chartSettings: action.data,
+                };
+            });
+
+            return {
+                ...state,
+                visualizations,
+            };
+        }
+        case 'set-visualization': {
+            const visualizations = state.visualizations.map((visualization, index) => {
+                if (index !== state.resultIndex) {
+                    return visualization;
+                }
+
+                return {
+                    ...visualization,
+                    id: action.data,
+                };
+            });
+
+            return {
+                ...state,
+                visualizations,
+            };
+        }
+        case 'set-result-index': {
+            return {
+                ...state,
+                resultIndex: action.data,
+            };
+        }
+        default:
+            return state;
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/store/selectors.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/store/selectors.ts
@@ -1,0 +1,218 @@
+import {createSelector} from 'reselect';
+import get from 'lodash/get';
+import {RootState} from '../../../../store/reducers/index';
+import type {QueryResult} from '../preparers/types';
+import type {Placeholder, PlaceholderId} from '../types';
+import objectHash from 'object-hash';
+
+export const selectQueryResultAllVisualizations = (state: RootState) =>
+    state.queryResultsVisualization.visualizations;
+
+export const selectQueryResultVisualization = (state: RootState) =>
+    state.queryResultsVisualization.visualizations[state.queryResultsVisualization.resultIndex];
+
+export const selectQueryResultVisualizationPlaceholders = (state: RootState) =>
+    selectQueryResultVisualization(state).placeholders;
+
+export const selectQueryResultVisualizationId = (state: RootState) =>
+    selectQueryResultVisualization(state).id;
+
+export const selectQueryResultChartSettings = (state: RootState) =>
+    selectQueryResultVisualization(state).chartSettings;
+
+export const selectQueryResultIndex = (state: RootState) =>
+    state.queryResultsVisualization.resultIndex;
+
+export const selectQueryResultChartSaved = (state: RootState) =>
+    state.queryResultsVisualization.saved;
+
+export const selectQueryId = (state: RootState) => state.queryResultsVisualization.query?.id;
+
+export const selectQueryResult = (state: RootState) =>
+    state.queryResultsVisualization.queryResults[state.queryResultsVisualization.resultIndex];
+
+export const selectAvailableFields = (state: RootState) => {
+    const result = selectQueryResult(state);
+
+    const row = (result && result[0]) || {};
+
+    const columns: {name: string}[] = Object.keys(row).map((name) => {
+        return {
+            name,
+        };
+    });
+
+    return columns;
+};
+
+export const resultsPlaceholdersValidation = createSelector(
+    [
+        selectQueryResult,
+        selectQueryResultVisualizationPlaceholders,
+        selectQueryResultVisualizationId,
+    ],
+    (queryResult, placeholders, visualizationId): Record<string, {invalid: boolean}> => {
+        const hasColors = Boolean(
+            placeholders.find((placeholder) => placeholder.id === 'colors')?.fields.length,
+        );
+
+        if (hasColors) {
+            return colorsValidation(queryResult, placeholders);
+        }
+
+        const validationFunction =
+            visualizationId === 'scatter' ? scatterValidation : lineAndBarValidation;
+
+        return validationFunction(queryResult, placeholders);
+    },
+);
+
+function scatterValidation(queryResult: QueryResult, placeholders: Placeholder[]) {
+    const fields = placeholders.reduce(
+        (ret: {x: null | string; y: null | string}, field) => {
+            const fieldName = get(field, 'fields.0.name');
+            const fieldType = get(field, 'id') as 'x' | 'y';
+
+            if (fieldName && fieldType) {
+                ret[fieldType] = fieldName;
+            }
+
+            return ret;
+        },
+        {x: null, y: null},
+    );
+
+    const xFieldName = fields.x;
+    const yFieldName = fields.y;
+    const notAllFieldsSelected = !xFieldName || !yFieldName;
+
+    if (notAllFieldsSelected) {
+        return {
+            x: {invalid: false},
+            y: {invalid: false},
+        };
+    }
+
+    const hashes: Record<string, boolean> = {};
+
+    const isPointsDuplicated = queryResult.some((item) => {
+        const xValue = item[xFieldName].$rawValue;
+        const yValue = item[yFieldName].$rawValue;
+        // eslint-disable-next-line new-cap
+        const hash = objectHash.MD5({
+            xValue,
+            yValue,
+        });
+
+        const isPointDuplicated = hashes[hash];
+
+        hashes[hash] = true;
+
+        return isPointDuplicated;
+    });
+
+    return {
+        x: {invalid: isPointsDuplicated},
+        y: {invalid: isPointsDuplicated},
+    };
+}
+
+function lineAndBarValidation(queryResult: QueryResult, placeholders: Placeholder[]) {
+    const fields = placeholders.reduce(
+        (ret: {x: null | string; y: null | string}, field) => {
+            const fieldName = get(field, 'fields.0.name');
+            const fieldType = get(field, 'id') as 'x' | 'y';
+
+            if (fieldName && fieldType) {
+                ret[fieldType] = fieldName;
+            }
+
+            return ret;
+        },
+        {x: null, y: null},
+    );
+
+    const xFieldName = fields.x;
+    const yFieldName = fields.y;
+    const notAllFieldsSelected = !xFieldName || !yFieldName;
+
+    if (notAllFieldsSelected) {
+        return {
+            x: {invalid: false},
+        };
+    }
+
+    const xCoords: Record<string, boolean> = {};
+
+    const isXCoordsDuplicated = queryResult.some((item) => {
+        const xValue = item[xFieldName].$rawValue;
+
+        const isXValueDuplicated = xCoords[xValue];
+
+        xCoords[xValue] = true;
+
+        return isXValueDuplicated;
+    });
+
+    return {
+        x: {invalid: isXCoordsDuplicated},
+    } as unknown as Record<string, {invalid: boolean}>;
+}
+
+function colorsValidation(queryResult: QueryResult, placeholders: Placeholder[]) {
+    const fields = placeholders.reduce((acc: string[], field) => {
+        const fieldName = get(field, 'fields.0.name');
+
+        if (fieldName) {
+            acc.push(fieldName);
+        }
+
+        return acc;
+    }, []);
+
+    const notAllFieldsSelected = fields.length < placeholders.length;
+
+    if (notAllFieldsSelected) {
+        return {
+            x: {invalid: false},
+        };
+    }
+
+    const hashes: Record<string, boolean> = {};
+
+    const isDataDuplicated = queryResult.some((item) => {
+        const newObject = fields.reduce((acc: Record<string, string>, field: string) => {
+            acc[field] = item[field].$rawValue;
+            return acc;
+        }, {});
+
+        // eslint-disable-next-line new-cap
+        const lineHash = objectHash.MD5(newObject);
+
+        const isLineDuplicated = hashes[lineHash];
+
+        hashes[lineHash] = true;
+
+        return isLineDuplicated;
+    });
+
+    return {
+        x: {invalid: isDataDuplicated},
+    };
+}
+
+export const selectIsPlaceholdersMissSomeFields = createSelector(
+    [selectQueryResultVisualizationPlaceholders],
+    (placeholders) => {
+        const placeholdersMap = placeholders.reduce(
+            (acc, placeholder) => {
+                acc[placeholder.id] = placeholder.fields.length > 0;
+
+                return acc;
+            },
+            {} as Record<PlaceholderId, boolean>,
+        );
+
+        return !placeholdersMap.x || !placeholdersMap.y;
+    },
+);

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/types.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/types.ts
@@ -1,0 +1,46 @@
+export type Field = {
+    name: string;
+};
+
+export type PlaceholderId = 'x' | 'y' | 'colors';
+
+export type Placeholder = {
+    id: PlaceholderId;
+    fields: Field[];
+};
+
+type RadioSetting = 'on' | 'off';
+
+type StringSetting = string;
+
+export type ChartSettings = {
+    xAxis: {
+        legend: RadioSetting;
+        labels: RadioSetting;
+        title: StringSetting;
+        grid: RadioSetting;
+        pixelInterval: StringSetting;
+    };
+    yAxis: {
+        labels: RadioSetting;
+        title: StringSetting;
+        grid: RadioSetting;
+        pixelInterval: StringSetting;
+    };
+};
+
+export type VisualizationId = 'line' | 'bar-x' | 'scatter';
+
+export type Visualization = {
+    id: VisualizationId;
+    placeholders: Placeholder[];
+    chartSettings: ChartSettings;
+};
+
+export type ExtendedQueryItem = {
+    id: string;
+    result_count: number;
+    annotations?: {
+        ui_chart_config: Visualization[];
+    };
+};

--- a/packages/ui/src/ui/store/reducers/index.main.ts
+++ b/packages/ui/src/ui/store/reducers/index.main.ts
@@ -41,6 +41,7 @@ import {hasOdinPage} from '../../config';
 import {chyt} from './chyt';
 import {RawVersion} from '../../store/selectors/thor/support';
 import {mainLocations} from '../../store/location.main';
+import {queryResultsVisualization} from '../../pages/query-tracker/QueryResultsVisualization/store/reducer';
 
 const appReducers = {
     acl,
@@ -79,6 +80,7 @@ const appReducers = {
 
     chyt,
     manageTokens,
+    queryResultsVisualization,
 };
 
 export type RootState = Omit<ReturnType<ReturnType<typeof makeRootReducer>>, 'global'> & {


### PR DESCRIPTION
Issue https://github.com/ytsaurus/ytsaurus-ui/issues/641.



All adhoc chart code is located at packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization.

1. QueryResultsVisualization/components - react components which don't use store
2. QueryResultsVisualization/containers  - react components which connected to store
3. QueryResultsVisualization/prepares - pure functions which maps query result to chartkit format.
4. QueryResultsVisualization/store - reducer, selectors and actions.


The most important place is [prepareWidgetData function ](https://github.com/ytsaurus/ytsaurus-ui/pull/643/files#diff-f330255613b8b931deb64ab26bf68721e892da3a2ba50a1ab808ecf4898055e5R8) where we map QueryResult data to ChartKitWidgetData.