### PR TITLE
feat: added ability to override default text on login page

### DIFF
--- a/packages/ui/src/shared/ui-settings.ts
+++ b/packages/ui/src/shared/ui-settings.ts
@@ -146,6 +146,14 @@ export interface UISettings {
      * @example reUseEffectiveAclForPath: '//sys/access_control_object_namespaces[^/+]{0,}'
      */
     reUseEffectiveAclForPath?: string;
+
+    /**
+     * Allows to override default title and text on login page, accepts HTML string.
+     */
+    loginPageSettings?: {
+        title?: string;
+        text?: string;
+    };
 }
 
 export interface UISettingsMonitoring {

--- a/packages/ui/src/ui/components/Login/LoginFormPage/LoginFormPage.tsx
+++ b/packages/ui/src/ui/components/Login/LoginFormPage/LoginFormPage.tsx
@@ -6,6 +6,7 @@ import {onSuccessLogin} from '../../../store/actions/global';
 import ytLocalStorage from '../../../utils/yt-local-storage';
 import {
     getGlobalYTAuthCluster,
+    getLoginPageText,
     getOAuthButtonLabel,
     getOAuthEnabled,
 } from '../../../store/selectors/global';
@@ -42,11 +43,19 @@ const validate = ({
     return result;
 };
 
+const DEFAULT_LOGIN_FORM_TITLE = 'Welcome to YTsaurus!';
+
+const DEFAULT_LOGIN_FORM_TEXT = `A unified scalable platform for storing and processing large volumes of data.
+<br />
+<br />
+Login under your credentials.`;
+
 function LoginForm({theme}: Props) {
     const dispatch = useDispatch();
     const [username, setUsername] = useState(ytLocalStorage.get('loginDialog')?.username || '');
     const allowOAuth = useSelector(getOAuthEnabled);
     const buttonLabel = useSelector(getOAuthButtonLabel);
+    const loginPageSettings = useSelector(getLoginPageText);
     const ytAuthCluster = useSelector(getGlobalYTAuthCluster) ?? '';
     const [password, setPassword] = useState('');
     const [loading, setLoading] = useState<boolean>(false);
@@ -83,15 +92,22 @@ function LoginForm({theme}: Props) {
         [username, password, dispatch],
     );
 
+    const {text, title} = loginPageSettings;
+
     return (
         <>
-            <h1 className={block('title')}>Welcome to YTsaurus!</h1>
-            <p className={block('text')}>
-                A unified scalable platform for storing and processing large volumes of data.
-                <br />
-                <br />
-                Login to your account.
-            </p>
+            <h1
+                className={block('title')}
+                dangerouslySetInnerHTML={{
+                    __html: title === undefined ? DEFAULT_LOGIN_FORM_TITLE : title,
+                }}
+            />
+            <p
+                className={block('text')}
+                dangerouslySetInnerHTML={{
+                    __html: text === undefined ? DEFAULT_LOGIN_FORM_TEXT : text,
+                }}
+            />
             <form onSubmit={handleFormSubmit}>
                 <TextInput
                     className={block('field')}

--- a/packages/ui/src/ui/store/selectors/global/index.ts
+++ b/packages/ui/src/ui/store/selectors/global/index.ts
@@ -210,6 +210,10 @@ export const getOAuthButtonLabel = () => {
     return getConfigData().oauthButtonLabel;
 };
 
+export const getLoginPageText = () => {
+    return getConfigData().uiSettings?.loginPageSettings ?? {};
+};
+
 export const getGlobalAsideHeaderWidth = (state: RootState) => state.global.asideHeaderWidth;
 
 export const getGlobalYTAuthCluster = (state: RootState) => state.global.ytAuthCluster;


### PR DESCRIPTION
https://github.com/ytsaurus/ytsaurus-ui/issues/636

Now we can change default text on login page via ui settings.

<img width="548" alt="image" src="https://github.com/ytsaurus/ytsaurus-ui/assets/2428161/6c7078e3-5a6c-428d-9bf6-c52944aca785">
