### PR TITLE
fix(Groups): expand group tree on non-empty group filter [#853]

### DIFF
--- a/packages/ui/src/ui/components/ExpandIcon/ExpandIcon.tsx
+++ b/packages/ui/src/ui/components/ExpandIcon/ExpandIcon.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import cn from 'bem-cn-lite';
 
 import Icon from '../../components/Icon/Icon';
@@ -8,23 +7,23 @@ import './ExpandIcon.scss';
 
 const block = cn('expand-icon');
 
-ExpandIcon.propTypes = {
-    className: PropTypes.string,
+type ExpandIconProps = {
+    className?: string;
 
-    expanded: PropTypes.bool,
-    visible: PropTypes.bool,
-    onClick: PropTypes.func,
+    expanded?: boolean;
+    visible?: boolean;
+    onClick?: (data?: string, expanded?: boolean) => void;
 
-    data: PropTypes.any,
+    data?: string;
 };
 
-export default function ExpandIcon({className, data, expanded, visible, onClick}) {
+export default function ExpandIcon({className, data, expanded, visible, onClick}: ExpandIconProps) {
     const icon = expanded ? 'angle-up' : 'angle-down';
     const onClickCb = React.useCallback(() => {
         if (onClick) {
-            onClick(data);
+            onClick(data, expanded);
         }
-    }, [data, onClick]);
+    }, [data, onClick, expanded]);
 
     return (
         <span

--- a/packages/ui/src/ui/pages/groups/GroupsPageTable/GroupsPageTable.tsx
+++ b/packages/ui/src/ui/pages/groups/GroupsPageTable/GroupsPageTable.tsx
@@ -105,9 +105,9 @@ class GroupsPageTable extends React.Component<GroupsPageTableProps> {
         );
     }
 
-    toggleExpand = (groupName: string) => {
+    toggleExpand = (groupName?: string, isExpanded?: boolean) => {
         const {toggleGroupExpand} = this.props;
-        toggleGroupExpand(groupName);
+        toggleGroupExpand(groupName!, !isExpanded);
     };
 
     renderIdmCell(col: string, {row}: {row: GroupsTreeNode}) {

--- a/packages/ui/src/ui/store/actions/groups.ts
+++ b/packages/ui/src/ui/store/actions/groups.ts
@@ -70,15 +70,11 @@ export function setGroupsPageSorting(column: string, order: OrderType) {
     };
 }
 
-export function toggleGroupExpand(groupName: string) {
+export function toggleGroupExpand(groupName: string, isExpanded: boolean) {
     return (dispatch: Dispatch, getState: () => RootState) => {
         const expanded = {...getGroupsExpanded(getState())};
-        const current = expanded[groupName];
-        if (current) {
-            delete expanded[groupName];
-        } else {
-            expanded[groupName] = true;
-        }
+
+        expanded[groupName] = isExpanded;
 
         return dispatch({type: GROUPS_TABLE_DATA_FIELDS, data: {expanded}});
     };


### PR DESCRIPTION
Let's say we have 3 groups:

- vrozaev-test-group-1
- vrozaev-test-group-2
- vrozaev-test-group-3

And the hierarchy is: vrozaev-test-group-1 => vrozaev-test-group-2 => vrozaev-test-group-3

In this case we want to expand all parents of the node which is matches the filter.

1. Example: with "vrozaev-test-group-1" filter there will be no expanded nodes
<img width="1728" alt="Screenshot 2024-11-26 at 11 26 11" src="https://github.com/user-attachments/assets/14020baa-229a-4969-b969-0a44ef44336f">

1. Example: with "vrozaev-test-group-2" filter the "vrozaev-test-group-1" node will be expanded
<img width="1727" alt="Screenshot 2024-11-26 at 11 26 19" src="https://github.com/user-attachments/assets/7f27b5f3-5ac8-45df-b4cc-8122cfa6e0ba">

1. Example: with "vrozaev-test-group-3" filter the "vrozaev-test-group-1" and "vrozaev-test-group-2" nodes will be expanded
<img width="1726" alt="Screenshot 2024-11-26 at 11 26 25" src="https://github.com/user-attachments/assets/52b345fd-3b50-4156-bccc-ce4770678ef2">
