### PR TITLE
feat(yql): add syntax highlighting for new YQL keywords

### DIFF
--- a/packages/ui/src/ui/libs/monaco-yql-languages/yql/yql.keywords.ts
+++ b/packages/ui/src/ui/libs/monaco-yql-languages/yql/yql.keywords.ts
@@ -3,7 +3,7 @@ import {generateSuggestion} from '../helpers/generateSuggestions';
 import {getRangeToInsertSuggestion} from '../helpers/getRangeToInsertSuggestion';
 
 export const keywords =
-    '$row|$rows|action|all|and|any|as|asc|assume|begin|bernoulli|between|by|case|columns|commit|compact|create|cross|cube|declare|define|delete|desc|dict|discard|distinct|do|drop|else|empty_action|end|erase|evaluate|exclusion|exists|export|flatten|for|from|full|group|grouping|having|if|ignore|ilike|import|in|inner|insert|into|is|join|left|like|limit|list|match|not|null|nulls|offset|on|only|optional|or|order|over|partition|pragma|presort|process|reduce|regexp|repeatable|replace|respect|result|return|right|rlike|rollup|sample|schema|select|semi|set|sets|stream|subquery|table|tablesample|then|truncate|union|update|upsert|use|using|values|view|when|where|window|with|without|xor'.split(
+    'intersect|except|$row|$rows|action|all|and|any|as|asc|assume|begin|bernoulli|between|by|case|columns|commit|compact|create|cross|cube|declare|define|delete|desc|dict|discard|distinct|do|drop|else|empty_action|end|erase|evaluate|exclusion|exists|export|flatten|for|from|full|group|grouping|having|if|ignore|ilike|import|in|inner|insert|into|is|join|left|like|limit|list|match|not|null|nulls|offset|on|only|optional|or|order|over|partition|pragma|presort|process|reduce|regexp|repeatable|replace|respect|result|return|right|rlike|rollup|sample|schema|select|semi|set|sets|stream|subquery|table|tablesample|then|truncate|union|update|upsert|use|using|values|view|when|where|window|with|without|xor'.split(
         '|',
     );
 export const typeKeywords =


### PR DESCRIPTION
## Summary by Sourcery
Brefore:
<img width="1158" height="173" alt="Screenshot 2025-09-18 at 11 08 09" src="https://github.com/user-attachments/assets/7c7f2d98-1f29-41b0-8e7e-6f159bbf12c1" />

After:
<img width="2246" height="700" alt="image" src="https://github.com/user-attachments/assets/f9266661-218c-4b66-8b39-9899bba7432a" />


New Features:
- Add syntax highlighting support for YQL keywords INTERSECT and EXCEPT