### PR TITLE
fix: always setted non-empty engine value in query-tracker [#1150]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/module/query/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/query/actions.ts
@@ -259,7 +259,7 @@ export function createEmptyQuery(
         const lastEngine = getLastUserChoiceQueryEngine(state);
         const defaultQueryACO = getDefaultQueryACO(state);
 
-        const initialEngine = engine || lastEngine;
+        const initialEngine = engine || lastEngine || QueryEngine.YQL;
 
         const defaultSettings: DraftQuery['settings'] = {};
         UIFactory.getInlineSuggestionsApi()?.onQueryCreate();


### PR DESCRIPTION
https://github.com/ytsaurus/ytsaurus-ui/issues/1150