### PR TITLE
feat(Operation/Details/Specification): add cpu_limit/gpu_limit/memory_limit [YTFRONT-5145]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Specification/Specification.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Specification/Specification.js
@@ -22,7 +22,7 @@ import {
     filterVisibleItems,
     prepareVisibleItems,
 } from '../../../../../../utils/operations/tabs/details/specification/specification';
-import hammer from '../../../../../../common/hammer';
+import format from '../../../../../../common/hammer/format';
 
 import './Specification.scss';
 
@@ -136,17 +136,44 @@ export default class Specification extends Component {
         );
     }
 
-    renderScript({type, caption, className, jobCount, environment, files, command, layerPaths}) {
+    renderScript({
+        type,
+        caption,
+        className,
+        jobCount,
+        environment,
+        files,
+        command,
+        layerPaths,
+        cpu_limit,
+        gpu_limit,
+        memory_limit,
+    }) {
         const {cluster} = this.props;
 
         return (
             <div className={specificationBlock('mapper')} key={`${type}/${caption}/${className}`}>
                 <div className={headingBlock({size: 's'})}>
-                    {hammer.format['ReadableField'](caption || type)}
+                    {format['ReadableField'](caption || type)}
                 </div>
 
                 <MetaTable
                     items={[
+                        {
+                            key: 'CPU limit',
+                            value: `${format.Number(cpu_limit)} CPU`,
+                            visible: Boolean(cpu_limit),
+                        },
+                        {
+                            key: 'GPU limit',
+                            value: `${format.Number(gpu_limit)} GPU`,
+                            visible: Boolean(gpu_limit),
+                        },
+                        {
+                            key: 'Memory limit',
+                            value: `${format.Bytes(memory_limit)} RAM`,
+                            visible: Boolean(memory_limit),
+                        },
                         {
                             key: 'class name',
                             value: className,

--- a/packages/ui/src/ui/utils/operations/tabs/details/specification/specification.ts
+++ b/packages/ui/src/ui/utils/operations/tabs/details/specification/specification.ts
@@ -371,6 +371,12 @@ function prepareScript(operation: DetailedOperationSelector, type: string) {
         const files = map_(ypath.getValue(script, '/file_paths'), prepareFile);
         const layerPaths = ypath.getValue(script, '/layer_paths');
 
+        const [cpu_limit, gpu_limit, memory_limit] = ypath.getValues(script, [
+            '/cpu_limit',
+            '/gpu_limit',
+            '/memory_limit',
+        ]);
+
         if (command || className || jobCount || files?.length || environment?.length) {
             return {
                 type: type,
@@ -381,6 +387,9 @@ function prepareScript(operation: DetailedOperationSelector, type: string) {
                 files,
                 environment,
                 layerPaths,
+                cpu_limit,
+                gpu_limit,
+                memory_limit,
             };
         }
     } catch (err) {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/gWXPEeEx7MnCu4
<!-- nda-end --> 

## Summary by Sourcery

Add support for script resource limits by extracting CPU, GPU, and memory limits from operation metadata and rendering them in the specification tab

New Features:
- Display CPU, GPU, and memory limits for operation scripts in the specification tab

Enhancements:
- Extract cpu_limit, gpu_limit, and memory_limit in prepareScript
- Update renderScript to accept and conditionally display the new limit fields
- Replace hammer.format with format in script captions