### PR TITLE
fix(Queries): engines info problem [YTFRONT-5286]

### DIFF
--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -538,7 +538,7 @@ export type GetQueryTrackerInfoResponse = {
     supported_features: {access_control: boolean; multiple_aco?: boolean};
     clusters?: Array<string>;
     engines_info?: {
-        yql: YqlEnginesInfo;
+        yql?: YqlEnginesInfo;
     };
 };
 

--- a/packages/ui/src/ui/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/ui/src/ui/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 
 import {YTErrorBlock} from '../../components/Block/Block';
 import CompactError from '../CompactError/CompactError';
+import {YTErrorInline} from '../../containers/YTErrorInline/YTErrorInline';
 
 import {rumLogError} from '../../rum/rum-counter';
 import {YTError} from '../../../@types/types';
@@ -14,6 +15,7 @@ export type ErrorBoundaryProps = {
 
     compact?: true;
     maxCompactMessageLength?: number;
+    inline?: boolean;
 
     children: React.ReactNode;
 
@@ -57,7 +59,12 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
 
     render() {
         const {hasError, error} = this.state;
-        const {children, compact, maxCompactMessageLength} = this.props;
+        const {children, compact, maxCompactMessageLength, inline} = this.props;
+
+        if (inline) {
+            return hasError ? <YTErrorInline error={error} /> : children;
+        }
+
         if (compact || maxCompactMessageLength) {
             return hasError ? (
                 <CompactError error={error} maxMessageLength={maxCompactMessageLength} />
@@ -65,6 +72,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
                 children
             );
         }
+
         return hasError ? <YTErrorBlock error={error} /> : children;
     }
 }

--- a/packages/ui/src/ui/hocs/withLazyLoading.tsx
+++ b/packages/ui/src/ui/hocs/withLazyLoading.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 
+import ErrorBoundary, {ErrorBoundaryProps} from '../components/ErrorBoundary/ErrorBoundary';
 import Loader from '../components/Loader/Loader';
-import ErrorBoundary from '../components/ErrorBoundary/ErrorBoundary';
 
 export default function withLazyLoading<P>(
     Component: React.ComponentType<P>,
     fallback?: React.ReactNode,
+    errorBoundaryProps?: Pick<ErrorBoundaryProps, 'inline' | 'compact' | 'maxCompactMessageLength'>,
 ) {
     return function WithSuspense(props: P & React.JSX.IntrinsicAttributes) {
         return (
-            <ErrorBoundary>
+            <ErrorBoundary {...errorBoundaryProps}>
                 <React.Suspense fallback={fallback ?? <Loader visible centered size="l" />}>
                     <Component {...props} />
                 </React.Suspense>

--- a/packages/ui/src/ui/pages/query-tracker/lazy.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/lazy.tsx
@@ -19,4 +19,5 @@ export const QueryTrackerTopRowLazy = withLazyLoading(
         return {default: (await importQT()).QueryTrackerTopRow};
     }),
     '',
+    {inline: true},
 );

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
@@ -46,7 +46,7 @@ export const getAvailableYql = createSelector([selectQueryTrackerInfo], (qtInfo)
 });
 
 export const getDefaultYqlVersion = createSelector([selectQueryTrackerInfo], (qtInfo) => {
-    return qtInfo?.engines_info?.yql.default_yql_ui_version;
+    return qtInfo?.engines_info?.yql?.default_yql_ui_version;
 });
 
 export const isSupportedShareQuery = createSelector(


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/sH72dn6i7LntyK
<!-- nda-end --> ## Summary by Sourcery

Fix errors related to missing engines_info.yql and improve error handling in lazy-loaded components.

Bug Fixes:
- Make engines_info.yql property optional in types and update selectors to guard against undefined yql fields

Enhancements:
- Replace generic ErrorBoundary with LazyLoadingErrorBoundary in the withLazyLoading HOC to render inline errors via YTErrorInline