### PR TITLE
fix attributes-editor: allow modifying tablet cell bundle attribute for replicated tables

### DIFF
--- a/packages/ui/src/ui/store/actions/navigation/modals/attributes-editor.tsx
+++ b/packages/ui/src/ui/store/actions/navigation/modals/attributes-editor.tsx
@@ -157,7 +157,7 @@ export function navigationSetNodeAttributes(
                 const newAttrs = {...restGeneralAttrs, ...storageAttrs};
                 const type = ypath.getValue(attrs, '/@type');
                 const isDynamic = ypath.getValue(attrs, '/@dynamic');
-                const isDynTable = type === 'table' && isDynamic;
+                const isDynTable = ['table', 'replicated_table'].includes(type) && isDynamic;
                 if (in_memory_mode !== undefined && isDynTable) {
                     Object.assign(newAttrs, {in_memory_mode});
                 }


### PR DESCRIPTION
Commit 2757be5 allows it to display "tablet cell bundle" attribute in attributes editor dialog. However, it does nothing on submit when this attribute is changed.

This PR addresses and fixes this issue.

## Summary by Sourcery

Bug Fixes:
- Ensure dynamic replicated tables are treated like dynamic tables when applying in-memory-related attribute updates from the attributes editor.