### PR TITLE
fix: allow empty ACO for existing query

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryACO/EditQueryACOModal/EditQueryACOModal.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryACO/EditQueryACOModal/EditQueryACOModal.tsx
@@ -59,7 +59,6 @@ export const EditQueryACOModal: FC<Props> = ({query_id}) => {
                         {
                             name: 'aco',
                             type: 'select',
-                            required: true,
                             extras: {
                                 options: selectACOOptions,
                                 placeholder: 'ACO',


### PR DESCRIPTION
Issue: https://github.com/ytsaurus/ytsaurus-ui/issues/1126