### PR TITLE
feat(Table): add "view" button for truncated cells [#655]

### DIFF
--- a/packages/ui/src/ui/components/Modal/SimpleModal.tsx
+++ b/packages/ui/src/ui/components/Modal/SimpleModal.tsx
@@ -21,6 +21,7 @@ interface SimpleModalProps {
     children?: React.ReactNode;
     onOutsideClick?: () => void;
     className?: string;
+    wrapperClassName?: string;
 }
 
 class SimpleModal extends Component<SimpleModalProps> {
@@ -69,11 +70,11 @@ class SimpleModal extends Component<SimpleModalProps> {
     }
 
     render() {
-        const {visible, onOutsideClick, size, className} = this.props;
+        const {visible, onOutsideClick, size, className, wrapperClassName} = this.props;
         return (
             visible && (
                 <ModalImpl className={className} open={visible} onClose={onOutsideClick}>
-                    <div className={b('wrapper', {size})}>
+                    <div className={b('wrapper', {size}, wrapperClassName)}>
                         {this.renderHeader()}
                         {this.renderContent()}
                     </div>

--- a/packages/ui/src/ui/components/Yson/StructuredYsonVirtualized/StructuredYsonVirtualized.scss
+++ b/packages/ui/src/ui/components/Yson/StructuredYsonVirtualized/StructuredYsonVirtualized.scss
@@ -77,6 +77,10 @@
         overflow-x: hidden;
     }
 
+    &__full-value-radio-buttons {
+        width: 200px;
+    }
+
     &__extra-tools {
         margin-left: 1ex;
     }

--- a/packages/ui/src/ui/components/Yson/Yson.tsx
+++ b/packages/ui/src/ui/components/Yson/Yson.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
 import {UnipikaSettings, UnipikaValue} from './StructuredYson/StructuredYsonTypes';
 
 import StructuredYsonVirtualized from './StructuredYsonVirtualized/StructuredYsonVirtualized';
+import type {Settings} from '@gravity-ui/react-data-table';
 
 export interface YsonProps {
     settings?: UnipikaSettings;
@@ -19,6 +20,7 @@ export interface YsonProps {
     extraTools?: React.ReactNode;
     virtualized?: boolean;
     className?: string;
+    tableSettings?: Settings;
 }
 
 interface State {
@@ -124,7 +126,7 @@ export default class Yson extends Component<YsonProps, State> {
     }
 
     render() {
-        const {inline, children, folding, extraTools, className} = this.props;
+        const {inline, children, folding, extraTools, className, tableSettings} = this.props;
         const {convertedValue, settings} = this.state;
 
         const classes = block('unipika-wrapper')(
@@ -140,6 +142,7 @@ export default class Yson extends Component<YsonProps, State> {
                     <div className={classes} title={this.getFormattedTitle()} dir="auto">
                         {folding ? (
                             <StructuredYsonVirtualized
+                                tableSettings={tableSettings}
                                 value={convertedValue}
                                 settings={settings!}
                                 extraTools={extraTools}

--- a/packages/ui/src/ui/constants/navigation/modals/cell-preview.ts
+++ b/packages/ui/src/ui/constants/navigation/modals/cell-preview.ts
@@ -1,0 +1,3 @@
+import createActionTypes from '../../utils';
+
+export const CELL_PREVIEW = createActionTypes('CELL_PREVIEW');

--- a/packages/ui/src/ui/pages/navigation/Navigation/Navigation.js
+++ b/packages/ui/src/ui/pages/navigation/Navigation/Navigation.js
@@ -60,6 +60,7 @@ import UIFactory from '../../../UIFactory';
 
 import './Navigation.scss';
 import {UI_TAB_SIZE} from '../../../constants/global';
+import {CellPreviewModal} from '../modals/CellPreviewModal/CellPreviewModal';
 
 const block = cn('navigation');
 
@@ -79,6 +80,7 @@ function renderModals() {
             <LinkToModal />
             <CreateACOModal />
             <RemoteCopyModal />
+            <CellPreviewModal />
         </Fragment>
     );
 }

--- a/packages/ui/src/ui/pages/navigation/content/Table/DataTableWrapper/DataTableWrapper.scss
+++ b/packages/ui/src/ui/pages/navigation/content/Table/DataTableWrapper/DataTableWrapper.scss
@@ -15,7 +15,7 @@
             padding-right: calc(var(--data-table-cell-horizontal-padding) + 20px);
         }
 
-        &__clipboard-button-wrapper {
+        &__control-button-wrapper {
             opacity: 0.3;
 
             position: absolute;

--- a/packages/ui/src/ui/pages/navigation/modals/CellPreviewModal/CellPreviewModal.scss
+++ b/packages/ui/src/ui/pages/navigation/modals/CellPreviewModal/CellPreviewModal.scss
@@ -1,0 +1,32 @@
+.cell-preview-modal {
+    &__content {
+        height: 70vh;
+    }
+
+    &__wrapper {
+        width: 65vw;
+    }
+
+    &__command-wrapper {
+        font-family: var(--g-font-family-monospace);
+        background-color: var(--g-color-base-simple-hover);
+        word-break: break-all;
+        border-radius: 5px;
+        padding: 12px;
+        display: flex;
+    }
+
+    &__command {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    &__command-content {
+        display: inline-block;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+}

--- a/packages/ui/src/ui/pages/navigation/modals/CellPreviewModal/CellPreviewModal.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/CellPreviewModal/CellPreviewModal.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import {useDispatch, useSelector} from 'react-redux';
+import {Flex, Text} from '@gravity-ui/uikit';
+
+import SimpleModal from '../../../../components/Modal/SimpleModal';
+import {closeCellPreviewAndCancelRequest} from '../../../../store/actions/navigation/modals/cell-preview';
+import {
+    selectCellPreviewCellPath,
+    selectCellPreviewData,
+    selectCellPreviewLoading,
+    selectCellPreviewVisible,
+    selectErrorPreviewCellPath,
+} from '../../../../store/selectors/navigation/modals/cell-preview';
+
+import ClipboardButton from '../../../../components/ClipboardButton/ClipboardButton';
+import block from 'bem-cn-lite';
+
+import './CellPreviewModal.scss';
+import Yson from '../../../../components/Yson/Yson';
+import Error from '../../../../components/Error/Error';
+import {getPreviewCellYsonSettings} from '../../../../store/selectors/thor/unipika';
+
+const b = block('cell-preview-modal');
+
+export const CellPreviewModal: React.FC = () => {
+    const dispatch = useDispatch();
+
+    const loading = useSelector(selectCellPreviewLoading);
+    const data = useSelector(selectCellPreviewData);
+    const visible = useSelector(selectCellPreviewVisible);
+    const cellPath = useSelector(selectCellPreviewCellPath);
+    const error = useSelector(selectErrorPreviewCellPath);
+
+    const unipikaSettings = useSelector(getPreviewCellYsonSettings);
+
+    const command = `yt read-table '${cellPath}' --format json`;
+
+    return (
+        <SimpleModal
+            title="Preview"
+            visible={visible}
+            loading={loading}
+            onCancel={() => dispatch(closeCellPreviewAndCancelRequest())}
+            wrapperClassName={b('wrapper')}
+        >
+            <Flex className={b('content')} gap={2} direction="column">
+                <Flex gap={2} direction="column">
+                    <Text variant="subheader-3" color="secondary">
+                        {data?.$incomplete && !error
+                            ? 'Unable to load content more than 16MiB. Please use the command bellow to\n' +
+                              '                            load it locally.'
+                            : 'You could use the command bellow to load it locally.'}
+                    </Text>
+                    <code className={b('command-wrapper')}>
+                        <div className={b('command')}>
+                            <div className={b('command-content')} title={command}>
+                                {command}
+                            </div>
+                            <ClipboardButton view={'flat-secondary'} text={command} size={'s'} />
+                        </div>
+                    </code>
+                </Flex>
+                {error ? (
+                    <Error error={error} />
+                ) : (
+                    <Yson
+                        folding={true}
+                        value={data}
+                        tableSettings={{dynamicRenderScrollParentGetter: undefined}}
+                        settings={unipikaSettings}
+                    />
+                )}
+            </Flex>
+        </SimpleModal>
+    );
+};

--- a/packages/ui/src/ui/store/actions/navigation/modals/cell-preview.ts
+++ b/packages/ui/src/ui/store/actions/navigation/modals/cell-preview.ts
@@ -1,0 +1,77 @@
+import {ThunkAction} from 'redux-thunk';
+import {RootState} from '../../../reducers';
+import {ytApiV4} from '../../../../rum/rum-wrap-api';
+import {getPath} from '../../../selectors/navigation';
+import {batch} from 'react-redux';
+import {getDefaultRequestOutputFormat} from '../../../../utils/navigation/content/table/table';
+import {
+    type CellPreviewAction,
+    initialState,
+} from '../../../reducers/navigation/modals/cell-preview';
+import {CELL_PREVIEW} from '../../../../constants/navigation/modals/cell-preview';
+import CancelHelper, {isCancelled} from '../../../../utils/cancel-helper';
+
+type ActionType<R = any> = ThunkAction<R, RootState, any, CellPreviewAction>;
+
+const PREVIEW_LIMIT = 16 * 1024 * 1024; // 16MiB;
+
+const cancelHelper = new CancelHelper();
+
+const openCellPreview = (): CellPreviewAction => {
+    return {
+        type: CELL_PREVIEW.PARTITION,
+        data: {visible: true},
+    };
+};
+
+export const closeCellPreview = (): CellPreviewAction => {
+    return {
+        type: CELL_PREVIEW.PARTITION,
+        data: {visible: false},
+    };
+};
+
+export const closeCellPreviewAndCancelRequest = (): ActionType => {
+    return (dispatch) => {
+        cancelHelper.removeAllRequests();
+
+        batch(() => {
+            dispatch({type: CELL_PREVIEW.PARTITION, data: initialState});
+            dispatch(closeCellPreview());
+        });
+    };
+};
+
+export const showCellPreviewModal = (columnName: string, index: number): ActionType => {
+    return async (dispatch, getState) => {
+        const path = getPath(getState());
+
+        const cellPath = `${path}{${columnName}}[#${index}:#${index + 1}]`;
+
+        batch(() => {
+            dispatch({type: CELL_PREVIEW.REQUEST, data: {cellPath}});
+            dispatch(openCellPreview());
+        });
+
+        try {
+            const json = await ytApiV4.readTable({
+                parameters: {
+                    path: cellPath,
+                    output_format: getDefaultRequestOutputFormat({
+                        stringLimit: PREVIEW_LIMIT,
+                    }),
+                },
+                cancellation: cancelHelper.removeAllAndSave,
+            });
+
+            const parsed = JSON.parse(json);
+
+            const data = parsed.rows[0][columnName];
+            dispatch({type: CELL_PREVIEW.SUCCESS, data: {data}});
+        } catch (error: any) {
+            if (!isCancelled(error)) {
+                dispatch({type: CELL_PREVIEW.FAILURE, data: {error}});
+            }
+        }
+    };
+};

--- a/packages/ui/src/ui/store/reducers/navigation/modals/cell-preview.ts
+++ b/packages/ui/src/ui/store/reducers/navigation/modals/cell-preview.ts
@@ -1,0 +1,46 @@
+import type {ActionD, YTError} from '../../../../types';
+import {CELL_PREVIEW} from '../../../../constants/navigation/modals/cell-preview';
+
+export interface CellPreviewState {
+    visible: boolean;
+    loading: boolean;
+    data: any | undefined;
+    cellPath: string;
+    error?: YTError;
+}
+
+export const initialState: CellPreviewState = {
+    visible: false,
+    loading: false,
+    data: undefined,
+    cellPath: '',
+};
+
+export default function cellPreviewReducer(
+    state = initialState,
+    action: CellPreviewAction,
+): CellPreviewState {
+    switch (action.type) {
+        case CELL_PREVIEW.REQUEST: {
+            return {...state, cellPath: action.data.cellPath, loading: true, error: undefined};
+        }
+        case CELL_PREVIEW.SUCCESS: {
+            return {...state, data: action.data.data, loading: false};
+        }
+        case CELL_PREVIEW.FAILURE: {
+            return {...state, error: action.data.error, loading: false};
+        }
+        case CELL_PREVIEW.PARTITION: {
+            return {...state, ...action.data};
+        }
+        default: {
+            return state;
+        }
+    }
+}
+
+export type CellPreviewAction =
+    | ActionD<typeof CELL_PREVIEW.REQUEST, Pick<CellPreviewState, 'cellPath'>>
+    | ActionD<typeof CELL_PREVIEW.SUCCESS, Pick<CellPreviewState, 'data'>>
+    | ActionD<typeof CELL_PREVIEW.FAILURE, Pick<CellPreviewState, 'error'>>
+    | ActionD<typeof CELL_PREVIEW.PARTITION, Partial<CellPreviewState>>;

--- a/packages/ui/src/ui/store/reducers/navigation/modals/index.ts
+++ b/packages/ui/src/ui/store/reducers/navigation/modals/index.ts
@@ -13,6 +13,7 @@ import remoteCopyModal from './remote-copy-modal';
 import dynTablesStateModal from './dyn-tables-state-modal';
 import linkToModal from './link-to-modal';
 import createACOModal from './create-aco';
+import cellPreviewModal from './cell-preview';
 
 export default combineReducers({
     attributesEditor,
@@ -28,4 +29,5 @@ export default combineReducers({
     dynTablesStateModal,
     linkToModal,
     createACOModal,
+    cellPreviewModal,
 });

--- a/packages/ui/src/ui/store/selectors/navigation/modals/cell-preview.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/modals/cell-preview.ts
@@ -1,0 +1,12 @@
+import type {RootState} from '../../../reducers';
+
+export const selectCellPreviewVisible = (state: RootState) =>
+    state.navigation.modals.cellPreviewModal.visible;
+export const selectCellPreviewLoading = (state: RootState) =>
+    state.navigation.modals.cellPreviewModal.loading;
+export const selectCellPreviewData = (state: RootState) =>
+    state.navigation.modals.cellPreviewModal.data;
+export const selectCellPreviewCellPath = (state: RootState) =>
+    state.navigation.modals.cellPreviewModal.cellPath;
+export const selectErrorPreviewCellPath = (state: RootState) =>
+    state.navigation.modals.cellPreviewModal.error;

--- a/packages/ui/src/ui/store/selectors/thor/unipika.ts
+++ b/packages/ui/src/ui/store/selectors/thor/unipika.ts
@@ -60,3 +60,5 @@ export const getNavigationMountConfigYsonSettings = createSelector([getYsonSetti
 export const getEditJsonYsonSettings = createSelector([getYsonSettings], clone_);
 
 export const getNodeUnrecognizedOptionsYsonSettings = createSelector([getYsonSettings], clone_);
+
+export const getPreviewCellYsonSettings = createSelector([getYsonSettings], clone_);

--- a/packages/ui/src/ui/utils/navigation/content/table/table.js
+++ b/packages/ui/src/ui/utils/navigation/content/table/table.js
@@ -62,15 +62,11 @@ export function getRequestOutputFormat(
 ) {
     const filteredColumns = _.filter(columns, (column) => column.checked || column.keyColumn);
     const columnNames = _.map(filteredColumns, (column) => column.name);
-    const outputFormat = {
-        $value: 'web_json',
-        $attributes: {
-            field_weight_limit: stringLimit,
-            string_weight_limit: Math.round(stringLimit / 10),
-            max_selected_column_count: defaultTableColumnLimit,
-            max_all_column_names_count: 3000,
-        },
-    };
+    const outputFormat = getDefaultRequestOutputFormat({
+        stringLimit,
+        defaultTableColumnLimit,
+        columnNamesLimit: 3000,
+    });
     if (useYqlTypes) {
         outputFormat.$attributes.value_format = 'yql';
     }
@@ -78,6 +74,22 @@ export function getRequestOutputFormat(
         outputFormat.$attributes.column_names = columnNames;
     }
     return outputFormat;
+}
+
+export function getDefaultRequestOutputFormat({
+    stringLimit,
+    tableColumnLimit = undefined,
+    columnNamesLimit = undefined,
+}) {
+    return {
+        $value: 'web_json',
+        $attributes: {
+            field_weight_limit: stringLimit,
+            string_weight_limit: stringLimit ? Math.round(stringLimit / 10) : undefined,
+            max_selected_column_count: tableColumnLimit,
+            max_all_column_names_count: columnNamesLimit,
+        },
+    };
 }
 
 export function getParsedError(error) {

--- a/packages/ui/src/ui/utils/navigation/prepareColumns.tsx
+++ b/packages/ui/src/ui/utils/navigation/prepareColumns.tsx
@@ -25,12 +25,14 @@ export function prepareColumns({
     schemaByName: Record<string, any>;
 }) {
     return _.map(columns, (column) => {
-        const render = ({value}: {value?: any; index: number; row: any}) => (
+        const render = ({value, index}: {value?: any; index: number; row: any}) => (
             <ColumnCell
                 allowRawStrings={useRawStrings}
                 value={value}
                 yqlTypes={yqlTypes}
                 ysonSettings={ysonSettings}
+                rowIndex={index}
+                columnName={column.name}
             />
         );
         const {sortOrder} = column;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/V-VZJwcr77A6rS
<!-- nda-end -->Related to the [issue](https://github.com/ytsaurus/ytsaurus-ui/issues/655). 

I have added a view button to a cell when the value is truncated. When the user clicks on this button, it uses the yt command to read one specific cell from the current table and also has a 16MiB limit. 

The preview is displayed in a virtualized list that allows the json/yson format to be displayed.