### PR TITLE
fix(Accounts): typo in the graphic [YTFRONT-5151]

### DIFF
--- a/packages/ui/src/ui/components/Histogram/HistogramChart.tsx
+++ b/packages/ui/src/ui/components/Histogram/HistogramChart.tsx
@@ -234,7 +234,7 @@ function renderDefaultTooltip({
             ? `<b>${colValue}</b> partitions contain in range from <b>${colX0}</b> to <b>${colX1}</b> - ${dataName}`
             : undefined,
         lineValue !== undefined
-            ? `<b>${lp}${lineValue}</b> of tablets conains <b>${lp}${lineX}</b> or less`
+            ? `<b>${lp}${lineValue}</b> of tablets contains <b>${lp}${lineX}</b> or less`
             : undefined,
     ]).join('<br/>');
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/5LYQC8jE7HYjLD
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Correct typo in default tooltip text from 'conains' to 'contains'