### PR TITLE
feat(Navigation/CreateTable): add new aggregate type [YTFRONT-5153]

### DIFF
--- a/packages/ui/src/ui/constants/navigation/modals/create-table.ts
+++ b/packages/ui/src/ui/constants/navigation/modals/create-table.ts
@@ -15,9 +15,10 @@ export const ColumnAggregateTypes = {
     MIN: 'min',
     MAX: 'max',
     FIRST: 'first',
+    XDELTA: 'xdelta',
 };
 
-export type ColumnAggregateType = 'sum' | 'min' | 'max' | 'first';
+export type ColumnAggregateType = 'sum' | 'min' | 'max' | 'first' | 'xdelta';
 
 export const ColumnDataTypes = {
     INT64: 'int64',

--- a/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableModal.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableModal.tsx
@@ -348,6 +348,10 @@ class CreateTableModalContentImpl extends React.Component<Props> {
                 return `[${aggr}] aggregate might be only applied to a column of type int64/uint64/double`;
             }
         }
+
+        if (aggr === AggrTypes.XDELTA && type !== ColumnDataTypes.STRING) {
+            return `[${aggr}] aggregate might be only applied to a column of type string`;
+        }
         return undefined;
     }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/LXhiUlLM7HaZ9y
<!-- nda-end -->## Summary by Sourcery

Add 'xdelta' aggregate type to CreateTableModal and update validation to ensure it applies only to string columns

New Features:
- Introduce 'xdelta' as a new column aggregate type

Enhancements:
- Restrict 'xdelta' aggregate to columns of type string