### PR TITLE
fix(Queries): graph when switching tabs [YTFRONT-5263]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/Plan/Plan.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/Plan.tsx
@@ -50,7 +50,10 @@ export default React.memo(function Plan({isActive, className, prepareNode}: Plan
                     ) : (
                         <>
                             {newGraphType ? (
-                                <QueriesGraphLazy processedGraph={graph} />
+                                <QueriesGraphLazy
+                                    key={planView === 'graph' ? 'visible' : 'hidden'}
+                                    processedGraph={graph}
+                                />
                             ) : (
                                 <Graph
                                     isActive={isActive && planView === 'graph'}


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Cxu7mtbm7LTANn
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Add conditional key prop to QueriesGraphLazy to ensure the graph re-renders when toggling between views