### PR TITLE
fix(ColumnSelector): decode columns with non-english names [YTFRONT-4873]

### DIFF
--- a/packages/ui/src/ui/components/common/ColumnSelector/ColumnSelector.tsx
+++ b/packages/ui/src/ui/components/common/ColumnSelector/ColumnSelector.tsx
@@ -3,6 +3,8 @@ import block from 'bem-cn-lite';
 import {Button, Popup, PopupPlacement} from '@gravity-ui/uikit';
 import {ItemSelector, ItemSelectorProps} from '@gravity-ui/components';
 
+import unipika from '../../../common/thor/unipika';
+
 import {SelectControl} from '../SelectControl/SelectControl';
 
 import i18n from './i18n';
@@ -100,7 +102,7 @@ export function ColumnSelector<T>({
                         displayArrow
                         disabled={disabled}
                         placeholder={i18n('label_placeholder')}
-                        value={value}
+                        value={value?.map?.((item) => unipika.decode(item)) || []}
                         focused={focused}
                         width={controlWidth}
                     />


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/3lTHUgDF7GwoYJ
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Decode non-English column names in ColumnSelector value prop using unipika.decode