### PR TITLE
chore: fix default columns in accounts widget [YTFRONT-3400]

### DIFF
--- a/packages/ui/src/ui/constants/dashboard2/index.ts
+++ b/packages/ui/src/ui/constants/dashboard2/index.ts
@@ -54,7 +54,7 @@ export const defaultDashboardItems = {
             x: navigationLayoutWidth,
             y: 0,
         },
-        data: {name: 'Accounts', columns: [{name: 'Nodes'}, {name: 'Chunks'}]},
+        data: {name: 'Accounts', columns: [{name: 'Nodes'}, {name: 'Chunks'}, {name: 'default'}]},
     },
     pools: {
         layout: {

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/components/CopyConfigDialog/CopyConfigDialog.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/components/CopyConfigDialog/CopyConfigDialog.tsx
@@ -47,6 +47,7 @@ export function CopyConfigDialog() {
                     extras: {
                         options: copyConfigOptions,
                         width: 'max',
+                        filterable: true,
                         placeholder: 'Cluster',
                     },
                 },


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/r4wmtYzZ7K3i8d
<!-- nda-end --> ## Summary by Sourcery

Fix the default columns for the Accounts widget and improve the Copy Config dialog selector

Bug Fixes:
- Add the missing 'default' column to the Accounts widget default columns

Enhancements:
- Enable filtering on the Cluster dropdown in the Copy Config dialog