### PR TITLE
fix(Queries): queries list update problem [YTFRONT-5260]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/index.tsx
@@ -43,7 +43,7 @@ function QueriesHistoryListUpdater() {
     const dispatch = useDispatch();
 
     const updateFn = React.useCallback(() => {
-        dispatch(requestQueriesList());
+        dispatch(requestQueriesList({refresh: true}));
     }, [dispatch]);
 
     useUpdater(updateFn, {timeout: 5000});

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/index.tsx
@@ -37,8 +37,8 @@ export function QueriesList() {
         if (!isInitializedRef.current) {
             isInitializedRef.current = true;
             dispatch(setFilter(DefaultQueriesListFilter[activeTab]));
+            dispatch(requestQueriesList({refresh: true}));
         }
-        dispatch(requestQueriesList());
     }, [dispatch, activeTab]);
 
     const handleTabSelect = (tabId: string) => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryACO/EditQueryACOModal/EditQueryACOModal.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryACO/EditQueryACOModal/EditQueryACOModal.tsx
@@ -26,7 +26,7 @@ export const EditQueryACOModal: FC<Props> = ({query_id}) => {
     const handleSubmit = async (values: FormValues) => {
         try {
             await changeCurrentQueryACO({aco: values.aco, query_id});
-            await dispatch(requestQueriesList());
+            await dispatch(requestQueriesList({refresh: true}));
         } catch (err) {
             setError(err as Error);
             throw err;

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -503,7 +503,7 @@ export function abortCurrentQuery(): ThunkAction<any, RootState, any, SetQueryAc
                 errorTitle: 'Failed to abort query',
             });
             dispatch(loadQuery(currentQuery?.id, {dontReplaceQueryText: true}));
-            dispatch(requestQueriesList());
+            dispatch(requestQueriesList({refresh: true}));
         }
     };
 }
@@ -591,5 +591,5 @@ export const toggleShareQuery =
             type: UPDATE_ACO_QUERY,
             data: {access_control_objects: aco},
         });
-        dispatch(requestQueriesList());
+        dispatch(requestQueriesList({refresh: true}));
     };


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/U7OzKlhK7LWZbT
<!-- nda-end -->## Summary by Sourcery

Fix queries list refresh and pagination by properly resetting the cursor on refresh, merging and sorting items to eliminate duplicates, and explicitly triggering a refresh in all relevant actions and components.

Bug Fixes:
- Reset the pagination cursor when params.refresh is true to ensure fresh data is loaded
- Fix merging of existing and newly fetched queries and sort them by start time to maintain correct order and remove duplicates

Enhancements:
- Refactor requestQueriesList to handle refresh and pagination in separate branches with distinct updateListState payloads
- Update all calls to requestQueriesList in actions and components to pass {refresh: true} for consistent list reloading