### PR TITLE
feat(Queries/List): add additional list filters [YTFRONT-5058]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/FilterDropdown.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/FilterDropdown.scss
@@ -1,0 +1,4 @@
+.yt-qt-filter-dropdown {
+    padding: 15px 24px;
+    max-width: 350px;
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/FilterDropdown.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/FilterDropdown.tsx
@@ -1,0 +1,52 @@
+import React, {FC, PropsWithChildren} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {resetFilter} from '../../module/queries_list/actions';
+import './FilterDropdown.scss';
+import cn from 'bem-cn-lite';
+import {Button, Flex, Icon, Text} from '@gravity-ui/uikit';
+import TrashBinIcon from '@gravity-ui/icons/svgs/trash-bin.svg';
+import {QueryStateFilter} from './QueryStateFilter';
+import {QueryUserFilter} from './QueryUserFilter';
+import {QueryDateFilter} from './QueryDateFilter';
+import {hasCustomHistoryFilters} from '../../module/queries_list/selectors';
+
+const block = cn('yt-qt-filter-dropdown');
+
+const Block: FC<PropsWithChildren<{title: string}>> = ({title, children}) => {
+    return (
+        <Flex direction="column" gap={2}>
+            <Text variant="subheader-1">{title}</Text>
+            {children}
+        </Flex>
+    );
+};
+
+export const FilterDropdown: FC = () => {
+    const dispatch = useDispatch();
+    const changed = useSelector(hasCustomHistoryFilters);
+
+    const handleResetFilter = React.useCallback(() => {
+        dispatch(resetFilter());
+    }, [dispatch]);
+
+    return (
+        <Flex className={block()} direction="column" gap={3}>
+            <Block title="Operation date">
+                <QueryDateFilter />
+            </Block>
+            <Block title="Operation owner">
+                <QueryUserFilter />
+            </Block>
+            <Block title="Query state">
+                <QueryStateFilter />
+            </Block>
+            {changed && (
+                <Flex justifyContent="flex-end">
+                    <Button view="outlined" onClick={handleResetFilter}>
+                        <Icon data={TrashBinIcon} size={16} /> Reset filters
+                    </Button>
+                </Flex>
+            )}
+        </Flex>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryDateFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryDateFilter.tsx
@@ -1,0 +1,44 @@
+import React, {FC, useMemo} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {getQueriesFilters} from '../../module/queries_list/selectors';
+import {DatePicker} from '@gravity-ui/date-components';
+import {DateTime, dateTime} from '@gravity-ui/date-utils';
+import {Flex} from '@gravity-ui/uikit';
+import {applyFilter} from '../../module/queries_list/actions';
+
+export const QueryDateFilter: FC = () => {
+    const dispatch = useDispatch();
+    const {from, to} = useSelector(getQueriesFilters);
+
+    const setFilter = useMemo(
+        () => ({
+            from: (value?: DateTime | null) => {
+                dispatch(applyFilter({from: value ? value.valueOf() : undefined}));
+            },
+            to: (value?: DateTime | null) => {
+                dispatch(applyFilter({to: value ? value.valueOf() : undefined}));
+            },
+        }),
+        [dispatch],
+    );
+
+    return (
+        <Flex alignItems="center" gap={1}>
+            <DatePicker
+                placeholder="Start date"
+                format="DD.MM.YYYY"
+                value={from ? dateTime({input: from}) : null}
+                onUpdate={setFilter.from}
+                hasClear
+            />{' '}
+            &mdash;
+            <DatePicker
+                placeholder="End date"
+                format="DD.MM.YYYY"
+                value={to ? dateTime({input: to}) : null}
+                onUpdate={setFilter.to}
+                hasClear
+            />
+        </Flex>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryEngineFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryEngineFilter.tsx
@@ -1,49 +1,52 @@
-import React, {useCallback, useMemo} from 'react';
-import {ControlGroupOption, RadioButton} from '@gravity-ui/uikit';
+import React, {FC, useCallback} from 'react';
+import {Select} from '@gravity-ui/uikit';
 import {Engines} from '../../module/api';
 import {QueryEngine} from '../../../../../shared/constants/engines';
 import {QueryEnginesNames} from '../../utils/query';
+import {useDispatch, useSelector} from 'react-redux';
+import {getQueriesFilters} from '../../module/queries_list/selectors';
+import {applyFilter} from '../../module/queries_list/actions';
 
 const ALL_ENGINE_KEY = '__all';
 
-export function QueryEngineFilter({
-    value,
-    onChange,
-    className,
-    engines = Engines,
-}: {
-    engines?: QueryEngine[];
-    value?: QueryEngine;
-    className?: string;
-    onChange: (value?: QueryEngine) => void;
-}) {
-    const enginesList = useMemo<ControlGroupOption[]>(() => {
-        return [
-            {
-                value: ALL_ENGINE_KEY,
-                content: 'All',
-            },
-            ...engines.map((engine) => {
-                return {
-                    value: engine,
-                    content: QueryEnginesNames[engine],
-                };
-            }),
-        ];
-    }, [engines]);
+const enginesList = [
+    {
+        value: ALL_ENGINE_KEY,
+        content: 'All',
+    },
+    ...Engines.map((engine) => {
+        return {
+            value: engine,
+            content: QueryEnginesNames[engine],
+        };
+    }),
+];
+
+export const QueryEngineFilter: FC = () => {
+    const dispatch = useDispatch();
+    const {engine} = useSelector(getQueriesFilters);
 
     const onChangeEngineFilter = useCallback(
-        (engine: string) => {
-            onChange(engine === ALL_ENGINE_KEY ? undefined : (engine as QueryEngine));
+        (values: string[]) => {
+            const selectedEngine = values[0];
+            dispatch(
+                applyFilter({
+                    engine:
+                        selectedEngine === ALL_ENGINE_KEY
+                            ? undefined
+                            : (selectedEngine as QueryEngine),
+                }),
+            );
         },
-        [onChange],
+        [dispatch],
     );
+
     return (
-        <RadioButton
-            className={className}
+        <Select
             options={enginesList}
-            value={value || ALL_ENGINE_KEY}
+            value={[engine || ALL_ENGINE_KEY]}
             onUpdate={onChangeEngineFilter}
+            placeholder="Select engine"
         />
     );
-}
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryFastUserFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryFastUserFilter.tsx
@@ -1,0 +1,37 @@
+import React, {FC, useMemo} from 'react';
+import {QueriesListAuthorFilter, QueriesListFilter} from '../../module/queries_list/types';
+import {ControlGroupOption, RadioButton} from '@gravity-ui/uikit';
+import {useDispatch, useSelector} from 'react-redux';
+import {getQueriesFilters} from '../../module/queries_list/selectors';
+import {applyFilter} from '../../module/queries_list/actions';
+import {getCurrentUserName} from '../../../../store/selectors/global';
+
+const AuthorFilter: ControlGroupOption[] = [
+    {
+        value: QueriesListAuthorFilter.My,
+        content: 'My',
+    },
+    {
+        value: QueriesListAuthorFilter.All,
+        content: 'All',
+    },
+];
+
+export const QueryFastUserFilter: FC = () => {
+    const dispatch = useDispatch();
+    const {user} = useSelector(getQueriesFilters);
+    const login = useSelector(getCurrentUserName);
+
+    const handleUserChange = (value: string) => {
+        dispatch(applyFilter({user: value as QueriesListFilter['user']}));
+    };
+
+    const value = useMemo(() => {
+        if (QueriesListAuthorFilter.My === user || user === login)
+            return QueriesListAuthorFilter.My;
+
+        return QueriesListAuthorFilter.All;
+    }, [login, user]);
+
+    return <RadioButton options={AuthorFilter} value={value} onUpdate={handleUserChange} />;
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryStateFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryStateFilter.tsx
@@ -1,0 +1,46 @@
+import React, {FC, useCallback} from 'react';
+import {Select} from '@gravity-ui/uikit';
+import {QueryStatus} from '../../../../types/query-tracker';
+import hammer from '../../../../common/hammer';
+import {useDispatch, useSelector} from 'react-redux';
+import {applyFilter} from '../../module/queries_list/actions';
+import {getQueriesFilters} from '../../module/queries_list/selectors';
+
+const ALL_STATUS_KEY = '__all';
+const statusesList = [
+    {
+        value: ALL_STATUS_KEY,
+        content: 'All',
+    },
+    ...Object.values(QueryStatus).map((i) => {
+        return {
+            value: i,
+            content: hammer.format.Readable(i),
+        };
+    }),
+];
+
+export const QueryStateFilter: FC = () => {
+    const dispatch = useDispatch();
+    const {state} = useSelector(getQueriesFilters);
+
+    const onChangeStatusFilter = useCallback(
+        (values: string[]) => {
+            const selectedStatus = values[0];
+            const result =
+                selectedStatus === ALL_STATUS_KEY ? undefined : (selectedStatus as QueryStatus);
+            dispatch(applyFilter({state: result}));
+        },
+        [dispatch],
+    );
+
+    return (
+        <Select
+            width="max"
+            options={statusesList}
+            value={[state || ALL_STATUS_KEY]}
+            onUpdate={onChangeStatusFilter}
+            placeholder="Select status"
+        />
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryUserFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryUserFilter.tsx
@@ -1,0 +1,51 @@
+import React, {FC, useCallback, useMemo} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {getAllUserNames, getCurrentUserName} from '../../../../store/selectors/global';
+import {useAllUserNamesFiltered} from '../../../../hooks/global';
+import {Select, SelectOption} from '@gravity-ui/uikit';
+import {getQueriesFilters} from '../../module/queries_list/selectors';
+import {QueriesListAuthorFilter} from '../../module/queries_list/types';
+import {applyFilter} from '../../module/queries_list/actions';
+
+const ALL_STATUS_KEY = '__all';
+
+export const QueryUserFilter: FC = () => {
+    useAllUserNamesFiltered();
+    const dispatch = useDispatch();
+    const userNames = useSelector(getAllUserNames);
+    const login = useSelector(getCurrentUserName);
+    const {user} = useSelector(getQueriesFilters);
+
+    const values = useMemo<SelectOption[]>(() => {
+        return [
+            {
+                value: ALL_STATUS_KEY,
+                content: 'All',
+            },
+            ...userNames.map((userName) => ({
+                value: userName,
+                content: userName,
+            })),
+        ];
+    }, [userNames]);
+
+    const value = useMemo(() => {
+        let result = user;
+        if (!result) {
+            result = ALL_STATUS_KEY;
+        }
+        if (result === QueriesListAuthorFilter.My) {
+            result = login;
+        }
+        return [result];
+    }, [login, user]);
+
+    const handleOnChange = useCallback(
+        (items: string[]) => {
+            dispatch(applyFilter({user: items[0]}));
+        },
+        [dispatch],
+    );
+
+    return <Select options={values} value={value} onUpdate={handleOnChange} filterable />;
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.scss
@@ -7,7 +7,6 @@
     &__row {
         display: flex;
         align-items: center;
-        flex-direction: row;
         gap: 0 8px;
 
         &:not(:last-child) {
@@ -16,10 +15,6 @@
     }
 
     &__row-item:not(:first-child) {
-        margin-left: 8px;
-    }
-
-    &__columns-button {
         margin-left: 8px;
     }
 }

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.tsx
@@ -1,40 +1,28 @@
 import React from 'react';
 import block from 'bem-cn-lite';
-import {ControlGroupOption, Icon as GravityIcon, RadioButton, Tooltip} from '@gravity-ui/uikit';
-import {
-    QueriesListAuthorFilter,
-    QueriesListFilter,
-    QueriesListMode,
-} from '../../module/queries_list/types';
+import {Icon, Tooltip} from '@gravity-ui/uikit';
+import {QueriesListFilter, QueriesListMode} from '../../module/queries_list/types';
 import CircleQuestionIcon from '@gravity-ui/icons/svgs/circle-question.svg';
+import FunnelIcon from '@gravity-ui/icons/svgs/funnel.svg';
 
 import './index.scss';
 import {QueryEngineFilter} from './QueryEngineFilter';
-import {QueryEngine} from '../../../../../shared/constants/engines';
 import Dropdown from '../../../../components/Dropdown/Dropdown';
 import Button from '../../../../components/Button/Button';
-import Icon from '../../../../components/Icon/Icon';
+import GearIcon from '@gravity-ui/icons/svgs/gear.svg';
 import ColumnSelector from '../../../../components/ColumnSelector/ColumnSelector';
 import {useDispatch, useSelector} from 'react-redux';
 import {
     getQueriesFilters,
     getQueriesListMode,
     getQueryListColumns,
+    hasCustomHistoryFilters,
 } from '../../module/queries_list/selectors';
 import {applyFilter} from '../../module/queries_list/actions';
 import {setSettingByKey} from '../../../../store/actions/settings';
 import TextInputWithDebounce from '../../../../components/TextInputWithDebounce/TextInputWithDebounce';
-
-const AuthorFilter: ControlGroupOption[] = [
-    {
-        value: QueriesListAuthorFilter.My,
-        content: 'My',
-    },
-    {
-        value: QueriesListAuthorFilter.All,
-        content: 'All',
-    },
-];
+import {FilterDropdown} from './FilterDropdown';
+import {QueryFastUserFilter} from './QueryFastUserFilter';
 
 const b = block('queries-history-filter');
 
@@ -47,6 +35,7 @@ export function QueriesHistoryListFilter({className}: QueriesHistoryListFilterPr
     const filter = useSelector(getQueriesFilters);
     const filterViewMode = useSelector(getQueriesListMode);
     const {allowedColumns} = useSelector(getQueryListColumns);
+    const customFilterChanged = useSelector(hasCustomHistoryFilters);
 
     const handleColumnChange = (selectedColumns: {
         items: Array<{checked: boolean; name: string}>;
@@ -59,68 +48,76 @@ export function QueriesHistoryListFilter({className}: QueriesHistoryListFilterPr
         );
     };
 
-    const setFilter = React.useMemo(
-        () => ({
-            user: (value: string) => {
-                dispatch(applyFilter({user: value as QueriesListFilter['user']}));
-            },
-            engine: (value?: QueryEngine) => {
-                dispatch(applyFilter({engine: value as QueriesListFilter['engine']}));
-            },
-            filter: (value?: string) => {
-                dispatch(applyFilter({filter: value as QueriesListFilter['filter']}));
-            },
-        }),
-        [dispatch],
-    );
+    const handleFilterChange = (value: string) => {
+        dispatch(applyFilter({filter: value as QueriesListFilter['filter']}));
+    };
+
+    const isHistory = filterViewMode === QueriesListMode.History;
+
+    if (!isHistory) {
+        return (
+            <div className={b(null, className)}>
+                <div className={b('row')}>
+                    <QueryEngineFilter />
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className={b(null, className)}>
             <div className={b('row')}>
-                {filterViewMode === QueriesListMode.History && (
-                    <RadioButton
-                        options={AuthorFilter}
-                        value={filter?.user || QueriesListAuthorFilter.My}
-                        onUpdate={setFilter.user}
-                    />
-                )}
-                <QueryEngineFilter value={filter?.engine} onChange={setFilter.engine} />
+                <QueryFastUserFilter />
+                <QueryEngineFilter />
+
+                <Dropdown
+                    trigger="click"
+                    directions={['bottom']}
+                    button={
+                        <Button
+                            view={customFilterChanged ? 'outlined-info' : 'outlined'}
+                            tooltipProps={{content: 'Additional filters'}}
+                            withTooltip
+                        >
+                            <Icon data={FunnelIcon} size={16} />
+                        </Button>
+                    }
+                    template={<FilterDropdown />}
+                />
+                <Dropdown
+                    trigger="click"
+                    directions={['bottom']}
+                    button={
+                        <Button tooltipProps={{content: 'Table column settings'}} withTooltip>
+                            <Icon data={GearIcon} size={16} />
+                        </Button>
+                    }
+                    template={
+                        <ColumnSelector items={allowedColumns} onChange={handleColumnChange} />
+                    }
+                />
             </div>
-            {filterViewMode === QueriesListMode.History && (
-                <div className={b('row')}>
-                    <TextInputWithDebounce
-                        placeholder="Search in query name, body and access control"
-                        value={filter?.filter}
-                        onUpdate={setFilter.filter}
-                    />
-                    <Tooltip
-                        content={
-                            <>
-                                Search in query text, annotations and access control
-                                <br />
-                                Use `&quot;title&quot;=&quot;test_name&quot;` to search in query
-                                name
-                                <br />
-                                Use `aco:nobody` to search in query access control
-                            </>
-                        }
-                    >
-                        <GravityIcon data={CircleQuestionIcon} size={16} />
-                    </Tooltip>
-                    <Dropdown
-                        trigger="click"
-                        directions={['bottom']}
-                        button={
-                            <Button pin={'round-round'} className={b('columns-button')}>
-                                <Icon awesome="table" face="light" />
-                            </Button>
-                        }
-                        template={
-                            <ColumnSelector items={allowedColumns} onChange={handleColumnChange} />
-                        }
-                    />
-                </div>
-            )}
+
+            <div className={b('row')}>
+                <TextInputWithDebounce
+                    placeholder="Search in query name, body and access control"
+                    value={filter?.filter}
+                    onUpdate={handleFilterChange}
+                />
+                <Tooltip
+                    content={
+                        <>
+                            Search in query text, annotations and access control
+                            <br />
+                            Use `&quot;title&quot;=&quot;test_name&quot;` to search in query name
+                            <br />
+                            Use `aco:nobody` to search in query access control
+                        </>
+                    }
+                >
+                    <Icon data={CircleQuestionIcon} size={16} />
+                </Tooltip>
+            </div>
         </div>
     );
 }

--- a/packages/ui/src/ui/pages/query-tracker/module/queries_list/actions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/queries_list/actions.ts
@@ -2,8 +2,14 @@ import {ThunkAction} from 'redux-thunk';
 import {wrapApiPromiseByToaster} from '../../../../utils/utils';
 import {RootState} from '../../../../store/reducers';
 import {loadQueriesList} from '../api';
-import {getQueriesList, getQueriesListCursorParams, getQueriesListFilterParams} from './selectors';
-import {QueriesListFilter} from './types';
+import {
+    getQueriesFilters,
+    getQueriesList,
+    getQueriesListCursorParams,
+    getQueriesListFilterParams,
+    getQueriesListMode,
+} from './selectors';
+import {DefaultQueriesListFilter, QueriesListFilter} from './types';
 import {QueriesHistoryCursorDirection} from '../query-tracker-contants';
 import {setCursor, setFilter, setLoading, updateListState} from './queryListSlice';
 
@@ -82,10 +88,22 @@ export function resetCursor(silent = false): AsyncAction {
     };
 }
 
-export function applyFilter(patch: QueriesListFilter): AsyncAction {
-    return (dispatch) => {
-        dispatch(resetCursor(true));
-        dispatch(setFilter(patch));
+export function resetFilter(): AsyncAction {
+    return (dispatch, getState) => {
+        const state = getState();
+        const listMode = getQueriesListMode(state);
+
+        dispatch(setFilter({...DefaultQueriesListFilter[listMode]}));
         dispatch(requestQueriesList());
+    };
+}
+
+export function applyFilter(patch: QueriesListFilter): AsyncAction {
+    return (dispatch, getState) => {
+        const filter = getQueriesFilters(getState());
+
+        dispatch(resetCursor(true));
+        dispatch(setFilter({...filter, ...patch}));
+        dispatch(requestQueriesList({refresh: true}));
     };
 }

--- a/packages/ui/src/ui/pages/query-tracker/module/queries_list/types.ts
+++ b/packages/ui/src/ui/pages/query-tracker/module/queries_list/types.ts
@@ -1,5 +1,6 @@
 import {QueryEngine} from '../../../../../shared/constants/engines';
 import type {QueriesHistoryCursorDirection} from '../query-tracker-contants';
+import {QueryStatus} from '../../../../types/query-tracker';
 
 export enum QueriesListAuthorFilter {
     All = 'all',
@@ -38,8 +39,11 @@ export const DefaultQueriesListFilter: Record<QueriesListMode, Partial<QueriesLi
 };
 
 export type QueriesListFilter = {
-    user?: QueriesListAuthorFilter;
+    user?: string;
     engine?: QueryEngine;
+    from?: number;
+    to?: number;
+    state?: QueryStatus;
     filter?: string;
     is_tutorial?: boolean;
 };


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/t9ks22GD7HrYvS
<!-- nda-end -->## Summary by Sourcery

Overhaul the query list filtering UI and logic to support advanced history filters, quick user toggle, and improved filter management

New Features:
- Add FilterDropdown with date, owner, and state filters plus reset option
- Introduce QueryFastUserFilter component for quick My/All user toggle
- Add funnel button for advanced filters and gear button for column settings

Enhancements:
- Refactor QueryEngineFilter to use Select and connect directly to Redux
- Extend filter parameters with from, to, and state and normalize them in getQueriesListFilterParams
- Simplify applyFilter action, add resetFilter action, and refresh list on filter change
- Add hasCustomHistoryFilters selector to detect non-default history filters

Chores:
- Remove deprecated author filter code, styling, and unused imports