### PR TITLE
fix: prevent page hotkeys firing with opened YTDialog [#768]

### DIFF
--- a/packages/ui/.eslintrc
+++ b/packages/ui/.eslintrc
@@ -15,6 +15,20 @@
             "never"
         ],
         "lodash/import-scope": "error",
+        "no-restricted-imports": ["error", {
+            "paths": [
+                {
+                    "name": "@gravity-ui/uikit",
+                    "importNames": ["Dialog"],
+                    "message": "Please use src/components/YTDialog instead."
+                },
+                {
+                    "name": "@gravity-ui/uikit",
+                    "importNames": ["Modal"],
+                    "message": "Please use src/components/Modal or src/components/SimpleModal instead."
+                }
+            ]
+        }]
     },
     "env": {
         "jest": true

--- a/packages/ui/.eslintrc
+++ b/packages/ui/.eslintrc
@@ -26,6 +26,11 @@
                     "name": "@gravity-ui/uikit",
                     "importNames": ["Modal"],
                     "message": "Please use src/components/Modal or src/components/SimpleModal instead."
+                },
+                {
+                    "name": "@gravity-ui/dialog-fields",
+                    "importNames": ["DFDialog"],
+                    "message": "Please use src/components/Dialog instead."
                 }
             ]
         }]

--- a/packages/ui/src/ui/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/ui/components/Dialog/Dialog.tsx
@@ -53,6 +53,7 @@ import {TimeDuration} from '../../components/TimeDuration/TimeDuration';
 import {DatePickerControl} from './controls/DatePickerControl/DatePickerControl';
 import {RangeInputPickerControl} from './controls/RangeInputPickerControl/RangeInputPickerControl';
 import {AclColumnsControl} from '../../containers/ACL/RequestPermissions/AclColumnsControl/AclColumnsControl';
+import {useHotkeysScope} from '../../hooks/use-hotkeysjs-scope';
 
 const block = cn('yt-dialog');
 
@@ -214,10 +215,15 @@ export function YTDialog<Values, InitialValues = Partial<Values>>(
         InitialValues,
         DialogTabField<DialogField<Values>>,
         DialogField<Values>
-    > & {asLeftTopBlock?: boolean},
+    > & {hotkeyScope?: string; asLeftTopBlock?: boolean},
 ) {
-    const {modal, asLeftTopBlock, headerProps} = props;
+    const {modal, asLeftTopBlock, headerProps, hotkeyScope = 'yt-dialog'} = props;
     const dialog = <DFDialog {...(props as any)} modal={asLeftTopBlock ? false : modal} />;
+
+    // We don't want to trigger any page hotkeys when dialog is visible,
+    // therefore we switing to dialog hotkeys scope.
+    useHotkeysScope(hotkeyScope, props.visible);
+
     return asLeftTopBlock ? (
         <div className={block('as-block', {['has-header']: Boolean(headerProps)})}>{dialog}</div>
     ) : (

--- a/packages/ui/src/ui/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/ui/components/Dialog/Dialog.tsx
@@ -33,6 +33,7 @@ import {UsableAccountSuggest} from '../../pages/accounts/UsableAccountSuggest';
 import {EditAnnotationWithPreview} from '../EditAnnotationWithPreview/EditAnnotationWithPreview';
 import {EditJsonWithPreview} from '../EditJsonWithPreview/EditJsonWithPreview';
 import {
+    // eslint-disable-next-line no-restricted-imports
     DFDialog,
     DFDialogField,
     DFDialogProps,
@@ -233,6 +234,7 @@ export function YTDialog<Values, InitialValues = Partial<Values>>(
 
 export {registerDialogControl, registerDialogTabControl, RoleListControl};
 
+// eslint-disable-next-line no-restricted-imports
 export type * from '@gravity-ui/dialog-fields';
 export {EditableList, TabFieldVertical} from '@gravity-ui/dialog-fields';
 export type {ControlStaticApi} from '@gravity-ui/dialog-fields/build/cjs/dialog/types';

--- a/packages/ui/src/ui/components/DialogWrapper/DialogWrapper.tsx
+++ b/packages/ui/src/ui/components/DialogWrapper/DialogWrapper.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {Dialog, DialogProps} from '@gravity-ui/uikit';
+import {useHotkeysScope} from '../../hooks/use-hotkeysjs-scope';
+
+type DialogWrapperProps = DialogProps & {hotkeyScope?: string};
+
+type DialogWrapperType = React.FC<DialogWrapperProps> & {
+    Header: typeof Dialog.Header;
+    Body: typeof Dialog.Body;
+    Footer: typeof Dialog.Footer;
+    Divider: typeof Dialog.Divider;
+};
+
+export const DialogWrapper: DialogWrapperType = (props) => {
+    const {hotkeyScope = 'yt-dialog', ...restProps} = props;
+
+    // We don't want to trigger any page hotkeys when dialog is visible,
+    // therefore we switing to dialog hotkeys scope.
+    useHotkeysScope(hotkeyScope, restProps.open);
+
+    return <Dialog {...restProps} />;
+};
+
+DialogWrapper.Header = Dialog.Header;
+DialogWrapper.Body = Dialog.Body;
+DialogWrapper.Footer = Dialog.Footer;
+DialogWrapper.Divider = Dialog.Divider;

--- a/packages/ui/src/ui/components/DialogWrapper/DialogWrapper.tsx
+++ b/packages/ui/src/ui/components/DialogWrapper/DialogWrapper.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {Dialog, DialogProps} from '@gravity-ui/uikit';
 import {useHotkeysScope} from '../../hooks/use-hotkeysjs-scope';
 

--- a/packages/ui/src/ui/components/Modal/Modal.tsx
+++ b/packages/ui/src/ui/components/Modal/Modal.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import block from 'bem-cn-lite';
 
-import {Modal as ModalImpl} from '@gravity-ui/uikit';
+import {ModalWrapper as ModalImpl} from '../ModalWrapper/ModalWrapper';
 import Icon from '../Icon/Icon';
 
 import withHandledScrollBar from '../../hocs/components/Modal/withHandledScrollBar';

--- a/packages/ui/src/ui/components/Modal/SimpleModal.tsx
+++ b/packages/ui/src/ui/components/Modal/SimpleModal.tsx
@@ -3,7 +3,8 @@ import block from 'bem-cn-lite';
 
 import Icon from '../Icon/Icon';
 
-import {Button, Loader, Modal as ModalImpl} from '@gravity-ui/uikit';
+import {Button, Loader} from '@gravity-ui/uikit';
+import {ModalWrapper as ModalImpl} from '../ModalWrapper/ModalWrapper';
 
 import withHandledScrollBar from '../../hocs/components/Modal/withHandledScrollBar';
 

--- a/packages/ui/src/ui/components/ModalWrapper/ModalWrapper.tsx
+++ b/packages/ui/src/ui/components/ModalWrapper/ModalWrapper.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+// eslint-disable-next-line no-restricted-imports
+import {Modal, ModalProps} from '@gravity-ui/uikit';
+import {useHotkeysScope} from '../../hooks/use-hotkeysjs-scope';
+
+type ModalWrapperProps = ModalProps & {hotkeyScope?: string};
+
+export const ModalWrapper: React.FC<ModalWrapperProps> = (props) => {
+    const {hotkeyScope = 'yt-modal', ...restProps} = props;
+
+    // We don't want to trigger any page hotkeys when modal is visible,
+    // therefore we switing to dialog hotkeys scope.
+    useHotkeysScope(hotkeyScope, Boolean(restProps.open));
+
+    return <Modal {...restProps} />;
+};

--- a/packages/ui/src/ui/components/Yson/StructuredYsonVirtualized/StructuredYsonVirtualized.tsx
+++ b/packages/ui/src/ui/components/Yson/StructuredYsonVirtualized/StructuredYsonVirtualized.tsx
@@ -5,7 +5,8 @@ import fill_ from 'lodash/fill';
 import isEmpty_ from 'lodash/isEmpty';
 import reduce_ from 'lodash/reduce';
 
-import {Button, Dialog, Flex, RadioButton} from '@gravity-ui/uikit';
+import {Button, Flex, RadioButton} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../components/DialogWrapper/DialogWrapper';
 // @ts-ignore
 import unipika from '@gravity-ui/unipika/lib/unipika';
 

--- a/packages/ui/src/ui/containers/ACL/ManageAcl/ManageAcl.tsx
+++ b/packages/ui/src/ui/containers/ACL/ManageAcl/ManageAcl.tsx
@@ -4,7 +4,8 @@ import cn from 'bem-cn-lite';
 
 import isEqual_ from 'lodash/isEqual';
 
-import {Dialog as CommonDialog, Loader} from '@gravity-ui/uikit';
+import {Loader} from '@gravity-ui/uikit';
+import {DialogWrapper as CommonDialog} from '../../../components/DialogWrapper/DialogWrapper';
 
 import {
     DialogField,

--- a/packages/ui/src/ui/containers/ACL/ManageInheritance/ManageInheritance.tsx
+++ b/packages/ui/src/ui/containers/ACL/ManageInheritance/ManageInheritance.tsx
@@ -2,7 +2,8 @@ import React, {useCallback, useMemo, useState} from 'react';
 import {compose} from 'redux';
 import cn from 'bem-cn-lite';
 
-import {Dialog as CommonDialog, Loader} from '@gravity-ui/uikit';
+import {Loader} from '@gravity-ui/uikit';
+import {DialogWrapper as CommonDialog} from '../../../components/DialogWrapper/DialogWrapper';
 
 import isEqual_ from 'lodash/isEqual';
 

--- a/packages/ui/src/ui/containers/ManageTokens/ManageTokensModal.tsx
+++ b/packages/ui/src/ui/containers/ManageTokens/ManageTokensModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Dialog} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../components/DialogWrapper/DialogWrapper';
 import {useDispatch, useSelector} from 'react-redux';
 import {isManageTokensModalOpened} from '../../store/selectors/manage-tokens';
 import withLazyLoading from '../../hocs/withLazyLoading';

--- a/packages/ui/src/ui/containers/ManageTokens/ManageTokensPasswordModal/ManageTokensPasswordModal.tsx
+++ b/packages/ui/src/ui/containers/ManageTokens/ManageTokensPasswordModal/ManageTokensPasswordModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {useSelector} from 'react-redux';
-import {Alert, Dialog, Link} from '@gravity-ui/uikit';
+import {Alert, Link} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../components/DialogWrapper/DialogWrapper';
 import {isCryptoSubtleAvailable} from '../../../utils/sha256';
 import {createPasswordStrategy} from './password-strategies';
 import {YTDFDialog, makeErrorFields} from '../../../components/Dialog';

--- a/packages/ui/src/ui/containers/ModalErrors/ModalErrors.tsx
+++ b/packages/ui/src/ui/containers/ModalErrors/ModalErrors.tsx
@@ -1,4 +1,4 @@
-import {Dialog} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../components/DialogWrapper/DialogWrapper';
 import React from 'react';
 import {ConnectedProps, connect} from 'react-redux';
 

--- a/packages/ui/src/ui/containers/RetryBatchModal/RetryBatchModal.tsx
+++ b/packages/ui/src/ui/containers/RetryBatchModal/RetryBatchModal.tsx
@@ -3,7 +3,8 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import map_ from 'lodash/map';
 
-import {Button, Dialog} from '@gravity-ui/uikit';
+import {Button} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../components/DialogWrapper/DialogWrapper';
 
 import {getExecuteBatchState} from '../../store/selectors/execute-batch';
 import {ExecuteBatchStateItem} from '../../store/reducers/execute-batch';

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/ChaosBundleEditorDialog/ChaosBundleEditorDialog.tsx
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/ChaosBundleEditorDialog/ChaosBundleEditorDialog.tsx
@@ -4,7 +4,8 @@ import cn from 'bem-cn-lite';
 
 import capitalize_ from 'lodash/capitalize';
 
-import {Dialog, Progress} from '@gravity-ui/uikit';
+import {Progress} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../../components/DialogWrapper/DialogWrapper';
 
 import hammer from '../../../../common/hammer';
 import ypath from '../../../../common/thor/ypath';

--- a/packages/ui/src/ui/pages/job/JobActions/JobActions.tsx
+++ b/packages/ui/src/ui/pages/job/JobActions/JobActions.tsx
@@ -8,7 +8,8 @@ import map_ from 'lodash/map';
 // @ts-ignore
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 
-import {ButtonProps, Dialog, DropdownMenu, Toaster} from '@gravity-ui/uikit';
+import {ButtonProps, DropdownMenu, Toaster} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../components/DialogWrapper/DialogWrapper';
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
 import PathEditor from '../../../containers/PathEditor/PathEditor';
 import Button from '../../../components/Button/Button';

--- a/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
+++ b/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
@@ -4,7 +4,8 @@ import * as d3 from 'd3';
 import moment from 'moment';
 import map_ from 'lodash/map';
 
-import {Button, Dialog, Loader, Popup, Icon as UIKitIcon} from '@gravity-ui/uikit';
+import {Button, Loader, Popup, Icon as UIKitIcon} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../components/DialogWrapper/DialogWrapper';
 
 import chevronLeftSvg from '@gravity-ui/icons/svgs/chevron-left.svg';
 import chevronRightSvg from '@gravity-ui/icons/svgs/chevron-right.svg';

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/Overview.js
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/Overview.js
@@ -48,7 +48,7 @@ import ShareUsageBar from '../../controls/ShareUsageBar';
 import SchedulingStaticConfiguration from '../../../PoolStaticConfiguration/SchedulingStaticConfiguration';
 
 import './Overview.scss';
-import {Dialog} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../../../components/DialogWrapper/DialogWrapper';
 import {Tooltip} from '../../../../../components/Tooltip/Tooltip';
 import SchedulingOperationsError from '../SchedulingOperationsError/SchedulingOperationsError';
 import {

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/Scheduling.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/Scheduling.tsx
@@ -4,7 +4,7 @@ import cn from 'bem-cn-lite';
 
 import keys_ from 'lodash/keys';
 
-import {Dialog as DeleteDialog} from '@gravity-ui/uikit';
+import {DialogWrapper as DeleteDialog} from '../../../components/DialogWrapper/DialogWrapper';
 
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
 import Error from '../../../components/Error/Error';

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.js
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.js
@@ -7,7 +7,8 @@ import ypath from '@ytsaurus/interface-helpers/lib/ypath';
 import keys_ from 'lodash/keys';
 import map_ from 'lodash/map';
 
-import {Button, Dialog} from '@gravity-ui/uikit';
+import {Button} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../components/DialogWrapper/DialogWrapper';
 
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
 import MetaTable, {Template} from '../../../components/MetaTable/MetaTable';

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/StoresDialog.tsx
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/StoresDialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Dialog} from '@gravity-ui/uikit';
+import {DialogWrapper as Dialog} from '../../../components/DialogWrapper/DialogWrapper';
 import Stores from './Stores';
 
 interface Props {


### PR DESCRIPTION
Issue: https://github.com/ytsaurus/ytsaurus-ui/issues/768

The rootcase of the issue is a way of hotkeys declaration via hotkeys-js.

Each hotkey is declared in some scope. Now that scope stays the same when any modal windows opens. That means that hotkeys from the page could be triggered with opened modal window, which might lead to unforeseen results.

The obvious solution here is switching hotkeys scope once any modal window become visible. That prevent page hotkeys from firing. 

So we need to modify all code which shows any king of modal windows and add there a scope switch.


1. packages/ui/src/ui/components/Dialog/Dialog.tsx
2. packages/ui/src/ui/components/Modal/Modal.tsx
3. packages/ui/src/ui/components/Modal/SimpleModal.tsx


Also, there are a lot of direct usage of `Dialog` and `Modal` components from `@gravity-ui/uikit`. I think we need to introduce wrappers for them and switch scope there. Let's name them `YTDialog` and `YTModal`.
