### PR TITLE
fix(Accounts/DetailedUsage): move navigation link from path to button [YTFRONT-4896]

### DIFF
--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountActionsField.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountActionsField.tsx
@@ -1,10 +1,4 @@
-import React, {FC, useCallback, useMemo} from 'react';
-import Icon from '../../../../components/Icon/Icon';
-import {Flex, Text} from '@gravity-ui/uikit';
-import {Tooltip} from '../../../../components/Tooltip/Tooltip';
-import Link from '../../../../components/Link/Link';
-import {makeRoutedURL} from '../../../../store/location';
-import {Page} from '../../../../../shared/constants/settings';
+import React, {FC, useCallback} from 'react';
 import AttributesButton from '../../../../components/AttributesButton/AttributesButton';
 
 export type AccountRequestData = {title: string; path: string; cluster: string; account: string};
@@ -26,29 +20,15 @@ export const AccountActionsField: FC<Props> = ({
         onAttributeButtonClick({path, account, cluster, title: path});
     }, [onAttributeButtonClick, path, account, cluster]);
 
-    const navigationUrl = useMemo(() => {
-        return makeRoutedURL(`/${cluster}/${Page.NAVIGATION}`, {path});
-    }, [cluster, path]);
-
     if (!path) return undefined;
 
     return (
-        <Flex gap={1} alignItems="center">
-            <AttributesButton
-                view="flat"
-                withTooltip
-                tooltipProps={{placement: 'bottom-end', content: 'Show attributes'}}
-                onClick={handleOpenAttributeModal}
-                size="xs"
-            />
-            <Link theme={'secondary'} url={navigationUrl} routed routedPreserveLocation>
-                <Tooltip
-                    content={<Text whiteSpace="nowrap">Open original path in Navigation</Text>}
-                    placement={'left'}
-                >
-                    <Icon awesome={'folder-tree'} />
-                </Tooltip>
-            </Link>
-        </Flex>
+        <AttributesButton
+            view="flat"
+            withTooltip
+            tooltipProps={{placement: 'bottom-end', content: 'Show attributes'}}
+            onClick={handleOpenAttributeModal}
+            size="xs"
+        />
     );
 };

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.scss
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.scss
@@ -1,7 +1,13 @@
 .account-usage-details {
+    $self: &;
+
     &__row {
         &:hover {
             background-color: var(--g-color-base-simple-hover-solid);
+
+            #{$self}__link {
+                display: block;
+            }
         }
     }
     &__no-wrap {
@@ -28,5 +34,14 @@
         min-width: 200px;
         text-align: right;
         padding-right: 2em;
+    }
+
+    &__link {
+        display: none;
+        color: var(--external-link);
+
+        &:hover {
+            color: var(--g-color-text-link-hover);
+        }
     }
 }

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.tsx
@@ -52,6 +52,7 @@ import {
     readableAccountUsageColumnName,
 } from '../../../../store/selectors/accounts/account-usage';
 import DataTable, {Column, Settings} from '@gravity-ui/react-data-table';
+import ArrowUpRightFromSquareIcon from '@gravity-ui/icons/svgs/arrow-up-right-from-square.svg';
 
 import {YTErrorBlock} from '../../../../components/Error/Error';
 import {
@@ -83,9 +84,9 @@ import './AccountUsageDetails.scss';
 import {AccountActionsField, AccountRequestData} from './AccountActionsField';
 import {DetailTableCell} from './DetailTableCell';
 import {Page} from '../../../../constants/index';
-import Link from '../../../../components/Link/Link';
 import PathView from '../../../../containers/PathFragment/PathFragment';
-import {isFolderNode} from '../../../../utils/navigation/isFolderNode';
+import {Button, Flex, Icon as GravityIcon, Tooltip} from '@gravity-ui/uikit';
+import {makeRoutedURL} from '../../../../store/window-store';
 
 const TABLE_SETTINGS: Settings = {
     displayIndices: false,
@@ -196,21 +197,31 @@ function useColumnsByPreset(mediums: Array<string>) {
             header: <PathHeader />,
             sortable: false,
             render(item) {
-                const {path, type} = item.row;
+                const {path} = item.row;
                 if (!path) {
                     return <Warning>Permission denied</Warning>;
                 }
 
-                if (isFolderNode(type)) {
-                    const url = `/${cluster}/${Page.NAVIGATION}?path=${path}`;
-                    return (
-                        <Link url={url} title={url} theme="primary">
-                            {path}
-                        </Link>
-                    );
-                }
-
-                return <PathView path={path} lastFragmentOnly={viewType === 'tree'} />;
+                const url = makeRoutedURL(`/${cluster}/${Page.NAVIGATION}?path=${path}`);
+                return (
+                    <Flex alignItems="center" gap={1}>
+                        <span>
+                            <PathView path={path} lastFragmentOnly={viewType === 'tree'} />
+                        </span>
+                        <Tooltip content="Open original path in Navigation">
+                            <Button
+                                className={block('link')}
+                                href={url}
+                                title={url}
+                                view="flat"
+                                target="_blank"
+                                size="xs"
+                            >
+                                <GravityIcon data={ArrowUpRightFromSquareIcon} size="14" />
+                            </Button>
+                        </Tooltip>
+                    </Flex>
+                );
             },
             onClick: ({row}) => {
                 const {path} = row;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/d_wLrkGv7Gwbs2
<!-- nda-end -->## Summary by Sourcery

Remove direct hyperlink wrapping the path in account detailed usage components and replace inline links with a dedicated external link button.

Bug Fixes:
- Remove the navigation link and tooltip icon from AccountActionsField so the path is no longer clickable.

Enhancements:
- Update AccountUsageDetails to render the path as plain text with a separate external link button and tooltip using UIKit Button and Icon instead of the custom Link component.

Chores:
- Clean up unused imports and remove the makeRoutedURL logic from AccountActionsField.