### PR TITLE
feat(Queries): add yql versions [YTFRONT-5098]

### DIFF
--- a/packages/ui/src/shared/constants/settings-types.ts
+++ b/packages/ui/src/shared/constants/settings-types.ts
@@ -184,6 +184,9 @@ export type QueryTrackerLastDiscoveryPath = {
 export type QueryTrackerLastChytClique = {
     [key in `local::${Cluster}::queryTracker::lastChytClique`]: string;
 };
+export type QueryTrackerLastYqlVersion = {
+    [key in `local::${Cluster}::queryTracker::lastYqlVersion`]: string;
+};
 
 export type SchedulingOverviewColumnNames =
     | 'name'
@@ -236,6 +239,7 @@ export type DescribedSettings = GlobalSettings &
     QueryTrackerUserDefaultACOSettings &
     QueryTrackerLastDiscoveryPath &
     QueryTrackerLastChytClique &
+    QueryTrackerLastYqlVersion &
     ComponentsSettings &
     SchedulingSettings &
     DashboardSettings;

--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -526,12 +526,20 @@ export type FlowViewWorkerInfo = {
     address: FlowViewWorkerId;
 };
 
+export type YqlEnginesInfo = {
+    available_yql_versions: string[];
+    default_yql_ui_version: string;
+};
+
 export type GetQueryTrackerInfoResponse = {
     cluster_name: string;
     access_control_objects: string[];
     query_tracker_stage: string;
     supported_features: {access_control: boolean; multiple_aco?: boolean};
     clusters?: Array<string>;
+    engines_info?: {
+        yql: YqlEnginesInfo;
+    };
 };
 
 export type FlowExecuteCommand = 'describe-pipeline';

--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/DefaultAcoSelect.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/DefaultAcoSelect.tsx
@@ -1,5 +1,8 @@
 import React, {FC} from 'react';
-import {getQueryACO, setUserDefaultACO} from '../../../store/actions/query-tracker/queryAco';
+import {
+    getQueryTrackerInfo,
+    setUserDefaultACO,
+} from '../../../store/actions/query-tracker/queryAco';
 import {Item} from '../../../components/Select/Select';
 import {SettingsMenuSelect} from '../../SettingsMenu/SettingsMenuSelect';
 import {useThunkDispatch} from '../../../store/thunkDispatch';
@@ -13,7 +16,7 @@ export const DefaultAcoSelect: FC = () => {
     return (
         <SettingsMenuSelect
             getOptionsOnMount={() =>
-                dispatch(getQueryACO()).then((data) => {
+                dispatch(getQueryTrackerInfo()).then((data) => {
                     return data.access_control_objects.reduce((acc: Item[], item: string) => {
                         acc.push({value: item, text: item});
                         return acc;

--- a/packages/ui/src/ui/pages/query-tracker/QueryACO/useQueryACO.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryACO/useQueryACO.ts
@@ -7,10 +7,10 @@ import {
 } from '../../../store/selectors/query-tracker/query';
 import {
     getQueryACOOptions,
-    getQueryTrackerInfo,
     isQueryTrackerInfoLoading as isQueryTrackerInfoLoadingSelector,
+    selectQueryTrackerInfo,
 } from '../../../store/selectors/query-tracker/queryAco';
-import {getQueryACO} from '../../../store/actions/query-tracker/queryAco';
+import {getQueryTrackerInfo} from '../../../store/actions/query-tracker/queryAco';
 import {setDraftQueryACO, setQueryACO} from '../../../store/actions/query-tracker/query';
 
 export const useQueryACO = () => {
@@ -19,7 +19,7 @@ export const useQueryACO = () => {
     const currentDraftQueryACO = useSelector(getCurrentDraftQueryACO);
     const selectOptions = useSelector(getQueryACOOptions);
     const isQueryTrackerInfoLoading = useSelector(isQueryTrackerInfoLoadingSelector);
-    const trackerInfo = useSelector(getQueryTrackerInfo);
+    const trackerInfo = useSelector(selectQueryTrackerInfo);
     const [loading, setLoading] = useState(false);
 
     const changeCurrentQueryACO = useCallback(
@@ -45,7 +45,7 @@ export const useQueryACO = () => {
     );
 
     const loadQueryTrackerInfo = () => {
-        dispatch(getQueryACO());
+        dispatch(getQueryTrackerInfo());
     };
 
     return {

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.scss
@@ -1,0 +1,5 @@
+.yt-query-selector-by-engine {
+    &__version {
+        flex-shrink: 0;
+    }
+}

--- a/packages/ui/src/ui/store/actions/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryAco.ts
@@ -14,7 +14,7 @@ import {setSettingByKey} from '../settings';
 
 type QueryTrackerInfoResponse = Awaited<ReturnType<typeof ytApiV4Id.getQueryTrackerInfo>>;
 
-export const getQueryACO = (): ThunkAction<
+export const getQueryTrackerInfo = (): ThunkAction<
     Promise<QueryTrackerInfoResponse>,
     any,
     any,

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
@@ -38,7 +38,16 @@ export const selectAvailableAco = (state: RootState) =>
 
 export const isQueryTrackerInfoLoading = (state: RootState) => selectAcoState(state).loading;
 
-export const getQueryTrackerInfo = (state: RootState) => selectAcoState(state).data;
+export const selectQueryTrackerInfo = (state: RootState) => selectAcoState(state).data;
+
+export const getAvailableYql = createSelector([selectQueryTrackerInfo], (qtInfo) => {
+    const versions = qtInfo?.engines_info?.yql?.available_yql_versions;
+    return Array.isArray(versions) ? versions : [];
+});
+
+export const getDefaultYqlVersion = createSelector([selectQueryTrackerInfo], (qtInfo) => {
+    return qtInfo?.engines_info?.yql.default_yql_ui_version;
+});
 
 export const isSupportedShareQuery = createSelector(
     [selectIsMultipleAco, selectAvailableAco],

--- a/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
@@ -24,6 +24,13 @@ export const getLastUserChoiceQueryChytClique = createSelector(
     },
 );
 
+export const getLastUserChoiceYqlVersion = createSelector(
+    [getSettingsData, getQueryDraft],
+    (data, {settings}) => {
+        return data[`local::${settings?.cluster}::queryTracker::lastYqlVersion`];
+    },
+);
+
 export const getQueryTokens = createSelector([getSettingsData], (data) => {
     return data['global::queryTracker::tokens'] || [];
 });


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Wam34uKF7Kb9wy
<!-- nda-end -->  ## Summary by Sourcery

Add support for selecting and persisting YQL engine versions in the query tracker UI.

New Features:
- Display a YQL version dropdown when the YQL engine is selected and available versions are fetched
- Persist the last chosen YQL version per cluster in user settings

Enhancements:
- Introduce AsyncAction alias to simplify ThunkAction types
- Rename getQueryACO to getQueryTrackerInfo and update related selectors and hooks
- Add getAvailableYql and getDefaultYqlVersion selectors and extend DraftQuery with yql_version

Chores:
- Add styling for the YQL version selector