### PR TITLE
fix(Queries/Tutorials): wrong items in list [YTFRONT-5302]

### DIFF
--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -305,6 +305,7 @@ type QueriesListRequestParams = {
     engine?: string;
     filter?: string;
     state?: string;
+    tutorial_filter?: boolean;
 };
 
 export type ListQueriesParams = ApiMethodParams<QueriesListRequestParams> & {

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesTutorialList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesTutorialList/index.tsx
@@ -7,7 +7,7 @@ import tutorialIcon from '../../../../assets/img/svg/learn.svg';
 import './index.scss';
 import {useSelector} from '../../../../store/redux-hooks';
 import {
-    getQueriesList,
+    getTutorialQueriesList,
     isQueriesListLoading,
 } from '../../../../store/selectors/query-tracker/queriesList';
 
@@ -26,7 +26,7 @@ function renderItem(item: QueryItem) {
 }
 
 export function QueriesTutorialList({className}: {className: string}) {
-    const items = useSelector(getQueriesList);
+    const items = useSelector(getTutorialQueriesList);
     const isLoading = useSelector(isQueriesListLoading);
 
     const [selectedId, goToQuery] = useQueryNavigation();

--- a/packages/ui/src/ui/pages/query-tracker/hooks/Query/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/hooks/Query/index.ts
@@ -5,17 +5,22 @@ import {createQueryUrl} from '../../utils/navigation';
 import {QueryItem} from '../../../../types/query-tracker/api';
 import {getCluster} from '../../../../store/selectors/global';
 import {getQuery} from '../../../../store/selectors/query-tracker/query';
+import {getQueriesListMode} from '../../../../store/selectors/query-tracker/queriesList';
 
 export const useQueryNavigation = (): [QueryItem['id'] | undefined, (id: QueryItem) => void] => {
     const selectedItem = useSelector(getQuery);
     const cluster = useSelector(getCluster);
+    const listMode = useSelector(getQueriesListMode);
     const history = useHistory();
 
     const goToQuery = useCallback(
         (item: QueryItem) => {
-            history.push(createQueryUrl(cluster, item.id));
+            const url = createQueryUrl(cluster, item.id);
+            const searchParams = new URLSearchParams(history.location.search);
+            searchParams.set('listMode', listMode);
+            history.push(`${url}?${searchParams.toString()}`);
         },
-        [cluster, history],
+        [cluster, history, listMode],
     );
 
     return [selectedItem?.id, goToQuery];

--- a/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
@@ -34,6 +34,10 @@ export const getQueriesFilters = (state: RootState) => getQueriesListState(state
 export const getQueriesListMode = (state: RootState) => getQueriesListState(state).listMode;
 export const getQueriesListCursor = (state: RootState) => getQueriesListState(state).cursor;
 
+export const getTutorialQueriesList = createSelector([getQueriesList], (listItems) => {
+    return listItems.filter((item) => item?.is_tutorial);
+});
+
 export const getQueryListByDate = createSelector([getQueriesList], (listItems) => {
     return Object.entries(
         groupBy_(listItems, (item) => moment(item.start_time).format('DD MMMM YYYY')),
@@ -130,11 +134,9 @@ export function getQueriesListFilterParams(state: RootState): QueriesListParams 
         to_time: to,
         state: queryState,
         user,
+        tutorial_filter: is_tutorial,
     };
 
-    if (is_tutorial) {
-        params.filter = `is_tutorial`;
-    }
     return params;
 }
 

--- a/packages/ui/src/ui/types/query-tracker/api.ts
+++ b/packages/ui/src/ui/types/query-tracker/api.ts
@@ -112,6 +112,7 @@ export interface QueryItem extends DraftQuery {
     result_count: number;
     progress?: SingleProgress | CHYTMultiProgress;
     error?: QueryError;
+    is_tutorial?: boolean;
     annotations?: {
         title?: string;
         chartConfig?: VisualizationState;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/limFTRsa7MKrTZ
<!-- nda-end --> ## Summary by Sourcery

Enable dedicated filtering and navigation for tutorial queries by extending QueryItem type with is_tutorial, adding a tutorial-only selector, updating API parameters, and preserving listMode in navigation URLs

New Features:
- Introduce getTutorialQueriesList selector to filter tutorial queries and update QueriesTutorialList component to use it
- Add tutorial_filter parameter to API request params to request tutorial-only queries

Enhancements:
- Preserve listMode as a URL query parameter when navigating to a query