### PR TITLE
fix(Navigation/Description): use '&' to suppress links resolution [YTFRONT-5232]

### DIFF
--- a/packages/ui/src/ui/pages/navigation/NavigationDescription/hooks/use-update-annotaton.ts
+++ b/packages/ui/src/ui/pages/navigation/NavigationDescription/hooks/use-update-annotaton.ts
@@ -19,7 +19,7 @@ export function useUpdateAnnotation() {
                     {
                         command: 'set' as const,
                         parameters: prepareRequest('/@annotation', {
-                            path,
+                            path: `${path}&`,
                         }),
                         input: annotation,
                     },


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/JcsFGhKb7L5zrB
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Add '&' suffix to the path parameter in useUpdateAnnotation to prevent unwanted link resolution