### PR TITLE
feat(Navigation/ReplicatedTable): add column for content_type [YTFRONT-4964]

### DIFF
--- a/packages/ui/src/ui/pages/navigation/content/ReplicatedTable/ReplicatedTable.js
+++ b/packages/ui/src/ui/pages/navigation/content/ReplicatedTable/ReplicatedTable.js
@@ -50,6 +50,7 @@ const tableSets = {
         items: [
             'name',
             'cluster',
+            'content_type',
             'mode',
             'error_count',
             'replication_lag_time',
@@ -61,6 +62,7 @@ const tableSets = {
         items: [
             'name',
             'cluster',
+            'content_type',
             'mode',
             'error_count',
             'replication_lag_time',
@@ -100,6 +102,13 @@ class ReplicatedTable extends Component {
             sort: false,
             get(replica) {
                 return ypath.getValue(replica, '/@cluster_name');
+            },
+        },
+        content_type: {
+            align: 'left',
+            sort: false,
+            get(replica) {
+                return ypath.getValue(replica, '/@content_type');
             },
         },
         mode: {
@@ -262,6 +271,7 @@ class ReplicatedTable extends Component {
             templates: {
                 name: ReplicatedTable.renderName,
                 cluster: ReplicatedTable.renderField,
+                content_type: ReplicatedTable.renderField,
                 mode: ReplicatedTable.renderField,
                 errors: ReplicatedTable.renderErrors,
                 error_count: ReplicatedTable.renderAsReadableField,

--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Partitions/Partitions.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Partitions/Partitions.tsx
@@ -55,11 +55,14 @@ const getColumns = createSelector(
                 } else if (name === 'host') {
                     return host<SelectedPartition>(
                         caption,
-                        (x) => x.meta?.host,
+                        (x) => x?.meta?.host || format.NO_VALUE,
                         block('hover-action'),
                     );
                 } else if (name === 'cell_id') {
-                    return string<SelectedPartition>(caption, (x) => x.meta?.cell_id);
+                    return string<SelectedPartition>(
+                        caption,
+                        (x) => x?.meta?.cell_id || format.NO_VALUE,
+                    );
                 } else if (name === 'write_rate') {
                     return multimeter<SelectedPartition>(
                         writeRateName[rateMode],

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/queue.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/queue.ts
@@ -3,7 +3,6 @@ import {createSelector} from 'reselect';
 import type {RootState} from '../../../reducers';
 import type {YtQueueStatus} from '../../../reducers/navigation/tabs/queue/types';
 
-const metaMock = {cell_id: '890', host: 'lbk-vla-249.search.yandex.net'};
 export const emptyRate = {'1m': 0, '1h': 0, '1d': 0};
 
 export const getFamily = (state: RootState) =>
@@ -69,7 +68,7 @@ export const getPartitions = createSelector(
         partitionsData
             ?.map((partition, index) => ({
                 ...partition,
-                meta: partition.meta ?? metaMock,
+                meta: partition.meta,
                 partition_index: index,
                 write_data_weight_rate: partition.write_data_weight_rate ?? emptyRate,
                 write_row_count_rate: partition.write_row_count_rate ?? emptyRate,
@@ -77,8 +76,8 @@ export const getPartitions = createSelector(
             ?.filter(
                 (partition) =>
                     partition.partition_index.toString(10).includes(queuePartitionIndex) &&
-                    partition.meta.host.includes(queueTabletCellHost) &&
-                    partition.meta.cell_id.includes(queueTabletCellId),
+                    partition?.meta?.host?.includes?.(queueTabletCellHost) &&
+                    partition?.meta?.cell_id?.includes?.(queueTabletCellId),
             ) ?? [],
 );
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/yUsXnB5T7HGYrh
<!-- nda-end -->## Summary by Sourcery

Add content_type support to the replicated table and improve handling of missing partition metadata by defaulting to NO_VALUE and leveraging optional chaining.

New Features:
- Add a new content_type column to the ReplicatedTable component

Enhancements:
- Default to format.NO_VALUE when partition host or cell_id metadata is missing
- Remove the hardcoded metaMock fallback and use optional chaining in the partition selector filter for safer metadata handling