### PR TITLE
feat(Operations/Job): add gpu perforator [YTFRONT-5201]

### DIFF
--- a/packages/javascript-wrapper/lib/commands/v4.js
+++ b/packages/javascript-wrapper/lib/commands/v4.js
@@ -255,4 +255,9 @@ module.exports = {
         method: 'POST',
         dataType: 'json',
     },
+    runJobShellCommand: {
+        name: 'run_job_shell_command',
+        method: 'POST',
+        dataType: 'json',
+    },
 };

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -13,7 +13,7 @@
         "@gravity-ui/expresskit": "^2.2.0",
         "@gravity-ui/i18n": "^1.8.0",
         "@gravity-ui/nodekit": "^2.2.1",
-        "@ytsaurus/javascript-wrapper": "^0.15.1",
+        "@ytsaurus/javascript-wrapper": "^0.16.0",
         "axios": "^1.8.4",
         "cacheable-lookup": "^6.1.0",
         "cookie-parser": "1.4.6",
@@ -12713,9 +12713,9 @@
       }
     },
     "node_modules/@ytsaurus/javascript-wrapper": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@ytsaurus/javascript-wrapper/-/javascript-wrapper-0.15.1.tgz",
-      "integrity": "sha512-rPxu0eCz1k0IqgvGEHiCBvdOmC/ySHOdAIpO+tjKDOAg/4uXbdHKVMAebwWO5dSQv8IGlvO0mcrNgv+NCRIEMg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@ytsaurus/javascript-wrapper/-/javascript-wrapper-0.16.0.tgz",
+      "integrity": "sha512-LSN+FghNt8xYRAVul8HyRFnANhkdMOVOUE5mCBhGgH2pGkaPD+jU8lHGxJjFhcPpmfUsoaOvkbQcZmYlc0pmFA==",
       "license": "Apache License 2.0",
       "dependencies": {
         "axios": "^0.21.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,7 +76,7 @@
     "@gravity-ui/expresskit": "^2.2.0",
     "@gravity-ui/i18n": "^1.8.0",
     "@gravity-ui/nodekit": "^2.2.1",
-    "@ytsaurus/javascript-wrapper": "^0.15.1",
+    "@ytsaurus/javascript-wrapper": "^0.16.0",
     "axios": "^1.8.4",
     "cacheable-lookup": "^6.1.0",
     "cookie-parser": "1.4.6",

--- a/packages/ui/src/server/controllers/yt-api.ts
+++ b/packages/ui/src/server/controllers/yt-api.ts
@@ -24,7 +24,12 @@ interface CommandConfig {
 
 const YT_API_REQUEST_ID_HEADER_LOWER = YT_API_REQUEST_ID_HEADER.toLowerCase();
 
-const YT_KNOWN_COMMANDS = new Set(['get_job_stderr', 'get_job_input', 'get_job_fail_context']);
+const YT_KNOWN_COMMANDS = new Set([
+    'get_job_stderr',
+    'get_job_input',
+    'get_job_fail_context',
+    'run_job_shell_command',
+]);
 
 const supportedCommands: Record<string, Map<string, CommandConfig>> = yt.getSupportedCommands();
 

--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -43,6 +43,7 @@ export interface ClusterUiConfig {
     tablet_errors_base_url?: string;
     job_log_viewer_base_url?: string;
     job_log_viewer_tvm_key?: 'jobLog' | 'jobLogTest';
+    gpu_profiler_command?: string;
 }
 
 export type CypressNodeRaw<AttributesT extends Record<string, unknown>, ValueT> =

--- a/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
+++ b/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
@@ -24,7 +24,6 @@ import {RootState} from '../../../store/reducers';
 import {Page} from '../../../constants/index';
 
 import {TabSettings, makeTabProps} from '../../../utils';
-import {formatByParams} from '../../../../shared/utils/format';
 
 import hammer from '../../../common/hammer';
 import {RouteInfo} from '../Job';
@@ -33,7 +32,7 @@ import {ClickableText} from '../../../components/ClickableText/ClickableText';
 import ChartLink from '../../../components/ChartLink/ChartLink';
 import {getJob} from '../../../store/selectors/job/detail';
 import ClipboardButton from '../../../components/ClipboardButton/ClipboardButton';
-import {getCluster, getClusterUiConfig} from '../../../store/selectors/global';
+import {getCluster} from '../../../store/selectors/global';
 import UIFactory from '../../../UIFactory';
 import {StaleJobIcon} from '../../../pages/operations/OperationDetail/tabs/Jobs/StaleJobIcon';
 import {Host} from '../../../containers/Host/Host';
@@ -41,6 +40,7 @@ import {Host} from '../../../containers/Host/Host';
 import './JobGeneral.scss';
 import {UI_TAB_SIZE} from '../../../constants/global';
 import {YsonDownloadButton} from '../../../components/DownloadAttributesButton';
+import {useJobProfilingUrl} from './hooks/useJobProfilingUrl';
 
 const block = cn('job-general');
 
@@ -286,6 +286,7 @@ export default function JobGeneral() {
                             {
                                 key: 'Job trace',
                                 value: (
+                                    //
                                     <Link target="_blank" href={traceUrl!}>
                                         {traceTitle}
                                     </Link>
@@ -351,36 +352,4 @@ export default function JobGeneral() {
             </div>
         </ErrorBoundary>
     );
-}
-
-function useJobProfilingUrl({
-    operationId,
-    jobId,
-    pool_tree,
-    has_trace,
-    cluster,
-}: {
-    operationId?: string;
-    jobId?: string;
-    cluster: string;
-    has_trace?: boolean;
-    pool_tree?: string;
-}) {
-    const {job_trace_url_template: {url_template, title = 'Open trace', enforce_for_trees} = {}} =
-        useSelector(getClusterUiConfig);
-    return React.useMemo(() => {
-        const allowTrace = has_trace || 0 <= enforce_for_trees?.indexOf(pool_tree!)!;
-
-        if (!allowTrace || !cluster || !operationId || !jobId || !url_template) {
-            return {};
-        }
-        return {
-            url: formatByParams(url_template, {
-                operationId,
-                jobId,
-                cluster,
-            }),
-            title,
-        };
-    }, [cluster, operationId, jobId, url_template, title, enforce_for_trees, pool_tree, has_trace]);
 }

--- a/packages/ui/src/ui/pages/job/JobGeneral/hooks/useIsGpuProfilerAvailable.ts
+++ b/packages/ui/src/ui/pages/job/JobGeneral/hooks/useIsGpuProfilerAvailable.ts
@@ -1,0 +1,39 @@
+import {useEffect, useState} from 'react';
+
+import ypath from '../../../../common/thor/ypath';
+import {ytApiV3} from '../../../../rum/rum-wrap-api';
+import {JobState} from '../../../../types/operations/job';
+
+type Props = (data: {operationId?: string; jobState?: JobState}) => boolean;
+
+export const useIsGpuProfilerAvailable: Props = ({operationId, jobState}) => {
+    const [isAvailable, setIsAvailable] = useState(false);
+    const isJobRunning = jobState === 'running';
+
+    useEffect(() => {
+        if (!operationId || !isJobRunning) {
+            setIsAvailable(false);
+            return;
+        }
+
+        ytApiV3
+            .getOperation({
+                parameters: {
+                    operation_id: operationId,
+                    attributes: ['full_spec'],
+                },
+            })
+            .then((operation) => {
+                const kinetoConfig = ypath.getValue(
+                    operation,
+                    '/full_spec/cuda_profiler_environment_variables/KINETO_CONFIG',
+                );
+                setIsAvailable(Boolean(kinetoConfig));
+            })
+            .catch(() => {
+                setIsAvailable(false);
+            });
+    }, [operationId, isJobRunning]);
+
+    return isAvailable;
+};

--- a/packages/ui/src/ui/pages/job/JobGeneral/hooks/useJobProfilingUrl.ts
+++ b/packages/ui/src/ui/pages/job/JobGeneral/hooks/useJobProfilingUrl.ts
@@ -1,0 +1,36 @@
+import {useMemo} from 'react';
+import {useSelector} from '../../../../store/redux-hooks';
+import {getClusterUiConfig} from '../../../../store/selectors/global';
+import {formatByParams} from '../../../../../shared/utils/format';
+
+export const useJobProfilingUrl = ({
+    operationId,
+    jobId,
+    pool_tree,
+    has_trace,
+    cluster,
+}: {
+    operationId?: string;
+    jobId?: string;
+    cluster: string;
+    has_trace?: boolean;
+    pool_tree?: string;
+}) => {
+    const {job_trace_url_template: {url_template, title = 'Open trace', enforce_for_trees} = {}} =
+        useSelector(getClusterUiConfig);
+    return useMemo(() => {
+        const allowTrace = has_trace || 0 <= enforce_for_trees?.indexOf(pool_tree!)!;
+
+        if (!allowTrace || !cluster || !operationId || !jobId || !url_template) {
+            return {};
+        }
+        return {
+            url: formatByParams(url_template, {
+                operationId,
+                jobId,
+                cluster,
+            }),
+            title,
+        };
+    }, [cluster, operationId, jobId, url_template, title, enforce_for_trees, pool_tree, has_trace]);
+};

--- a/packages/ui/src/ui/pages/job/JobGeneral/hooks/useRunJobShellCommand.ts
+++ b/packages/ui/src/ui/pages/job/JobGeneral/hooks/useRunJobShellCommand.ts
@@ -1,0 +1,56 @@
+import {useCallback, useState} from 'react';
+
+import {ytApiV4} from '../../../../rum/rum-wrap-api';
+import {toaster} from '../../../../utils/toaster';
+import {showErrorPopup} from '../../../../utils/utils';
+import {YTError} from '../../../../types';
+
+type Props = (data: {jobId?: string; command?: string; shellName?: string}) => {
+    run: () => void;
+    loading: boolean;
+    error: YTError | null;
+};
+
+export const useRunJobShellCommand: Props = ({jobId, command, shellName}) => {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<YTError | null>(null);
+
+    const run = useCallback(() => {
+        if (!jobId || !command) {
+            return;
+        }
+
+        setLoading(true);
+        setError(null);
+
+        ytApiV4
+            .runJobShellCommand({
+                job_id: jobId,
+                command,
+                ...(shellName && {shell_name: shellName}),
+            })
+            .then((response: unknown) => {
+                console.log('runJobShellCommand result:', response);
+            })
+            .catch((err: YTError) => {
+                setError(err);
+                toaster.add({
+                    theme: 'danger',
+                    name: 'run-job-shell-command',
+                    autoHiding: false,
+                    content: err?.message || 'Oops, something went wrong',
+                    title: 'Failed to run job shell command',
+                    actions: [{label: 'Details', onClick: () => showErrorPopup(err)}],
+                });
+            })
+            .finally(() => {
+                setLoading(false);
+            });
+    }, [jobId, command, shellName]);
+
+    return {
+        run,
+        loading,
+        error,
+    };
+};


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/1Jo_RGcc7Tfz5h
<!-- nda-end -->## Summary by Sourcery

Add GPU profiling trigger to job details and wire it to a new backend shell command API.

New Features:
- Expose a GPU perforator button in the job general page when GPU profiling is available.
- Introduce hooks to detect GPU profiler availability and to trigger running a shell command for a job.

Enhancements:
- Refactor job profiling URL logic into a dedicated reusable hook.
- Extend the server YT API controller and JS wrapper to support the run_job_shell_command endpoint.

Build:
- Bump @ytsaurus/javascript-wrapper dependency to a newer version that supports the new command.