### PR TITLE
fix: fix logging of axios error in sendAndLogError function

### DIFF
--- a/packages/ui/src/server/utils/index.ts
+++ b/packages/ui/src/server/utils/index.ts
@@ -174,7 +174,7 @@ export async function sendAndLogError(
 ) {
     const ae = asAxiosError(e);
     if (ae) {
-        ctx.logError('AxiosError', ae.toJSON(), extra);
+        ctx.logError('AxiosError', ae, extra);
         if (await pipeAxiosErrorOrFalse(ctx, res, ae)) {
             return;
         }


### PR DESCRIPTION
It seems we found a bug in YT logs — axios errors are not logged correctly.

Why:

1. [Here is a sendAndLogError function which is used for logging.](https://github.com/ytsaurus/ytsaurus-ui/blob/f1c3ec3fc73a5bac17c0bffa2c3229a47c710ec3/packages/ui/src/server/utils/index.ts#L168C23-L168C38)
2. [And it has a separate branch for logging axios errors.](https://github.com/ytsaurus/ytsaurus-ui/blob/f1c3ec3fc73a5bac17c0bffa2c3229a47c710ec3/packages/ui/src/server/utils/index.ts#L177)
3. Logging looks like this: `ctx.logError('AxiosError', ae.toJSON(), extra);` what's important here is that the second argument is json.
4. [Second argument goes to extractErrorInfo function](https://github.com/gravity-ui/nodekit/blob/3c99b291bec166c8b3b13c92510db14c7e1b5321/src/lib/context.ts#L106).
5. [And in extractErrorInfo function we have the condition "error && error instanceof Error", which always will be false](https://github.com/gravity-ui/nodekit/blob/3c99b291bec166c8b3b13c92510db14c7e1b5321/src/lib/error-parser.ts#L40)
6. So, all that we will get in logs is  {err: {type: 'InvalidErrorObject'}}.