### PR TITLE
chore: bring USE_RSPACK environment variable

### DIFF
--- a/packages/custom-ytsaurus-ui.example/app-builder.config.ts
+++ b/packages/custom-ytsaurus-ui.example/app-builder.config.ts
@@ -14,12 +14,20 @@ if (debugPort) {
     console.log({debugPort}, '\n');
 }
 
+const useRspack = ['1', 'true'].includes(String(process.env.USE_RSPACK).toLowerCase());
+const rspackConfig: Pick<ServiceConfig['client'], 'bundler' | 'cache' | 'javaScriptLoader'> = {
+    bundler: 'rspack',
+    javaScriptLoader: 'swc',
+    cache: true,
+};
+
 const uiLink = fs.readlinkSync(path.resolve(__dirname, 'src/ytsaurus-ui.ui'));
 const includesByLinks = [uiLink, fs.readlinkSync(path.resolve(__dirname, 'src/shared'))];
 
 export default function () {
     return {
         client: {
+            ...(useRspack ? rspackConfig : {}),
             watchOptions: {
                 aggregateTimeout: 1000,
             },

--- a/packages/custom-ytsaurus-ui.example/package.json
+++ b/packages/custom-ytsaurus-ui.example/package.json
@@ -8,7 +8,7 @@
     "deps:check": "scripts/check-files.sh && scripts/sync-dependencies.sh check",
     "deps:sync": "scripts/check-links.sh && scripts/sync-dependencies.sh sync",
     "dev": "npm run deps:check && APP_DEV_MODE=1 APP_INSTALLATION=custom npm run dev:app",
-    "dev:app": "APP_ENV=${APP_ENV:-development} NODE_OPTIONS=\"--max-http-header-size=204800 ${NODE_OPTIONS}\" app-builder dev --config ./app-builder.config.ts",
+    "dev:app": "USE_RSPACK=1 APP_ENV=${APP_ENV:-development} NODE_OPTIONS=\"--max-http-header-size=204800 ${NODE_OPTIONS}\" app-builder dev --config ./app-builder.config.ts",
     "lint": "npm run lint:js && npm run lint:styles",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:styles -- --fix",
     "lint:js": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --ignore-pattern src/ui/vendor --quiet",

--- a/packages/ui/build.app.config.ts
+++ b/packages/ui/build.app.config.ts
@@ -12,18 +12,18 @@ if (debugPort) {
     console.log({debugPort}, '\n');
 }
 
-const isDev = process.env.APP_ENV === 'development';
+const useRspack = ['1', 'true'].includes(String(process.env.USE_RSPACK).toLowerCase());
 
 const port = Number(process.env.LOCAL_DEV_PORT);
 
-const devConfig = {
+const rspackConfig: Pick<ServiceConfig['client'], 'bundler' | 'cache' | 'javaScriptLoader'> = {
     bundler: 'rspack',
     javaScriptLoader: 'swc',
-    cache: 'true',
+    cache: true,
 };
 
 const client: ServiceConfig['client'] = {
-    ...(isDev ? devConfig : {}),
+    ...(useRspack ? rspackConfig : {}),
     watchOptions: {
         aggregateTimeout: 1000,
     },
@@ -38,11 +38,13 @@ const client: ServiceConfig['client'] = {
     disableReactRefresh: true,
     analyzeBundle,
 
-    ...(port ? {
-        devServer: {
-            port,
-        }
-    }: null),
+    ...(port
+        ? {
+              devServer: {
+                  port,
+              },
+          }
+        : null),
 };
 
 const server: ServiceConfig['server'] = {
@@ -50,9 +52,11 @@ const server: ServiceConfig['server'] = {
     watchThrottle: 1000,
     inspectBrk: debugPort,
 
-    ...(port ? {
-        port: port + 1,
-    }: null),
+    ...(port
+        ? {
+              port: port + 1,
+          }
+        : null),
 };
 
 export default {client, server};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,7 @@
     "deps:install": "npm ci ",
     "deps:truncate": "npm prune --omit=dev",
     "dev": "npm run dev:app",
-    "dev:app": "./scripts/check-start-files.sh && npm run copy:icons && APP_ENV=${APP_ENV:-development} APP_DEV_MODE=1 NODE_OPTIONS=\"--max-http-header-size=204800 ${NODE_OPTIONS}\" app-builder dev --config ./build.app.config.ts",
+    "dev:app": "./scripts/check-start-files.sh && npm run copy:icons && USE_RSPACK=1 APP_ENV=${APP_ENV:-development} APP_DEV_MODE=1 NODE_OPTIONS=\"--max-http-header-size=204800 ${NODE_OPTIONS}\" app-builder dev --config ./build.app.config.ts",
     "dev:localmode": "bash -c '. scripts/dev.localmode-env.sh && TVM_DISABLED=true npm run dev:app'",
     "dev:localmode:cluster": "APP_INSTALLATION=${APP_INSTALLATION:-e2e} . scripts/dev.localmode-env.sh",
     "dev:localmode:e2e": "APP_INSTALLATION=${APP_INSTALLATION:-e2e} npm run dev:localmode",


### PR DESCRIPTION
## Summary by Sourcery

Enable toggling of the Rspack bundler via a new USE_RSPACK environment variable and update dev scripts to opt in by default.

Enhancements:
- Introduce USE_RSPACK flag in UI and example build configs to conditionally apply a rspackConfig with bundler 'rspack', SWC loader, and caching
- Update 'dev:app' npm scripts in ui and custom-ytsaurus-ui.example packages to set USE_RSPACK=1 by default when running the development server