### PR TITLE
fix(JobLogs): use cluster config [YTFRONT-5348]

### DIFF
--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -41,6 +41,8 @@ export interface ClusterUiConfig {
         url_template: string;
     };
     tablet_errors_base_url?: string;
+    job_log_viewer_base_url?: string;
+    job_log_viewer_tvm_key?: 'jobLog' | 'jobLogTest';
 }
 
 export type CypressNodeRaw<AttributesT extends Record<string, unknown>, ValueT> =


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/loZZhe-97NhRfT
<!-- nda-end --> ## Summary by Sourcery

Extend cluster UI configuration to support job log viewer settings.

New Features:
- Add optional job_log_viewer_base_url to cluster UI configuration.
- Add optional job_log_viewer_tvm_key to cluster UI configuration for selecting the TVM client.