### PR TITLE
fix(Queries): tutorials tab [YTFRONT-5240]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo} from 'react';
+import React, {useEffect, useMemo, useRef} from 'react';
 import block from 'bem-cn-lite';
 import {Tabs} from '@gravity-ui/uikit';
 import {QueriesHistoryList} from './QueriesHistoryList';
@@ -8,15 +8,15 @@ import {
     getQueriesListTabs,
 } from '../../../store/selectors/query-tracker/queriesList';
 import {useDispatch, useSelector} from 'react-redux';
-import {QueriesListMode} from '../../../types/query-tracker/queryList';
-import {requestQueriesList} from '../../../store/actions/query-tracker/queriesList';
+import {DefaultQueriesListFilter, QueriesListMode} from '../../../types/query-tracker/queryList';
+import {applyListMode, requestQueriesList} from '../../../store/actions/query-tracker/queriesList';
 
 import './index.scss';
 import {QueriesTutorialList} from './QueriesTutorialList';
 import {QueriesHistoryListFilter} from './QueriesListFilter';
 import {Vcs} from '../Vcs';
 import {Navigation} from '../Navigation';
-import {setListMode} from '../../../store/reducers/query-tracker/queryListSlice';
+import {setFilter} from '../../../store/reducers/query-tracker/queryListSlice';
 
 const b = block('queries-list');
 
@@ -31,13 +31,18 @@ export function QueriesList() {
     const dispatch = useDispatch();
     const activeTab = useSelector(getQueriesListMode);
     const tabsList = useSelector(getQueriesListTabs);
+    const isInitializedRef = useRef(false);
 
     useEffect(() => {
+        if (!isInitializedRef.current) {
+            isInitializedRef.current = true;
+            dispatch(setFilter(DefaultQueriesListFilter[activeTab]));
+        }
         dispatch(requestQueriesList());
-    }, [dispatch]);
+    }, [dispatch, activeTab]);
 
     const handleTabSelect = (tabId: string) => {
-        dispatch(setListMode(tabId as QueriesListMode));
+        dispatch(applyListMode(tabId as QueriesListMode));
     };
 
     const tabs = useMemo(

--- a/packages/ui/src/ui/store/actions/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queriesList.ts
@@ -9,7 +9,11 @@ import {
     getQueriesListFilterParams,
     getQueriesListMode,
 } from '../../selectors/query-tracker/queriesList';
-import {DefaultQueriesListFilter, QueriesListFilter} from '../../../types/query-tracker/queryList';
+import {
+    DefaultQueriesListFilter,
+    QueriesListFilter,
+    QueriesListMode,
+} from '../../../types/query-tracker/queryList';
 import {QueriesHistoryCursorDirection} from '../../reducers/query-tracker/query-tracker-contants';
 import {
     setCursor,
@@ -109,6 +113,20 @@ export function applyFilter(patch: QueriesListFilter): AsyncAction {
 
         dispatch(resetCursor(true));
         dispatch(setFilter({...filter, ...patch}));
+        dispatch(requestQueriesList({refresh: true}));
+    };
+}
+
+export function applyListMode(listMode: QueriesListMode): AsyncAction {
+    return (dispatch) => {
+        dispatch(
+            updateListState({
+                listMode,
+                filter: DefaultQueriesListFilter[listMode],
+                cursor: {direction: QueriesHistoryCursorDirection.PAST},
+                items: [],
+            }),
+        );
         dispatch(requestQueriesList({refresh: true}));
     };
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/TUBkMhe27KyBMc
<!-- nda-end -->## Summary by Sourcery

Apply default filters and reset query list state when switching between tabs in the QueriesList to ensure the tutorials tab displays correctly on first load and subsequent changes.

Bug Fixes:
- Initialize the default filter for the active tab on component mount to fix tutorials tab view.

Enhancements:
- Introduce applyListMode action to reset mode, filter, cursor, and items before fetching queries.
- Use isInitializedRef in QueriesList to set the default filter once on initial render.
- Update effect in QueriesList to depend on activeTab and replace setListMode with applyListMode and setFilter.