### PR TITLE
fix(System): fix color of stats text in dark mode

### DIFF
--- a/packages/ui/src/ui/pages/system/ProxiesImpl/StatsInfo.tsx
+++ b/packages/ui/src/ui/pages/system/ProxiesImpl/StatsInfo.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 const COLORS_BY_STATUS = {
     ONLINE: ['var(--success-color)', 'var(--success-text)', 'var(--default-color)'],
-    OFFLINE: ['var(--danger-color)', 'var(--dnager-text)', 'var(--default-color)'],
+    OFFLINE: ['var(--danger-color)', 'var(--danger-text)', 'var(--default-color)'],
     BANNED: ['var(--warning-color)', 'var(--warning-text)', 'var(--default-color)'],
     OTHER: [],
     FULL: [],
@@ -75,7 +75,7 @@ export const StatsInfo = ({
             <div>
                 <CountUrl count={count} url={url} variant="body-2" />
             </div>
-            <Text className={block('text')} variant="body-short" color="dark-secondary">
+            <Text className={block('text')} variant="body-short">
                 {status}
             </Text>
             <Progress className={block('progress')} stack={stack ?? []} size="xs" />


### PR DESCRIPTION
Appearance in master:

<img width="417" alt="Screenshot 2024-09-17 at 12 02 33" src="https://github.com/user-attachments/assets/f6177a51-ea5b-4ab3-8f79-a3282b447486">

<img width="419" alt="Screenshot 2024-09-17 at 12 02 22" src="https://github.com/user-attachments/assets/449a2cb9-bf11-45d9-8593-12e0e8ab3c34">


Appearance in this PR:
<img width="398" alt="Screenshot 2024-09-17 at 12 01 55" src="https://github.com/user-attachments/assets/278bf7c6-cd48-4316-8e98-37f16f69a91a">

<img width="410" alt="Screenshot 2024-09-17 at 12 02 05" src="https://github.com/user-attachments/assets/e39f1d6b-cfd8-48a5-8aa9-a6714afa6ef3">
