### PR TITLE
fix(Queries/Share): changed dependency on list query [YTFRONT-4770]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/module/queries_list/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/queries_list/actions.ts
@@ -33,9 +33,8 @@ export function requestQueriesList(params?: {refresh?: boolean}): AsyncAction {
                 },
             );
 
-            const items = [
-                ...new Map([...list, ...result.queries].map((item) => [item.id, item])).values(),
-            ];
+            const rawItems = params?.refresh ? result.queries : [...list, ...result.queries];
+            const items = [...new Map(rawItems.map((item) => [item.id, item])).values()];
 
             dispatch(
                 updateListState({

--- a/packages/ui/src/ui/pages/query-tracker/module/query/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/query/actions.ts
@@ -560,9 +560,9 @@ export const toggleShareQuery =
         }
 
         await dispatch(updateACOQuery({aco, query_id: query.id}));
-        await dispatch(requestQueriesList());
         dispatch({
             type: UPDATE_ACO_QUERY,
             data: {access_control_objects: aco},
         });
+        dispatch(requestQueriesList());
     };

--- a/packages/ui/src/ui/pages/query-tracker/module/query/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/query/actions.ts
@@ -461,7 +461,8 @@ export function runQuery(
         if (!handled) {
             dispatch(loadQuery(query_id));
         }
-        dispatch(requestQueriesList());
+
+        dispatch(requestQueriesList({refresh: true}));
     };
 }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Rza7mJ8X7HaKkA
<!-- nda-end -->## Summary by Sourcery

Update query list actions to support conditional refresh and ensure list is updated correctly after operations

Bug Fixes:
- Force a full refresh of the query list when runQuery is dispatched
- Remove unnecessary await on requestQueriesList in toggleShareQuery to avoid blocking

Enhancements:
- Add a refresh parameter to requestQueriesList to control full vs incremental updates
- Refactor item merging to use a rawItems array and dedupe with a Map