### PR TITLE
feat(Settings): stage setting is available for users [YTFRONT-5261]

### DIFF
--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/i18n/en.json
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/i18n/en.json
@@ -1,6 +1,11 @@
 {
   "title_queries": "Queries",
   "field_default-aco": "Default ACO",
+  "field_query-tracker-stage": "Query Tracker Stage",
+  "context_query-tracker-stage-description": "Default Query Tracker stage is 'production'. But you can reassign it with this setting.",
+  "context_query-tracker-stage-placeholder": "Enter stage...",
+  "field_yql-agent-stage": "YQL agent stage",
+  "context_yql-agent-stage-placeholder": "Enter YQL agent stage...",
   "field_new-graph-progress": "Use new graph progress",
   "context_new-graph-progress-description": "Enable experimental graph view for Progress tab of a query",
   "field_query-assistant": "Query assistant",

--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/i18n/ru.json
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/i18n/ru.json
@@ -1,6 +1,11 @@
 {
   "title_queries": "Запросы",
   "field_default-aco": "ACO по умолчанию",
+  "field_query-tracker-stage": "Стейдж Query Tracker",
+  "context_query-tracker-stage-description": "По умолчанию стейдж Query Tracker — 'production'. Но вы можете переназначить его в этой настройке.",
+  "context_query-tracker-stage-placeholder": "Введите стейдж...",
+  "field_yql-agent-stage": "Стейдж YQL агента",
+  "context_yql-agent-stage-placeholder": "Введите стейдж YQL агента...",
   "field_new-graph-progress": "Использовать новый граф прогресса",
   "context_new-graph-progress-description": "Включить экспериментальный вид графа для вкладки Прогресс запроса",
   "field_query-assistant": "Помощник по запросам",

--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/index.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/index.tsx
@@ -9,6 +9,8 @@ import {
 import {makeItem, makePage} from '../settings-description';
 import i18n from './i18n';
 import {DefaultAcoSelect} from './DefaultAcoSelect';
+import SettingsMenuInput from '../../SettingsMenu/SettingsMenuInput';
+import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
 
 type Props = {
     cluster: string;
@@ -22,6 +24,27 @@ export const queriesPage = ({cluster, hasQuerySuggestions}: Props) => {
         compact_([
             cluster &&
                 makeItem('defaultACO', i18n('field_default-aco'), undefined, <DefaultAcoSelect />),
+            makeItem(
+                SettingName.QUERY_TRACKER.YQL_AGENT_STAGE,
+                i18n('field_yql-agent-stage'),
+                'top',
+                <SettingsMenuInput
+                    placeholder={i18n('context_yql-agent-stage-placeholder')}
+                    settingName={SettingName.QUERY_TRACKER.YQL_AGENT_STAGE}
+                    settingNS={NAMESPACES.QUERY_TRACKER}
+                />,
+            ),
+            makeItem(
+                SettingName.QUERY_TRACKER.STAGE,
+                i18n('field_query-tracker-stage'),
+                'top',
+                <SettingsMenuInput
+                    placeholder={i18n('context_query-tracker-stage-placeholder')}
+                    description={i18n('context_query-tracker-stage-description')}
+                    settingName={SettingName.QUERY_TRACKER.STAGE}
+                    settingNS={NAMESPACES.QUERY_TRACKER}
+                />,
+            ),
             makeItem(
                 'global::queryTracker::useNewGraphView',
                 i18n('field_new-graph-progress'),

--- a/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
@@ -220,27 +220,6 @@ function useSettings(cluster: string, isAdmin: boolean): Array<SettingsPage> {
                             ]}
                         />,
                     ),
-                makeItem(
-                    SettingName.QUERY_TRACKER.STAGE,
-                    'Query Tracker Stage',
-                    'top',
-                    <SettingsMenuInput
-                        placeholder="Enter stage..."
-                        description="Default Query Tracker stage is 'production'. But you can reassign it with this setting."
-                        settingName={SettingName.QUERY_TRACKER.STAGE}
-                        settingNS={NAMESPACES.QUERY_TRACKER}
-                    />,
-                ),
-                makeItem(
-                    SettingName.QUERY_TRACKER.YQL_AGENT_STAGE,
-                    'YQL agent stage',
-                    'top',
-                    <SettingsMenuInput
-                        placeholder="Enter YQL agent stage..."
-                        settingName={SettingName.QUERY_TRACKER.YQL_AGENT_STAGE}
-                        settingNS={NAMESPACES.QUERY_TRACKER}
-                    />,
-                ),
             ]),
         ),
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/_TMx4-XN7LQG8w
<!-- nda-end -->## Summary by Sourcery

Add new user-configurable stage settings (Query Tracker stage and YQL agent stage) to the Queries page in the Settings panel and clean up redundant definitions.

New Features:
- Expose Query Tracker stage setting in the Settings panel under Queries
- Expose YQL agent stage setting in the Settings panel under Queries

Enhancements:
- Remove duplicate stage setting definitions from settings-description to centralize item creation