### PR TITLE
fix(Queries/Navigation): correct element icons [YTFRONT-5099]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeListRow.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeListRow.tsx
@@ -2,9 +2,7 @@ import React, {FC, MouseEvent} from 'react';
 import {NavigationNode} from '../../module/queryNavigation/queryNavigationSlice';
 import './NodeListRow.scss';
 import cn from 'bem-cn-lite';
-import {getIconNameForType} from '../../../../utils/navigation/path-editor';
-import AwesomeIcon from '../../../../components/Icon/Icon';
-import {Button, DropdownMenu, Icon, Text} from '@gravity-ui/uikit';
+import {Button, DropdownMenu, Icon} from '@gravity-ui/uikit';
 import {isFolderNode} from '../../../../utils/navigation/isFolderNode';
 import {isTableNode} from '../../../../utils/navigation/isTableNode';
 import StarFillIcon from '@gravity-ui/icons/svgs/star-fill.svg';
@@ -13,6 +11,8 @@ import TextIndentIcon from '@gravity-ui/icons/svgs/text-indent.svg';
 import ArrowUpRightFromSquareIcon from '@gravity-ui/icons/svgs/arrow-up-right-from-square.svg';
 import {useToggle} from 'react-use';
 import {QueryEngine} from '../../../../../shared/constants/engines';
+import {MapNodeIcon} from '../../../../components/MapNodeIcon/MapNodeIcon';
+import {NodeName} from './NodeName';
 
 const b = cn('navigation-node-list-row');
 
@@ -28,7 +28,7 @@ type Props = {
 };
 
 export const NodeListRow: FC<Props> = ({
-    node: {type, broken, dynamic, name, path, isFavorite},
+    node,
     queryEngine,
     onClick,
     onFavoriteToggle,
@@ -37,10 +37,9 @@ export const NodeListRow: FC<Props> = ({
     onNewQuery,
     onNewWindowOpen,
 }) => {
+    const {type, dynamic, name, path, targetPath, isFavorite} = node;
     const [tableMenuOpen, toggleTapleMenuOpen] = useToggle(false);
     const [menuOpen, toggleMenuOpen] = useToggle(false);
-    const iconType = type === 'table' && dynamic ? 'table_dynamic' : type;
-    const iconName = getIconNameForType(iconType, broken);
     const isSupported = isFolderNode(type) || isTableNode(type);
     const showActions = isSupported && name !== '...';
 
@@ -69,12 +68,12 @@ export const NodeListRow: FC<Props> = ({
             onClick={handleClick}
         >
             <div className={b('icon-wrap')}>
-                <AwesomeIcon awesome={iconName} size={16} />
+                <MapNodeIcon node={{$attributes: node}} />
                 {isFavorite && (
                     <Icon data={StarFillIcon} className={b('favorite-icon')} size={10} />
                 )}
             </div>
-            <Text ellipsis>{name}</Text>
+            <NodeName type={type} name={name} targetPath={targetPath} />
             {showActions && (
                 <div className={b('actions')}>
                     <Button view="flat" onClick={handleFavoriteClick}>

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeName.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeName.tsx
@@ -1,0 +1,26 @@
+import React, {FC} from 'react';
+import {Text} from '@gravity-ui/uikit';
+
+type Props = {
+    name: string;
+    type?: string;
+    targetPath?: string;
+};
+
+export const NodeName: FC<Props> = ({type, name, targetPath}) => {
+    return (
+        <Text ellipsis>
+            {type === 'link' ? (
+                <>
+                    {name}{' '}
+                    <span role="img" aria-label="Arrow pointing right" style={{margin: '0 4px'}}>
+                        &#10142;
+                    </span>{' '}
+                    {targetPath}
+                </>
+            ) : (
+                name
+            )}
+        </Text>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/module/queryNavigation/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/queryNavigation/actions.ts
@@ -98,7 +98,7 @@ export const loadNodeByPath =
                 },
                 parameters: {
                     path,
-                    attributes: ['type', 'broken', 'dynamic'],
+                    attributes: ['type', 'broken', 'dynamic', 'sorted', 'target_path'],
                 },
             }),
             {
@@ -115,11 +115,13 @@ export const loadNodeByPath =
                 const name = ypath.getValue(item);
                 const newPath = path + '/' + name;
                 const attributes = ypath.getAttributes(item);
+                const {target_path, ...restAttributes} = attributes;
 
                 return {
                     name,
-                    ...attributes,
+                    ...restAttributes,
                     path: newPath,
+                    targetPath: target_path,
                     isFavorite: favorites.includes(newPath),
                 };
             })

--- a/packages/ui/src/ui/pages/query-tracker/module/queryNavigation/queryNavigationSlice.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/queryNavigation/queryNavigationSlice.ts
@@ -15,7 +15,9 @@ export type NavigationNode = {
     type?: string;
     broken?: boolean;
     dynamic?: boolean;
+    sorted?: boolean;
     path: string;
+    targetPath?: string;
     isFavorite: boolean;
 };
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/VriRIWIN7Hf6RL
<!-- nda-end --> ## Summary by Sourcery

Improve node rendering in the query tracker navigation by delegating icon logic to MapNodeIcon, introducing a NodeName component for link nodes, and extending node attributes with sort and targetPath.

Enhancements:
- Replace AwesomeIcon usage with MapNodeIcon in NodeListRow and simplify node property destructuring
- Add NodeName component to handle ellipsis text and display link nodes with an arrow and targetPath
- Extend loadNodeByPath action to fetch sort and target_path attributes and map target_path to targetPath
- Update queryNavigation slice to include sorted and targetPath fields on NavigationNode