### PR TITLE
fix(Navigation): correct operation reference in metadata [YTFRONT-5193]

### DIFF
--- a/packages/ui/src/ui/components/MetaTable/presets/main.js
+++ b/packages/ui/src/ui/components/MetaTable/presets/main.js
@@ -9,24 +9,30 @@ import {Flex, Icon, Label, Link} from '@gravity-ui/uikit';
 import AbbrSqlIcon from '@gravity-ui/icons/svgs/abbr-sql.svg';
 
 export default function metaTablePresetMain(attributes) {
-    const [id, owner, account, creationTime, modificationTime, accessTime, yql_op_id, yql_op_url] =
-        ypath.getValues(attributes, [
-            '/id',
-            '/owner',
-            '/account',
-            '/creation_time',
-            '/modification_time',
-            '/access_time',
-            '/_yql_op_id',
-            '/_yql_op_url',
-        ]);
+    const [
+        id,
+        owner,
+        account,
+        creationTime,
+        modificationTime,
+        accessTime,
+        yql_op_id,
+        operationUrl,
+        yql_runner,
+    ] = ypath.getValues(attributes, [
+        '/id',
+        '/owner',
+        '/account',
+        '/creation_time',
+        '/modification_time',
+        '/access_time',
+        '/_yql_op_id',
+        '/_yql_op_url',
+        '/_yql_runner',
+    ]);
 
-    const qtUrl = yql_op_url;
-
-    const yqlLink =
-        yql_op_id && !yql_op_url
-            ? UIFactory.yqlWidgetSetup?.renderYqlOperationLink(yql_op_id)
-            : null;
+    const isYqlOperation = yql_runner === 'yql-service';
+    const yqlLink = yql_op_id ? UIFactory.yqlWidgetSetup?.renderYqlOperationLink(yql_op_id) : null;
 
     return [
         {
@@ -61,12 +67,12 @@ export default function metaTablePresetMain(attributes) {
         {
             key: 'YQL operation',
             value: yqlLink,
-            visible: Boolean(yqlLink),
+            visible: Boolean(yqlLink) && isYqlOperation,
         },
         {
             key: 'QT operation',
             value: (
-                <Link href={qtUrl} target="_blank">
+                <Link href={operationUrl} target="_blank">
                     <Flex alignItems="center" gap={1}>
                         <Label theme="info">
                             <Flex alignItems="center" justifyContent="center">
@@ -77,7 +83,7 @@ export default function metaTablePresetMain(attributes) {
                     </Flex>
                 </Link>
             ),
-            visible: Boolean(qtUrl),
+            visible: !isYqlOperation && Boolean(operationUrl),
         },
     ];
 }

--- a/packages/ui/src/ui/store/actions/navigation/index.ts
+++ b/packages/ui/src/ui/store/actions/navigation/index.ts
@@ -271,6 +271,7 @@ const attributesToLoad = [
     '_yql_key_meta',
     '_yql_op_id',
     '_yql_op_url',
+    '_yql_runner',
     '_yql_row_spec',
     '_yql_subkey_meta',
     '_yql_type',


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/-sxnfxFb7NHaLn
<!-- nda-end -->## Summary by Sourcery

Load the _yql_runner attribute and use it to distinguish between YQL and QT operations in the meta table, correct the URL references, and update visibility logic for operation links.

Bug Fixes:
- Fix the operation link references by using a unified operationUrl variable
- Ensure only YQL operations show when runner is 'yql-service' and only QT operations show otherwise

Enhancements:
- Extract and load the _yql_runner attribute in navigation actions
- Simplify yqlLink rendering to rely solely on the presence of yql_op_id