### PR TITLE
chore: fix locales in date-components

### DIFF
--- a/packages/ui/.eslintrc
+++ b/packages/ui/.eslintrc
@@ -31,6 +31,10 @@
                     "name": "@gravity-ui/dialog-fields",
                     "importNames": ["DFDialog"],
                     "message": "Please use src/components/Dialog instead."
+                },
+                {
+                    "name": "@gravity-ui/date-utils",
+                    "message": "Please use utils/date-utils instead."
                 }
             ]
         }]

--- a/packages/ui/src/ui/components/Timeline/TimelineRuler.tsx
+++ b/packages/ui/src/ui/components/Timeline/TimelineRuler.tsx
@@ -3,11 +3,10 @@ import React, {FC} from 'react';
 import {Button} from '@gravity-ui/uikit';
 
 import cn from 'bem-cn-lite';
-import {dateTimeParse} from '@gravity-ui/date-utils';
 import {RangeDateSelection, RangeDateSelectionProps} from '@gravity-ui/date-components';
+import {DateTime, dateTimeParse} from '../../utils/date-utils';
 
 import './TimelineRuler.scss';
-import {DateTime} from '@gravity-ui/date-utils/build/typings/dateTime';
 
 const b = cn('yc-timeline-ruler');
 

--- a/packages/ui/src/ui/i18n/configure.ts
+++ b/packages/ui/src/ui/i18n/configure.ts
@@ -1,0 +1,31 @@
+export enum Lang {
+    Ru = 'ru',
+    En = 'en',
+}
+
+interface Config {
+    lang?: Lang;
+}
+
+type Subscriber = (config: Config) => void;
+
+let config: Config = {};
+let subscribers: Subscriber[] = [];
+
+export const configure = (newConfig: Config) => {
+    if (newConfig) {
+        config = {...config, ...newConfig};
+        subscribers.forEach((sub) => sub(config));
+    }
+};
+
+export const subscribeConfigure = (sub: Subscriber): (() => void) => {
+    subscribers.push(sub);
+    sub(config);
+
+    return () => {
+        subscribers = subscribers.filter((el) => el === sub);
+    };
+};
+
+export const getConfig = () => config;

--- a/packages/ui/src/ui/i18n/index.ts
+++ b/packages/ui/src/ui/i18n/index.ts
@@ -1,18 +1,18 @@
 import moment from 'moment';
 
-import {configure} from '@gravity-ui/uikit';
 import {I18N, KeyData, KeysData} from '@gravity-ui/i18n';
 
 import type {AppLang} from '../../shared/constants/settings-types';
+import {Lang, configure} from './configure';
 
 export const i18n = new I18N({lang: 'en', fallbackLang: 'en'});
 
-configure({lang: 'en'});
+configure({lang: Lang.En});
 ytSetLang('en');
 
 export function ytSetLang(lang: AppLang) {
     i18n.setLang(lang);
-    configure({lang});
+    configure({lang: lang === 'en' ? Lang.En : Lang.Ru});
 
     moment.updateLocale(lang, {
         week: {

--- a/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
+++ b/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
@@ -16,7 +16,7 @@ import {absolute} from '../../../common/utils/url';
 
 import hammer from '../../../common/hammer';
 
-import {dateTime} from '@gravity-ui/date-utils';
+import {dateTime} from '../../../utils/date-utils';
 
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsTimeline/TimeLineHeader.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsTimeline/TimeLineHeader.tsx
@@ -11,9 +11,8 @@ import {
     setFilter,
     setInterval,
 } from '../../../../../store/reducers/operations/jobs/jobs-timeline-slice';
-import {dateTimeParse} from '@gravity-ui/date-utils';
+import {DateTime, dateTimeParse} from '../../../../../utils/date-utils';
 import {RangeDateSelection} from '@gravity-ui/date-components';
-import {DateTime} from '@gravity-ui/date-utils/build/typings/dateTime';
 import ChevronsExpandToLinesIcon from '@gravity-ui/icons/svgs/chevrons-expand-to-lines.svg';
 import {resetInterval} from '../../../../../store/actions/operations/jobs-timeline';
 

--- a/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsArchiveFilter.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsArchiveFilter.tsx
@@ -3,7 +3,7 @@ import cn from 'bem-cn-lite';
 import {DatePicker} from '@gravity-ui/date-components';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {RootState} from '../../../../store/reducers';
-import {dateTimeParse} from '@gravity-ui/date-utils';
+import {dateTimeParse} from '../../../../utils/date-utils';
 import {showArchiveOperations, showCurrentOperations} from '../../../../store/actions/operations';
 import {OPERATIONS_DATA_MODE} from '../../../../constants/operations';
 

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryDateFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryDateFilter.tsx
@@ -2,7 +2,7 @@ import React, {FC, useMemo} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {getQueriesFilters} from '../../../../store/selectors/query-tracker/queriesList';
 import {DatePicker} from '@gravity-ui/date-components';
-import {DateTime, dateTime} from '@gravity-ui/date-utils';
+import {DateTime, dateTimeParse} from '../../../../utils/date-utils';
 import {Flex} from '@gravity-ui/uikit';
 import {applyFilter} from '../../../../store/actions/query-tracker/queriesList';
 
@@ -27,7 +27,7 @@ export const QueryDateFilter: FC = () => {
             <DatePicker
                 placeholder="Start date"
                 format="DD.MM.YYYY"
-                value={from ? dateTime({input: from}) : null}
+                value={from ? dateTimeParse({input: from}) : null}
                 onUpdate={setFilter.from}
                 hasClear
             />{' '}
@@ -35,7 +35,7 @@ export const QueryDateFilter: FC = () => {
             <DatePicker
                 placeholder="End date"
                 format="DD.MM.YYYY"
-                value={to ? dateTime({input: to}) : null}
+                value={to ? dateTimeParse({input: to}) : null}
                 onUpdate={setFilter.to}
                 hasClear
             />

--- a/packages/ui/src/ui/store/api/dashboard2/queries/queries.ts
+++ b/packages/ui/src/ui/store/api/dashboard2/queries/queries.ts
@@ -1,4 +1,3 @@
-import {dateTimeParse} from '@gravity-ui/date-utils';
 import map_ from 'lodash/map';
 
 import format from '../../../../common/hammer/format';
@@ -10,6 +9,7 @@ import {QueryStatus} from '../../../../types/query-tracker';
 import {QueriesListResponse} from '../../../../types/query-tracker/api';
 import {YTError} from '../../../../types';
 import {UNKNOWN_ITEM_NAME} from '../../../../constants/dashboard2';
+import {dateTimeParse} from '../../../../utils/date-utils';
 
 type FetchQueriesArgs = {
     cluster: string;

--- a/packages/ui/src/ui/store/selectors/operations/incarnations.ts
+++ b/packages/ui/src/ui/store/selectors/operations/incarnations.ts
@@ -1,4 +1,3 @@
-import {dateTimeParse} from '@gravity-ui/date-utils';
 import {createSelector} from '@reduxjs/toolkit';
 
 import {YTError} from '../../../../@types/types';
@@ -12,6 +11,7 @@ import {getIncarnations} from '../../../store/api/yt';
 import {OperationSelector, OperationStates} from '../../../pages/operations/selectors';
 import {ViewState} from '../../../components/StatusLabel/StatusLabel';
 import {formatInterval} from '../../../components/common/Timeline';
+import {dateTimeParse} from '../../../utils/date-utils';
 
 import {getOperation} from './operation';
 

--- a/packages/ui/src/ui/utils/date-utils.ts
+++ b/packages/ui/src/ui/utils/date-utils.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-restricted-imports */
+import {settings} from '@gravity-ui/date-utils';
+import {subscribeConfigure} from '../i18n/configure';
+export * from '@gravity-ui/date-utils';
+
+settings.loadLocale('ru');
+settings.loadLocale('en');
+
+subscribeConfigure((config) => {
+    if (config?.lang) {
+        settings.loadLocale(config.lang);
+    }
+});


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/UGfq9heq7N54gM
<!-- nda-end -->            ## Summary by Sourcery

Centralize date utility imports by adding a local date-utils wrapper that initializes required locales and updating components to use it

Enhancements:
- Introduce a local date-utils module that re-exports @gravity-ui/date-utils and preloads the ru and en locales
- Refactor components to import DateTime, dateTime, and dateTimeParse from the new local date-utils module instead of the original package