### PR TITLE
fix(Scheduling): returned filtering when selecting a pool tree [YTFRO…

### DIFF
--- a/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
@@ -185,7 +185,7 @@ function SchedulingPhysicalTree() {
         <div className={block('tree')}>
             <Select
                 value={[tree]}
-                filterable={treeItems?.length <= 5}
+                filterable={treeItems?.length >= 5}
                 options={treeItems}
                 onUpdate={(vals) => onChange(vals[0])}
                 className={block('path-tree')}


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/ugwlCVPM7Nh8ub
<!-- nda-end -->…NT-5363]

## Summary by Sourcery

Bug Fixes:
- Restore correct filter behavior for the pool tree selector so filtering is enabled when there are at least five items.