### PR TITLE
fix(Navigation/Attributes): compression codec [YTFRONT-5200]

### DIFF
--- a/packages/ui/src/ui/components/Dialog/controls/SelectWithSubItems/SelectWithSubItems.tsx
+++ b/packages/ui/src/ui/components/Dialog/controls/SelectWithSubItems/SelectWithSubItems.tsx
@@ -16,6 +16,7 @@ export interface Props {
     labels?: Array<React.ReactNode>;
     labelClassName?: string;
     placeholder?: string;
+    disablePortal?: boolean;
 }
 
 export type SelectWithSubItemsProps = Props;
@@ -63,7 +64,7 @@ export default class SelectWithSubItems extends Component<Props> {
             return null;
         }
 
-        const {labelClassName} = this.props;
+        const {labelClassName, disablePortal = true} = this.props;
 
         return (
             <div className={block('control')}>
@@ -74,7 +75,7 @@ export default class SelectWithSubItems extends Component<Props> {
                     onUpdate={(vals) => onChange(vals[0])}
                     placeholder={placeholder}
                     width="max"
-                    disablePortal
+                    disablePortal={disablePortal}
                 />
             </div>
         );

--- a/packages/ui/src/ui/pages/navigation/modals/AttributesEditor.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/AttributesEditor.tsx
@@ -481,7 +481,10 @@ function AttributesEditorLoaded() {
                                     UIFactory.docsUrls['storage:compression#compression_codecs'],
                                 ),
                             ),
-                            extras: compressionCodecs,
+                            extras: {
+                                ...compressionCodecs,
+                                disablePortal: false,
+                            },
                         },
                         {
                             name: '_storageOption',

--- a/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableModal.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableModal.tsx
@@ -671,6 +671,7 @@ class CreateTableModalContentImpl extends React.Component<Props> {
                                 ),
                                 extras: {
                                     ...compressionCodecs,
+                                    disablePortal: false,
                                 },
                             },
                             {

--- a/packages/ui/src/ui/store/selectors/global/supported-features.ts
+++ b/packages/ui/src/ui/store/selectors/global/supported-features.ts
@@ -85,18 +85,17 @@ function prepareItemsSubitems(arr: Array<string> = []): CompressionCodecs {
     const {items, subItemsMap} = res;
 
     for (const item of arr) {
-        const parts = item.split('_');
-        const [first, ...rest] = parts;
+        const match = item.match(/^(.+_)(\d+)$/);
 
-        if (rest.length) {
-            const value = first + '_';
+        if (match) {
+            const value = match[1];
+            const subValue = match[2];
 
             if (!subItemsMap[value]) {
                 items.push({value, content: value});
             }
 
             const dst = (subItemsMap[value] = subItemsMap[value] || new Array<string>());
-            const subValue = rest.join('_');
             dst.push({value: subValue, content: subValue});
         } else {
             items.push({value: item, content: item});


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Itfg2Tis7L2Xxg
<!-- nda-end -->## Summary by Sourcery

Allow SelectWithSubItems components to opt out of portal rendering and apply this behavior to the compression codec dropdown, while cleaning up manual codec labeling

Enhancements:
- Introduce disablePortal prop in SelectWithSubItems to control portal rendering
- Disable portal for the compression codec selector in AttributesEditor
- Remove hardcoded “faster”/“slower & smaller” annotations from compression codec items