### PR TITLE
fix(Operation/Details): move to bottom Alerts/Tasks section from 'vanilla' operations in gpu-trees [YTFRONT-4961]

### DIFF
--- a/packages/ui/src/ui/constants/global/index.ts
+++ b/packages/ui/src/ui/constants/global/index.ts
@@ -5,5 +5,5 @@ export const SUPPORTED_FEATURES_SUCCESS = 'SUPPORTED_FEATURES_SUCCESS';
 export const SUPPORTED_FEATURES_FAILURE = 'SUPPORTED_FEATURES_FAILURE';
 export const SUPPORTED_FEATURES_CANCELLED = 'SUPPORTED_FEATURES_CANCELLED';
 
-export const UI_TAB_SIZE = 'l';
-export const UI_COLLAPSIBLE_SIZE = 'ss';
+export const UI_TAB_SIZE = 'l' as const;
+export const UI_COLLAPSIBLE_SIZE = 'ss' as const;

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Runtime/Runtime.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Runtime/Runtime.js
@@ -44,7 +44,6 @@ export const operationProps = PropTypes.shape({
     duration: PropTypes.number,
     startTime: PropTypes.string,
     finishTime: PropTypes.string,
-    description: PropTypes.object,
     pools: PropTypes.arrayOf(
         PropTypes.shape({
             tree: PropTypes.string.isRequired,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Tasks/Tasks.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Tasks/Tasks.tsx
@@ -62,6 +62,7 @@ interface CompletedStats {
 interface OwnProps {
     className?: string;
     collapsibleSize?: 'ss';
+    collapsed?: boolean;
 }
 
 type Props = OwnProps & ConnectedProps<typeof connector>;
@@ -242,13 +243,14 @@ class Tasks extends React.Component<Props, State> {
     }
 
     render() {
-        const {className, jobs, collapsibleSize} = this.props;
+        const {className, jobs, collapsibleSize, collapsed} = this.props;
         return !jobs?.items?.length ? null : (
             <CollapsibleSection
                 name="Tasks"
                 className={className}
                 size={collapsibleSize}
                 marginDirection="bottom"
+                collapsed={collapsed}
             >
                 {this.renderContent()}
             </CollapsibleSection>

--- a/packages/ui/src/ui/store/reducers/operations/detail.ts
+++ b/packages/ui/src/ui/store/reducers/operations/detail.ts
@@ -34,6 +34,11 @@ export interface OperationDetailState {
     details: {
         alert_events: Array<AlertEvent>;
         runtime?: Array<RuntimeItem>;
+        specification?: unknown;
+        resources?: Array<unknown>;
+        error?: YTError;
+        events?: Array<unknown>;
+        intermediateResources?: unknown;
     };
     resourcesStatus: (typeof LOADING_STATUS)[keyof typeof LOADING_STATUS];
     resources: {intermediateResources?: unknown};


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/52XsWYjO7GapzW
<!-- nda-end -->## Summary by Sourcery

Adapt the Operation Details view to handle vanilla GPU operations specially by collapsing and moving Alerts and Tasks sections to the bottom, and improve type safety and selector usage

Enhancements:
- Detect vanilla GPU operations via a new selector flag
- Automatically collapse Alerts and Tasks sections for vanilla GPU operations
- Reorder Alerts and Tasks to the bottom when rendering vanilla GPU operations

Chores:
- Switch mapStateToProps to use typed RootState and store selectors
- Strengthen UI constants with 'as const' typing and clean up imports