### PR TITLE
fix(Navigation): show light text color in the dark theme

### DIFF
--- a/packages/ui/src/ui/pages/navigation/NavigationDiscription/AnnotationWithPartial.tsx
+++ b/packages/ui/src/ui/pages/navigation/NavigationDiscription/AnnotationWithPartial.tsx
@@ -21,7 +21,7 @@ export const AnnotationWithPartial: FC<Props> = ({annotation, expanded, onToggle
 
     return (
         <>
-            <Markdown text={expanded ? value : text} />
+            <Markdown color={'complementary'} text={expanded ? value : text} />
             {isFullText ? null : (
                 <ClickableText color={'secondary'} onClick={onToggle}>
                     {expanded ? 'Hide more' : 'Show more'}


### PR DESCRIPTION
changed default color for description of operation in Navigation block from dark ".yfm" (rgba(0, 0, 0, .7), picture below) -> to color "complementary" which can be automatically changed between dark and light themes


<img width="502" alt="Снимок экрана 2024-12-27 в 14 44 33" src="https://github.com/user-attachments/assets/a1bff9a7-4806-4479-9d43-5f91b598710e" />
