### PR TITLE
fix(Operations/JobsMonitoring): display of limit exceeding [YTFRONT-5…

### DIFF
--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -232,6 +232,7 @@ export interface UIFactory {
         | React.ComponentType<{
               cluster: string;
               job_descriptor: string;
+              alerts?: React.ReactNode;
               from?: number;
               to?: number;
           }>;

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/en.json
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/en.json
@@ -1,4 +1,4 @@
 {
   "alert_no-jobs-with-monitoring-descriptor": "There are no jobs with \"monitoring_descriptor\"",
-  "alert_descriptors-limit-exceeded": "The limit of {{limit}} unique descriptors has been exceeded"
+  "alert_descriptors-limited": "There are more than {{limit}} unique monitoring descriptors. Showing the first {{limit}} monitoring descriptors from the most recent jobs."
 }

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/ru.json
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/ru.json
@@ -1,4 +1,4 @@
 {
   "alert_no-jobs-with-monitoring-descriptor": "Нет задач с \"monitoring_descriptor\"",
-  "alert_descriptors-limit-exceeded": "Превышен лимит {{limit}} уникальных дескрипторов"
+  "alert_descriptors-limited": "Дескрипторов мониторинга больше {{limit}}. Показаны первые {{limit}} дескрипторов мониторинга из самых свежих задач."
 }

--- a/packages/ui/src/ui/store/actions/operations/jobs-monitor.ts
+++ b/packages/ui/src/ui/store/actions/operations/jobs-monitor.ts
@@ -24,6 +24,7 @@ export function getJobsMonitoringDescriptors(operation_id: string): JobsMonitorT
                 parameters: {
                     operation_id,
                     sort_field: 'start_time',
+                    sort_order: 'descending',
                     attributes: ['monitoring_descriptor', 'start_time', 'finish_time'],
                     with_monitoring_descriptor: true,
                 },

--- a/packages/ui/src/ui/store/selectors/operations/jobs-monitor.ts
+++ b/packages/ui/src/ui/store/selectors/operations/jobs-monitor.ts
@@ -53,6 +53,22 @@ export const getUniqueJobsMonitorDescriptors = createSelector(
     },
 );
 
+export const getLimitedJobsMonitorDescriptors = createSelector(
+    [getJobsMonitoringItemsWithDescriptor],
+    (jobs) => {
+        const descriptors = new Set<string>();
+        for (const job of jobs) {
+            if (job.monitoring_descriptor && descriptors.size < MAX_DESCRIPTORS_COUNT) {
+                descriptors.add(job.monitoring_descriptor);
+            }
+            if (descriptors.size >= MAX_DESCRIPTORS_COUNT) {
+                break;
+            }
+        }
+        return [...descriptors];
+    },
+);
+
 export const getJobsMonitorTabVisible = createSelector(
     [
         getOperationId,
@@ -61,7 +77,7 @@ export const getJobsMonitorTabVisible = createSelector(
         getJobsMonitorError,
     ],
     (opId, jobMonId, jobsDescriptorArray, error) => {
-        if (opId !== jobMonId || jobsDescriptorArray.length > MAX_DESCRIPTORS_COUNT) {
+        if (opId !== jobMonId) {
             return false;
         }
         if (!isEmpty_(error)) {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/KvNOQncs7KnA49
<!-- nda-end -->   …231]

## Summary by Sourcery

Show only the first N job monitoring descriptors when the total exceeds the limit and render a warning instead of blocking the monitor view, while retaining the component rendering and applying appropriate styling.

Bug Fixes:
- Prevent the entire monitor from hiding when descriptors exceed the limit by showing a warning message and partial list instead of an early return

Enhancements:
- Introduce getLimitedJobsMonitorDescriptors selector to cap descriptors to MAX_DESCRIPTORS_COUNT
- Use Flex container and BEM-based CSS class to conditionally render warning and styling when limit is exceeded
- Apply descending sort_order when fetching job monitoring descriptors