### PR TITLE
chore: remove useless mock [YTFRONT-4946]

### DIFF
--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Partitions/Partitions.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Partitions/Partitions.tsx
@@ -55,11 +55,11 @@ const getColumns = createSelector(
                 } else if (name === 'host') {
                     return host<SelectedPartition>(
                         caption,
-                        (x) => x.meta?.host,
+                        (x) => x?.meta?.host || format.NO_VALUE,
                         block('hover-action'),
                     );
                 } else if (name === 'cell_id') {
-                    return string<SelectedPartition>(caption, (x) => x.meta?.cell_id);
+                    return string<SelectedPartition>(caption, (x) => x?.meta?.cell_id || '-');
                 } else if (name === 'write_rate') {
                     return multimeter<SelectedPartition>(
                         writeRateName[rateMode],

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/queue.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/queue.ts
@@ -3,7 +3,6 @@ import {createSelector} from 'reselect';
 import type {RootState} from '../../../reducers';
 import type {YtQueueStatus} from '../../../reducers/navigation/tabs/queue/types';
 
-const metaMock = {cell_id: '890', host: 'lbk-vla-249.search.yandex.net'};
 export const emptyRate = {'1m': 0, '1h': 0, '1d': 0};
 
 export const getFamily = (state: RootState) =>
@@ -69,7 +68,7 @@ export const getPartitions = createSelector(
         partitionsData
             ?.map((partition, index) => ({
                 ...partition,
-                meta: partition.meta ?? metaMock,
+                meta: partition.meta,
                 partition_index: index,
                 write_data_weight_rate: partition.write_data_weight_rate ?? emptyRate,
                 write_row_count_rate: partition.write_row_count_rate ?? emptyRate,
@@ -77,8 +76,8 @@ export const getPartitions = createSelector(
             ?.filter(
                 (partition) =>
                     partition.partition_index.toString(10).includes(queuePartitionIndex) &&
-                    partition.meta.host.includes(queueTabletCellHost) &&
-                    partition.meta.cell_id.includes(queueTabletCellId),
+                    partition?.meta?.host?.includes?.(queueTabletCellHost) &&
+                    partition?.meta?.cell_id?.includes?.(queueTabletCellId),
             ) ?? [],
 );
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/TIj3mTW37GwrJn
<!-- nda-end --> ## Summary by Sourcery

Remove obsolete mock metadata and improve handling of missing partition meta in queue selectors and UI columns

Enhancements:
- Remove unused metaMock and its fallback in getPartitions selector
- Use optional chaining when filtering partitions by host and cell_id to avoid undefined errors
- Display '-' as default value for host and cell_id columns when meta is missing in the UI