### PR TITLE
fix(YQLTable): fixed exception in truncated cells preview

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/module/cell-preview/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/cell-preview/actions.ts
@@ -27,7 +27,13 @@ export const showQueryTrackerCellPreviewModal = (
                 ),
             );
 
-            const data = (response.rows[0][options.columnName][0] as any[])[0].val;
+            const dataRow: unknown = response.rows[0][options.columnName][0];
+
+            const dataObject: {val: any} | undefined = Array.isArray(dataRow)
+                ? dataRow[0]
+                : dataRow;
+
+            const data = dataObject?.val;
 
             dispatch({type: CELL_PREVIEW.SUCCESS, data: {data}});
         } catch (error: any) {


### PR DESCRIPTION
Error in interface
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/6ed561b9-0977-4acd-b9bc-85c0d7872d4e">

Error in debug mode
<img width="686" alt="Screenshot 2024-09-17 at 10 12 20" src="https://github.com/user-attachments/assets/220f0c36-a9e9-4988-9cb0-40c6c7a78a3f">

The root case - we don't have an array in `response.rows[0][options.columnName][0]`

<img width="308" alt="Screenshot 2024-09-17 at 10 12 28" src="https://github.com/user-attachments/assets/859b5484-8822-4a07-bd5a-deae2fd00ceb">
