### PR TITLE
fix(Components/Nodes): fix filtering by racks

### DIFF
--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/predicates.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/predicates.ts
@@ -514,7 +514,7 @@ function createNodeTagPredicate<K extends keyof typeof PropertiesByPredicate>(
         return (node) => {
             return some_(
                 getTags(node),
-                (item) => -1 !== item.toLowerCase().indexOf(tagFilter.toLowerCase()),
+                (item) => -1 !== item?.toLowerCase().indexOf(tagFilter.toLowerCase()),
             );
         };
     }


### PR DESCRIPTION
Sometime nodes don't have certain attributes and we get this error:
`TypeError: Cannot read properties of undefined (reading 'toLowerCase')`