### PR TITLE
fix(Query): fix adhoc charts

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/index.tsx
@@ -129,14 +129,12 @@ export const QueryResults = React.memo(function QueryResults({
                                 activeResultParams={activeResultParams}
                             />
                         </NotRenderUntilFirstVisible>
-                        {category === QueryResultTab.CUSTOM_TAB && (
-                            <NotRenderUntilFirstVisible
-                                hide={!Number.isInteger(resultIndex)}
-                                className={b('result-wrap')}
-                            >
-                                <CustomQueryTabContainer query={query} />
-                            </NotRenderUntilFirstVisible>
-                        )}
+                        <NotRenderUntilFirstVisible
+                            hide={category !== QueryResultTab.CUSTOM_TAB}
+                            className={b('result-wrap')}
+                        >
+                            <CustomQueryTabContainer query={query} />
+                        </NotRenderUntilFirstVisible>
                         {category === QueryResultTab.ERROR && <ErrorTree rootError={query.error} />}
                         {category === QueryResultTab.META && <QueryMetaTable query={query} />}
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartSettings/ChartSettings.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/containers/ChartSettings/ChartSettings.tsx
@@ -64,23 +64,6 @@ const xAxisTab: DialogTabField<DialogField<FormValues>> = {
             type: 'text',
         },
         {
-            name: 'grid',
-            caption: 'Grid',
-            type: 'radio',
-            extras: {
-                options: [
-                    {
-                        value: 'on',
-                        label: 'On',
-                    },
-                    {
-                        value: 'off',
-                        label: 'Off',
-                    },
-                ],
-            },
-        },
-        {
             caption: 'Grid step, px',
             name: 'pixelInterval',
             type: 'text',

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/d3config.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/preparers/d3config.ts
@@ -8,7 +8,7 @@ import {VisualizationId} from '../types';
 export function buildD3Config(args: PrepareLineArgs) {
     const chartSettings = args.visualization.chartSettings;
 
-    const xAxisGridEnabled = chartSettings.xAxis.grid === 'on';
+    const xAxisGridEnabled = true;
     const xAxisIsLegendEnabled = chartSettings.xAxis.legend === 'on';
     const xAxisEnableLabels = chartSettings.xAxis.labels === 'on';
     const xAxisTitle = chartSettings.xAxis.title;


### PR DESCRIPTION
Adhoc charts were broken because of that commit https://github.com/ytsaurus/ytsaurus-ui/commit/b39aa3e873f44dd45da2c7bf8005ccb93294a40e and because of future chartkit update which is break chart if grid is disabled in x axis.