### PR TITLE
feat: add disableHeavyProxies option to clusters-config [YTFRONT-5176]

### DIFF
--- a/packages/ui/src/server/components/requestsSetup.ts
+++ b/packages/ui/src/server/components/requestsSetup.ts
@@ -29,6 +29,7 @@ export interface YTApiSetup {
     useEncodedParameters: boolean;
     useHeavyProxy: boolean;
     timeout: number;
+    disableHeavyProxies: boolean;
 }
 
 function getClusterSetup(clusterConfig: ClusterConfig): {
@@ -47,6 +48,7 @@ function getClusterSetup(clusterConfig: ClusterConfig): {
             useEncodedParameters: true,
             useHeavyProxy: false,
             timeout: 5000,
+            disableHeavyProxies: clusterConfig?.disableHeavyProxies || false,
         },
         proxyBaseUrl: secure ? `https://${proxy}` : `http://${proxy}`,
     };

--- a/packages/ui/src/server/controllers/yt-api.ts
+++ b/packages/ui/src/server/controllers/yt-api.ts
@@ -89,13 +89,14 @@ export async function ytTvmApiHandler(req: Request, res: Response) {
         const {proxy, secure} = setup;
         const proto = secure ? 'https' : 'http';
         let requestProxy = proxy;
-        if (commandInfo?.heavy && !isLocalCluster) {
+        if (commandInfo?.heavy && !isLocalCluster && !setup.disableHeavyProxies) {
             ctx.log(`Request heavy proxy for command '${params.command}'`);
             const res = await axios.request({
                 method: 'GET',
                 url: `${proto}://${proxy}/hosts`,
                 headers: ctx.getMetadata(),
             });
+
             requestProxy = res.data[0];
         }
 

--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -137,6 +137,8 @@ export interface ClusterConfig {
         disableOptimizationForYTFRONT2838: boolean;
     };
 
+    disableHeavyProxies?: boolean;
+
     uiSettings?: Partial<Pick<UISettings, 'uploadTableExcelBaseUrl' | 'exportTableBaseurl'>>;
 }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Ac-WoJsB7Mwz7N
<!-- nda-end -->## Summary by Sourcery

Introduce a disableHeavyProxies flag in cluster configuration to allow clusters to bypass heavy proxy resolution for commands marked as heavy.

New Features:
- Add disableHeavyProxies option to ClusterConfig to opt out of heavy proxy usage
- Propagate disableHeavyProxies through request setup and conditional proxy selection in ytTvmApiHandler