### PR TITLE
fix(Queries): wrong clique selector size [YTFRONT-5227]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryCliqueSelector/QueryCliqueSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryCliqueSelector/QueryCliqueSelector.tsx
@@ -37,6 +37,7 @@ export const QueryCliqueSelector: FC<Props> = ({
 
     return (
         <QuerySelector
+            size="l"
             placeholder={placeholder}
             filterPlaceholder="Search"
             hasClear


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/apzuXcNc7KeW2Z
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Add `size="l"` prop to QueryCliqueSelector to fix its display size