### PR TITLE
fix(ClusterPage): align "Loading <cluster name>..." text to center of the page

### DIFF
--- a/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
+++ b/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
@@ -248,7 +248,7 @@ class ClusterPage extends Component {
                     {hasError ? (
                         <PreloadError />
                     ) : (
-                        <p className="preloader__loading">Loading {clusterConfig?.id}...</p>
+                        <p className={b('loading-text')}>Loading {clusterConfig?.id}...</p>
                     )}
                 </div>
                 <div className={b('error')}>

--- a/packages/ui/src/ui/containers/ClusterPage/ClusterPage.scss
+++ b/packages/ui/src/ui/containers/ClusterPage/ClusterPage.scss
@@ -48,4 +48,8 @@
         margin-top: 60px;
         margin-bottom: 60px;
     }
+
+    &__loading-text {
+        text-align: center;
+    }
 }


### PR DESCRIPTION
Before this patch:
<img width="1723" alt="Screenshot 2024-10-23 at 15 50 50" src="https://github.com/user-attachments/assets/f6a2353e-eaa6-4ef6-8b53-89291b39b7f0">


After this patch:
<img width="1728" alt="Screenshot 2024-10-23 at 15 49 20" src="https://github.com/user-attachments/assets/1ca40ab8-b719-47a4-86ff-6b5b51097d7f">
