### PR TITLE
fix(OperationsList): fix incorrect filters on OperationSuggestFilter blur [#705]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationSuggestFilter/OperationSuggestFilter.js
+++ b/packages/ui/src/ui/pages/operations/OperationSuggestFilter/OperationSuggestFilter.js
@@ -36,7 +36,7 @@ export default class OperationSuggestFilter extends Component {
         return (
             <Suggest
                 key={value}
-                apply={(newValue) => updateFilter(name, newValue)}
+                apply={(newValue) => updateFilter(name, newValue || defaultValue)}
                 filter={OperationSuggestFilter.simpleSuggestLoader}
                 text={value !== defaultValue ? value : ''}
                 items={states}


### PR DESCRIPTION
Reproduce:

1. Open operation list page
2. Focus to 'pool', 'user' or 'poolTree' filter
3. Remove focus from filter by clicking to any element outside 

Visually filter will be looked like it's using default value instead of default value,
but in fact filter will be setted to empty string and you will get no results.

Fix:
Use default value if filter was updated with empty string.