### PR TITLE
fix: move loginPageSettings to cluster config, that is allows to specify such setting per cluster

### DIFF
--- a/packages/ui/src/shared/ui-settings.ts
+++ b/packages/ui/src/shared/ui-settings.ts
@@ -146,14 +146,6 @@ export interface UISettings {
      * @example reUseEffectiveAclForPath: '//sys/access_control_object_namespaces[^/+]{0,}'
      */
     reUseEffectiveAclForPath?: string;
-
-    /**
-     * Allows to override default title and text on login page, accepts HTML string.
-     */
-    loginPageSettings?: {
-        title?: string;
-        text?: string;
-    };
 }
 
 export interface UISettingsMonitoring {

--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -99,6 +99,14 @@ export interface ClusterConfig {
         icon2x: string;
         iconbig?: string;
     };
+
+    /**
+     * Allows to override default title and text on login page, accepts HTML string.
+     */
+    loginPageSettings?: {
+        title?: string;
+        text?: string;
+    };
 }
 
 export interface SubRequest<K extends string, T extends BaseBatchParams> {

--- a/packages/ui/src/ui/components/Login/LoginFormPage/LoginFormPage.tsx
+++ b/packages/ui/src/ui/components/Login/LoginFormPage/LoginFormPage.tsx
@@ -5,8 +5,8 @@ import {Button, Text, TextInput} from '@gravity-ui/uikit';
 import {onSuccessLogin} from '../../../store/actions/global';
 import ytLocalStorage from '../../../utils/yt-local-storage';
 import {
+    getClusterConfigByName,
     getGlobalYTAuthCluster,
-    getLoginPageText,
     getOAuthButtonLabel,
     getOAuthEnabled,
 } from '../../../store/selectors/global';
@@ -55,8 +55,8 @@ function LoginForm({theme}: Props) {
     const [username, setUsername] = useState(ytLocalStorage.get('loginDialog')?.username || '');
     const allowOAuth = useSelector(getOAuthEnabled);
     const buttonLabel = useSelector(getOAuthButtonLabel);
-    const loginPageSettings = useSelector(getLoginPageText);
     const ytAuthCluster = useSelector(getGlobalYTAuthCluster) ?? '';
+    const ytAuthClusterConfig = useSelector(() => getClusterConfigByName(ytAuthCluster));
     const [password, setPassword] = useState('');
     const [loading, setLoading] = useState<boolean>(false);
     const [errors, setErrors] = React.useState<ErrorFields>({});
@@ -92,7 +92,7 @@ function LoginForm({theme}: Props) {
         [username, password, dispatch],
     );
 
-    const {text, title} = loginPageSettings;
+    const {text, title} = ytAuthClusterConfig.loginPageSettings || {};
 
     return (
         <>

--- a/packages/ui/src/ui/store/selectors/global/index.ts
+++ b/packages/ui/src/ui/store/selectors/global/index.ts
@@ -210,10 +210,6 @@ export const getOAuthButtonLabel = () => {
     return getConfigData().oauthButtonLabel;
 };
 
-export const getLoginPageText = () => {
-    return getConfigData().uiSettings?.loginPageSettings ?? {};
-};
-
 export const getGlobalAsideHeaderWidth = (state: RootState) => state.global.asideHeaderWidth;
 
 export const getGlobalYTAuthCluster = (state: RootState) => state.global.ytAuthCluster;


### PR DESCRIPTION
Hi there!

I made a mistake in https://github.com/ytsaurus/ytsaurus-ui/pull/645. The uiSettings did not allows to specify custom settings for different clusters, so the right place for such settings is cluster config, where we can specify settings per cluster.