### PR TITLE
fix(Queries/Result): result tab priority [YTFRONT-5122]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useQueryResultTabs.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useQueryResultTabs.tsx
@@ -167,6 +167,12 @@ export const useQueryResultTabs = (
             return;
         }
 
+        const errorTabItem = tabs.find((tabItem) => tabItem.id === QueryResultTab.ERROR);
+        if (errorTabItem && query?.state === QueryStatus.FAILED) {
+            setActiveTab(errorTabItem.id, query?.id);
+            return;
+        }
+
         const progressTabItem = tabs.find((tabItem) => tabItem.id === QueryResultTab.PROGRESS);
         if (progressTabItem && !progressTabShown && !resultTabShown) {
             setProgressTabShown(true);


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/7COxiztN7JACfZ
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Automatically activate the Error tab when a query state is FAILED before showing progress or results