### PR TITLE
fix(Users/Groups): fixed a bug when user could not see all group members or all groups of specific user [#704]

### DIFF
--- a/packages/ui/src/ui/components/CommaSeparateListWithRestCounter/CommaSeparateListWithRestCounter.js
+++ b/packages/ui/src/ui/components/CommaSeparateListWithRestCounter/CommaSeparateListWithRestCounter.js
@@ -75,7 +75,9 @@ export default class CommaSeparatedListWithRestCounter extends React.Component {
         }
 
         const {offsetWidth, offsetHeight} = this.ref;
-        const {font, lineHeight} = getComputedStyle(this.ref);
+        const {fontWeight, lineHeight, fontSize, fontFamily} = getComputedStyle(this.ref);
+        const font = `${fontWeight} ${fontSize}/${lineHeight} ${fontFamily}`;
+
         if (!offsetWidth || !offsetHeight) {
             return this.setStateIfChanged({rows: [], restCounter: 0});
         }


### PR DESCRIPTION
Issue: https://github.com/ytsaurus/ytsaurus-ui/issues/704.

Now we calculate text size in a correct way and user will see `+<number of hidden items>` if there is any.


