### PR TITLE
fix(Navigation): now renderNodeIcon is called with correct argument

### DIFF
--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -26,7 +26,7 @@ import type {PreparedRole} from '../utils/acl';
 import type {UISettingsMonitoring} from '../../shared/ui-settings';
 import type {SubjectCardProps} from '../components/SubjectLink/SubjectLink';
 import type {QueryItem} from '../pages/query-tracker/module/api';
-import type {Node} from '../utils/navigation/content/map-nodes/node';
+import type {BaseMapNode} from '../utils/navigation/content/map-nodes/node';
 import type {PreloadErrorType} from '../constants';
 import type {RootState} from '../store/reducers';
 import {YTError} from '../types';
@@ -471,7 +471,7 @@ export interface UIFactory {
         | undefined
         | {
               additionalAttributes: Array<string>;
-              renderNodeIcon: (item: Node) => React.ReactNode;
+              renderNodeIcon: (item: BaseMapNode) => React.ReactNode;
           };
 
     getInlineSuggestionsApi(): InlineSuggestionsApi | undefined;

--- a/packages/ui/src/ui/components/MapNodeIcon/MapNodeIcon.tsx
+++ b/packages/ui/src/ui/components/MapNodeIcon/MapNodeIcon.tsx
@@ -15,12 +15,14 @@ import {isLinkToTrashNode} from '../../utils/navigation/isLinkToTrashNode';
 import QueueConsumerIcon from '../../assets/img/svg/icons/queue-consumer.svg';
 import QueueProducerIcon from '../../assets/img/svg/icons/queue-producer.svg';
 
+import type {BaseMapNode} from '../../utils/navigation/content/map-nodes/node';
+
 import './MapNodeIcon.scss';
 
-export function MapNodeIcon({node}: {node: Record<string, unknown>}) {
+export function MapNodeIcon({node}: {node: BaseMapNode}) {
     const item = ypath.getAttributes(node);
     const iconType = item?.type === 'table' && item?.dynamic ? 'table_dynamic' : item?.type;
-    let icon = UIFactory.getNavigationMapNodeSettings()?.renderNodeIcon(item);
+    let icon = UIFactory.getNavigationMapNodeSettings()?.renderNodeIcon(node);
 
     if (icon) {
         // do nothing

--- a/packages/ui/src/ui/pages/navigation/content/MapNode/PathActions.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/MapNode/PathActions.tsx
@@ -38,7 +38,7 @@ interface Props {
         type: string;
         dynamic: boolean;
         path: string;
-        $attributes: object;
+        $attributes: Record<string, unknown>;
         $value: unknown;
         tabletState: TabletStateType;
     };

--- a/packages/ui/src/ui/store/reducers/navigation/modals/delete-object.ts
+++ b/packages/ui/src/ui/store/reducers/navigation/modals/delete-object.ts
@@ -10,7 +10,7 @@ import type {ActionD, YTError} from '../../../../types';
 
 export type DeleteObjectItem = {
     titleUnquoted?: string;
-    $attributes: object;
+    $attributes: Record<string, unknown>;
     name: string;
     path: string;
     type: string;

--- a/packages/ui/src/ui/utils/navigation/content/map-nodes/node.ts
+++ b/packages/ui/src/ui/utils/navigation/content/map-nodes/node.ts
@@ -2,6 +2,10 @@ import unipika from '../../../../common/thor/unipika';
 import ypath from '../../../../common/thor/ypath';
 import {prepareNavigationState} from '../../../../utils/navigation';
 
+export type BaseMapNode = {
+    $attributes?: Record<string, unknown>;
+};
+
 export class Node {
     static CAPTION_PRINT_SETTINGS = {
         indent: 0,


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/i2FI_uP87GiZeo
<!-- nda-end -->## Summary by Sourcery

Fix rendering of node icons by passing the correct node object and unify attribute types

Bug Fixes:
- MapNodeIcon now calls renderNodeIcon with the full node object instead of its attributes
- Corrected $attributes type to Record<string, unknown> in PathActions and delete-object reducer

Enhancements:
- Introduce BaseMapNode type for navigation nodes
- Update UIFactory renderNodeIcon signature to accept BaseMapNode items