### PR TITLE
feat(Operation/JobsMonitoring): new jobs monitor [YTFRONT-5053]

### DIFF
--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -30,6 +30,8 @@ import type {PreloadErrorType} from '../constants';
 import type {RootState} from '../store/reducers';
 import {YTError} from '../types';
 import {AnalyticsService} from '../common/utils/metrics';
+import type {DetailedOperationSelector} from '../pages/operations/selectors';
+import {JobItem} from '../store/reducers/operations/jobs/jobs-monitor';
 
 type HeaderItemOrPage =
     | {
@@ -230,9 +232,9 @@ export interface UIFactory {
     getMonitorComponentForJob():
         | undefined
         | React.ComponentType<{
+              operation: DetailedOperationSelector;
+              jobs: JobItem[];
               cluster: string;
-              job_descriptor: string;
-              alerts?: React.ReactNode;
               from?: number;
               to?: number;
           }>;

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/JobsMonitor.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/JobsMonitor.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import {useSelector} from 'react-redux';
 
 import {YTErrorBlock} from '../../../../../components/Error/Error';
@@ -6,45 +6,33 @@ import ErrorBoundary from '../../../../../components/ErrorBoundary/ErrorBoundary
 import Loader from '../../../../../components/Loader/Loader';
 import {NoContent} from '../../../../../components/NoContent/NoContent';
 import {
-    MAX_DESCRIPTORS_COUNT,
     getJobsMonitorError,
     getJobsMonitorFromTo,
     getJobsMonitorItemsLoaded,
     getJobsMonitorItemsLoading,
-    getLimitedJobsMonitorDescriptors,
-    getUniqueJobsMonitorDescriptors,
+    getJobsMonitoringItemsWithDescriptor,
 } from '../../../../../store/selectors/operations/jobs-monitor';
 import {getCluster} from '../../../../../store/selectors/global';
 import UIFactory from '../../../../../UIFactory';
-import {Alert, Flex} from '@gravity-ui/uikit';
+import {Flex} from '@gravity-ui/uikit';
 
 import i18n from './i18n';
+import {getOperation} from '../../../../../store/selectors/operations/operation';
 
 function JobsMonitor() {
     const cluster = useSelector(getCluster);
-    const allJobDescriptors = useSelector(getUniqueJobsMonitorDescriptors);
-    const limitedJobDescriptors = useSelector(getLimitedJobsMonitorDescriptors);
+    const allJobs = useSelector(getJobsMonitoringItemsWithDescriptor);
+    const operation = useSelector(getOperation);
     const {from, to} = useSelector(getJobsMonitorFromTo);
     const error = useSelector(getJobsMonitorError);
     const loaded = useSelector(getJobsMonitorItemsLoaded);
     const loading = useSelector(getJobsMonitorItemsLoading);
 
-    const job_descriptor = useMemo(() => limitedJobDescriptors.join('|'), [limitedJobDescriptors]);
-
-    const alert = useMemo(() => {
-        return allJobDescriptors.length > MAX_DESCRIPTORS_COUNT ? (
-            <Alert
-                message={i18n('alert_descriptors-limited', {limit: MAX_DESCRIPTORS_COUNT})}
-                theme="warning"
-            />
-        ) : undefined;
-    }, [allJobDescriptors]);
-
     if (!loaded && loading) {
         return <Loader visible centered />;
     }
 
-    if (!job_descriptor && !error) {
+    if (!allJobs.length && !error) {
         return <NoContent warning={i18n('alert_no-jobs-with-monitoring-descriptor')} />;
     }
 
@@ -54,7 +42,13 @@ function JobsMonitor() {
         <ErrorBoundary>
             <Flex direction="column" gap={1}>
                 {error && <YTErrorBlock error={error} />}
-                <JobMonitorComponent {...{cluster, job_descriptor, from, to}} alerts={alert} />
+                <JobMonitorComponent
+                    cluster={cluster}
+                    from={from}
+                    to={to}
+                    operation={operation}
+                    jobs={allJobs}
+                />
             </Flex>
         </ErrorBoundary>
     );

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/en.json
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/en.json
@@ -1,4 +1,3 @@
 {
-  "alert_no-jobs-with-monitoring-descriptor": "There are no jobs with \"monitoring_descriptor\"",
-  "alert_descriptors-limited": "There are more than {{limit}} unique monitoring descriptors. Showing the first {{limit}} monitoring descriptors from the most recent jobs."
+  "alert_no-jobs-with-monitoring-descriptor": "There are no jobs with \"monitoring_descriptor\""
 }

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/ru.json
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/i18n/ru.json
@@ -1,4 +1,3 @@
 {
-  "alert_no-jobs-with-monitoring-descriptor": "Нет задач с \"monitoring_descriptor\"",
-  "alert_descriptors-limited": "Дескрипторов мониторинга больше {{limit}}. Показаны первые {{limit}} дескрипторов мониторинга из самых свежих задач."
+  "alert_no-jobs-with-monitoring-descriptor": "Нет задач с \"monitoring_descriptor\""
 }

--- a/packages/ui/src/ui/store/location.main.ts
+++ b/packages/ui/src/ui/store/location.main.ts
@@ -43,6 +43,8 @@ import {
     getAccountsUsageState,
 } from './reducers/accounts/accounts/url-mapping';
 
+import {prometheusDashboardParams} from './reducers/prometheusDashboard/url-mapping';
+
 import {dashboardParams, getDashboardPreparedState} from './reducers/dashboard/url-mapping';
 
 import {getGlobalPreparedState, globalParams} from './reducers/url-mapping';
@@ -118,6 +120,7 @@ export const getMainLocations = (): Array<[string, PathParameters]> => [
         [statisticsParams, getStatisticsPreparedState],
     ],
     [`/*/${Page.OPERATIONS}/*/${OperationTab.JOBS}`, [jobsParams, getJobsPreparedState]],
+    [`/*/${Page.OPERATIONS}/*/${OperationTab.JOBS_MONITOR}`, [prometheusDashboardParams]],
 
     [`/*/${Page.ACCOUNTS}/${AccountsTab.GENERAL}`, [accountsParams, getAccountsPreparedState]],
     [`/*/${Page.ACCOUNTS}/${AccountsTab.USAGE}`, [accountUsageParams, getAccountsUsageState]],

--- a/packages/ui/src/ui/store/reducers/prometheusDashboard/prometheusDashboard-hooks.ts
+++ b/packages/ui/src/ui/store/reducers/prometheusDashboard/prometheusDashboard-hooks.ts
@@ -30,6 +30,7 @@ export function usePrometheusDashboardParams<ParamsT extends Record<string, unkn
 
 export function usePrometheusDashboardType<T extends string = PrometheusDashboardType>(
     allowedValues?: Array<T>,
+    defaultValue?: T,
 ) {
     const dispatch = useDispatch();
     const type = useSelector(prometheusDashboardSelectors.getType) as T;
@@ -46,11 +47,11 @@ export function usePrometheusDashboardType<T extends string = PrometheusDashboar
     const effectiveType = React.useMemo(() => {
         let res = type;
         if (allowedValues && -1 === allowedValues.indexOf(type)) {
-            res = allowedValues[0];
+            res = defaultValue ?? allowedValues[0];
             setType(res);
         }
         return res;
-    }, [type, setType, allowedValues]);
+    }, [type, allowedValues, defaultValue, setType]);
 
     return {
         type: effectiveType,
@@ -87,7 +88,7 @@ export function usePrometheusDashbordTimeRange(initialTimeRange?: {from?: number
             initialRef.current = initialTimeRange;
             setTimeRange({...timeRange, from, to});
         }
-    }, [timeRange, dispatch]);
+    }, [timeRange, initialTimeRange, setTimeRange]);
 
     return {
         timeRange,

--- a/packages/ui/src/ui/store/selectors/operations/jobs-monitor.ts
+++ b/packages/ui/src/ui/store/selectors/operations/jobs-monitor.ts
@@ -44,27 +44,10 @@ export const getJobsMonitorFromTo = createSelector(
     },
 );
 
-export const MAX_DESCRIPTORS_COUNT = 200;
 export const getUniqueJobsMonitorDescriptors = createSelector(
     [getJobsMonitoringItemsWithDescriptor],
     (jobs) => {
         const descriptors = new Set(map_(jobs, 'monitoring_descriptor'));
-        return [...descriptors];
-    },
-);
-
-export const getLimitedJobsMonitorDescriptors = createSelector(
-    [getJobsMonitoringItemsWithDescriptor],
-    (jobs) => {
-        const descriptors = new Set<string>();
-        for (const job of jobs) {
-            if (job.monitoring_descriptor && descriptors.size < MAX_DESCRIPTORS_COUNT) {
-                descriptors.add(job.monitoring_descriptor);
-            }
-            if (descriptors.size >= MAX_DESCRIPTORS_COUNT) {
-                break;
-            }
-        }
         return [...descriptors];
     },
 );


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/9pZyI2OB7LJw35
<!-- nda-end -->   ## Summary by Sourcery

Introduce operationId-based job monitoring alongside the existing job_descriptor approach and wire it through the UIFactory, JobsMonitor component, and selectors.

New Features:
- Enable operationId-based descriptors for gang jobs monitoring when the operation spec flag is set

Enhancements:
- Relax UIFactory.getMonitorComponentForJob props to accept either job_descriptor or operationId
- Update JobsMonitor component to conditionally pass operationId or job_descriptor and suppress descriptor-limit alerts for the new mode
- Add isNewMonitoringType selector to detect the use_operation_id_based_descriptors_for_gangs_jobs flag