### PR TITLE
fix: added proper padding in datepicker popup

### DIFF
--- a/packages/ui/src/ui/components/common/Datepicker/PopupContent/PopupContent.scss
+++ b/packages/ui/src/ui/components/common/Datepicker/PopupContent/PopupContent.scss
@@ -7,6 +7,7 @@
     flex-direction: column;
     height: 100%;
     max-height: 600px;
+    padding: 0 15px;
 
     &__tabs {
         flex: 0 0 40px;


### PR DESCRIPTION
Before: 
<img width="335" alt="Screenshot 2025-03-03 at 15 43 53" src="https://github.com/user-attachments/assets/7fe18e19-e161-42e5-a026-c4a8bb306c63" />

After:
<img width="333" alt="Screenshot 2025-03-03 at 15 43 41" src="https://github.com/user-attachments/assets/25a4a8fc-7c36-4acf-95f4-01d488a9acf7" />
