### PR TITLE
fix(Queries): make settings correct type [YTFRONT-5351]

### DIFF
--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -24,6 +24,7 @@ import {CancelTokenSource} from 'axios';
 import {JSONSerializer} from '../../../common/yt-api';
 import {createTablePrompt} from '../../../pages/query-tracker/Navigation/helpers/createTableSelect';
 import {getQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
+import {convertSettingsTypes} from '../../../utils/query-tracker/convertSettingsTypes';
 import type {
     DraftQuery,
     QueriesListRequestParams,
@@ -195,6 +196,8 @@ export function startQuery(
             access_control_object,
         } = queryInstance;
 
+        const processedSettings = engine === 'spyt' ? convertSettingsTypes(settings) : settings;
+
         return ytApiV4Id.startQuery(YTApiId.startQuery, {
             parameters: {
                 stage,
@@ -206,7 +209,7 @@ export function startQuery(
                 ...(isMultipleAco ? {access_control_objects} : {access_control_object}),
                 settings: {
                     stage: engine === 'yql' ? yqlAgentStage : undefined,
-                    ...settings,
+                    ...processedSettings,
                     execution_mode: options?.execution_mode,
                 },
                 output_format: 'json',

--- a/packages/ui/src/ui/utils/query-tracker/convertSettingsTypes.ts
+++ b/packages/ui/src/ui/utils/query-tracker/convertSettingsTypes.ts
@@ -1,0 +1,44 @@
+export function convertSettingsTypes(
+    settings?: Record<string, unknown>,
+): Record<string, string | number | boolean> {
+    if (!settings) {
+        return {};
+    }
+
+    const converted: Record<string, string | number | boolean> = {};
+
+    for (const [key, value] of Object.entries(settings)) {
+        if (typeof value === 'number' || typeof value === 'boolean') {
+            converted[key] = value;
+            continue;
+        }
+
+        if (typeof value !== 'string') {
+            continue;
+        }
+
+        const trimmedValue = value.trim();
+
+        const lowerValue = trimmedValue.toLowerCase();
+        if (lowerValue === 'true') {
+            converted[key] = true;
+            continue;
+        }
+        if (lowerValue === 'false') {
+            converted[key] = false;
+            continue;
+        }
+
+        if (trimmedValue !== '' && !isNaN(Number(trimmedValue))) {
+            const numValue = Number(trimmedValue);
+            if (isFinite(numValue)) {
+                converted[key] = numValue;
+                continue;
+            }
+        }
+
+        converted[key] = value;
+    }
+
+    return converted;
+}


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/iPGPYduR7NWxGf
<!-- nda-end -->## Summary by Sourcery

Ensure query settings are sent to the backend with correctly typed values instead of raw strings.

Bug Fixes:
- Convert string-based query settings into boolean or numeric types before starting a query to avoid type mismatches with the API.

Enhancements:
- Extract settings type conversion into a reusable utility for query tracker settings handling.