### PR TITLE
fix(Modal): close modal when pressing esc [YTFRONT-2533]

### DIFF
--- a/packages/ui/src/ui/components/Modal/Modal.tsx
+++ b/packages/ui/src/ui/components/Modal/Modal.tsx
@@ -44,6 +44,20 @@ class Modal extends Component<ModalProps> {
         confirmText: 'Apply',
     };
 
+    componentDidMount() {
+        document.addEventListener('keydown', this.handleKeyDown);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeyDown);
+    }
+
+    handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape' && this.props.visible) {
+            this.props.onCancel();
+        }
+    };
+
     _isConfirmDisabled = () => {
         const {isConfirmDisabled} = this.props;
         return typeof isConfirmDisabled === 'function' && isConfirmDisabled();


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/IA1a1i-77HmPEu
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Enable closing of Modal on Escape key press