### PR TITLE
fix(QueryTracker): fix error when switching to another query with open statistics tab

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLStatistics/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLStatistics/index.tsx
@@ -9,6 +9,10 @@ import './index.scss';
 export function YQLStatisticsTable() {
     const statistics = useSelector(getProgressYQLStatistics);
 
+    if (!statistics) {
+        return null;
+    }
+
     return (
         <StatisticTable
             fixedHeader


### PR DESCRIPTION
<img width="693" alt="Screenshot 2024-07-08 at 15 43 09" src="https://github.com/ytsaurus/ytsaurus-ui/assets/3217636/0712ef02-a2b6-40df-96f8-c6f0ec32291c">
