### PR TITLE
feat(Navigation): include tab title in document title

### DIFF
--- a/packages/ui/src/ui/pages/navigation/Navigation/Navigation.js
+++ b/packages/ui/src/ui/pages/navigation/Navigation/Navigation.js
@@ -132,7 +132,7 @@ class Navigation extends Component {
             updateView({trackVisit: true});
         }
 
-        if (this.props.parsedPath !== prevProps.parsedPath) {
+        if (this.props.parsedPath !== prevProps.parsedPath || this.props.mode !== prevProps.mode) {
             this.updateTitleWithPath();
         }
     }
@@ -142,8 +142,13 @@ class Navigation extends Component {
     }
 
     updateTitleWithPath() {
-        const {parsedPath, updateTitle} = this.props;
-        updateTitle({path: parsedPath ? parsedPath.getKey() : ''});
+        const {parsedPath, updateTitle, mode, tabs} = this.props;
+        let page = 'Navigation';
+        const tab = mode !== 'content' && tabs.find((tab) => tab.value === mode);
+        if (tab) {
+            page = tab.text || hammer.format['ReadableField'](mode);
+        }
+        updateTitle({path: parsedPath ? parsedPath.getKey() : '', page});
     }
 
     get items() {


### PR DESCRIPTION
We updated `document.title` generation: from `"{path} - Navigation - {cluster}"` to `"{path} - {tab title} - {cluster}"`.   This improves UX by making the page title more contextual and improves Analytics reporting for better segmentation.

## Summary by Sourcery

Enhancements:
- Derive the document title page segment from the selected navigation tab instead of using a fixed label, falling back to a readable mode name when needed.