### PR TITLE
fix(Odin): use the same format for DatePicker in odin

### DIFF
--- a/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
+++ b/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
@@ -272,7 +272,7 @@ function OdinOverview(props: OdinOverviewProps) {
                         <DatePicker
                             className={block('navigation-date-picker')}
                             size="m"
-                            format="MM/DD/YYYY HH:mm"
+                            format="DD.MM.YYYY HH:mm"
                             maxValue={dateTime({input: Date.now() - ODIN_OVERVIEW_TIME_RANGE})}
                             onUpdate={(value) => {
                                 dispatch(setOdinOverviewFromTimeFilter(value?.valueOf()));


### PR DESCRIPTION
Open odin and check out date format in "Overview" and "Details" tab. 

Right now they are different, it's looks like a mistake.


<img width="460" alt="Screenshot 2024-10-14 at 15 34 03" src="https://github.com/user-attachments/assets/215f6e6b-7e22-40fc-b05c-c074bde5c3ef">

<img width="289" alt="Screenshot 2024-10-14 at 15 33 59" src="https://github.com/user-attachments/assets/8ddd741b-3026-46e8-9f2c-bcee4e72747d">
