### PR TITLE
chore(Storybook): fix making breakpoints in browser devtools

### DIFF
--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -54,6 +54,7 @@ const config: StorybookConfig = {
             ...config.module,
             rules: uiCoreConfig.module.rules,
         };
+        config.devtool = 'source-map';
 
         return config;
     },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Enable source-map devtool in Storybook configuration to improve breakpoint support in browser devtools