### PR TITLE
fix(Operation): controller in terminal stages [YTFRONT-5573]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -39,7 +39,7 @@ import {DEFAULT_TAB, type OperationTabType, Tab} from '../../../constants/operat
 import {useUpdater} from '../../../hooks/use-updater';
 import {promptAction} from '../../../store/actions/actions';
 import {showEditPoolsWeightsModal} from '../../../store/actions/operations';
-import {getOperation} from '../../../store/actions/operations/detail';
+import {getOperation, updateOperation} from '../../../store/actions/operations/detail';
 import {
     selectIsOperationInGpuTree,
     selectOperationDetailsLoadingStatus,
@@ -90,7 +90,7 @@ function OperationDetailUpdater({operationId}: {operationId: string}) {
     const dispatch = useDispatch();
 
     const updateFn = React.useCallback(() => {
-        dispatch(getOperation(operationId));
+        dispatch(updateOperation(operationId));
     }, [dispatch, operationId]);
 
     useUpdater(updateFn, {timeout: 15 * 1000});

--- a/packages/ui/src/ui/store/actions/operations/detail.ts
+++ b/packages/ui/src/ui/store/actions/operations/detail.ts
@@ -20,25 +20,22 @@ import {
     LOAD_RESOURCE_USAGE,
     OPERATION_DETAIL_PARTIAL,
 } from '../../../constants/operations/detail';
-import {TYPED_OUTPUT_FORMAT} from '../../../constants/index';
 import {DetailedOperationSelector} from '../../../pages/operations/selectors';
 import {checkUserTransaction, prepareActions} from '../../../utils/operations/detail';
 import {prepareAttributes} from '../../../utils';
 import {showErrorPopup, wrapApiPromiseByToaster} from '../../../utils/utils';
 import {isOperationId} from '../../../utils/operations/list';
-import CancelHelper from '../../../utils/cancel-helper';
 import {YTErrors} from '../../../rum/constants';
-import {YTApiId, ytApiV3, ytApiV3Id} from '../../../rum/rum-wrap-api';
+import {YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
 import {getJobsMonitoringDescriptors} from '../../../store/actions/operations/jobs-monitor';
 
 import {selectCluster} from '../../../store/selectors/global';
 import {type RootState} from './../../../store/reducers';
 import {type OperationDetailActionType} from '../../reducers/operations/detail';
-import {JSONSerializer} from '../../../common/yt-api';
 import {toaster} from '../../../utils/toaster';
+import {isFinalState} from '../../../pages/operations/OperationDetail/tabs/JobsTimeline/helpers/isFinalState';
 import i18n from './i18n';
-
-const operationDetailsRequests = new CancelHelper();
+import {loadOperationAttributes} from './helpers/loadOperationAttributes';
 
 function loadIntermediateResourceUsage(
     operation: unknown,
@@ -75,24 +72,30 @@ function loadIntermediateResourceUsage(
     };
 }
 
+export function updateOperation(
+    id: string,
+): ThunkAction<Promise<void>, RootState, unknown, OperationDetailActionType> {
+    return (dispatch, getState) => {
+        const state = getState();
+        const {$value: operationId, state: operationState} = state.operations.detail.operation;
+
+        if (id === operationId && isFinalState(operationState)) {
+            return Promise.resolve();
+        }
+
+        return dispatch(getOperation(id));
+    };
+}
+
 export function getOperation(
     id: string,
 ): ThunkAction<Promise<void>, RootState, unknown, OperationDetailActionType> {
     return (dispatch, getState) => {
         const isAlias = !isOperationId(id);
 
-        const params = Object.assign(
-            {
-                include_scheduler: true,
-                output_format: TYPED_OUTPUT_FORMAT,
-            },
-            isAlias ? {operation_alias: id} : {operation_id: id},
-        );
-
         dispatch({type: GET_OPERATION.REQUEST, data: {isAlias, id}});
 
-        return ytApiV3
-            .getOperation({parameters: params, setup: {JSONSerializer}}, operationDetailsRequests)
+        return loadOperationAttributes(id, isAlias)
             .then(checkUserTransaction)
             .then(([operationAttributes, userTransactionAlive]) => {
                 const preparedAttributes = prepareAttributes(operationAttributes);

--- a/packages/ui/src/ui/store/actions/operations/helpers/loadOperationAttributes.ts
+++ b/packages/ui/src/ui/store/actions/operations/helpers/loadOperationAttributes.ts
@@ -1,0 +1,29 @@
+import {TYPED_OUTPUT_FORMAT} from '../../../../constants';
+import {JSONSerializer} from '../../../../common/yt-api';
+import {isFinalState} from '../../../../pages/operations/OperationDetail/tabs/JobsTimeline/helpers/isFinalState';
+import {ytApiV3} from '../../../../rum/rum-wrap-api';
+import CancelHelper from '../../../../utils/cancel-helper';
+
+const operationDetailsRequests = new CancelHelper();
+
+export const loadOperationAttributes = async (id: string, isAlias: boolean) => {
+    const {id: operationId, state} = await ytApiV3.getOperation({
+        parameters: {
+            ...(isAlias ? {operation_alias: id, include_runtime: true} : {operation_id: id}),
+            attributes: ['id', 'state'],
+        },
+        cancellation: operationDetailsRequests.removeAllAndSave,
+    });
+
+    const includeScheduler = Boolean(state) && !isFinalState(state);
+
+    return ytApiV3.getOperation({
+        parameters: {
+            operation_id: operationId,
+            includeScheduler,
+            output_format: TYPED_OUTPUT_FORMAT,
+        },
+        setup: {JSONSerializer},
+        cancellation: operationDetailsRequests.removeAllAndSave,
+    });
+};

--- a/packages/ui/tests/screenshots/pages/operations/operations.base.screen.ts
+++ b/packages/ui/tests/screenshots/pages/operations/operations.base.screen.ts
@@ -88,7 +88,6 @@ test('Operation - Statistics', async ({page}) => {
     await operationsPage(page).waitForFixedBoundingClientRect('.operations', {iterationDelay: 500});
     await operationsPage(page).replaceMetaData();
 
-    await page.waitForLoadState('networkidle');
     await page.mouse.wheel(0, -1000); // scroll back for autofocused offset
     await operationsPage(page).waitForFixedTableColumnWidths('.operation-statistics__table');
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Ilxxoodc7WenBE
<!-- nda-end -->           ## Summary by Sourcery

Optimize loading of operation details to avoid unnecessary scheduler data requests for terminal operations and reduce redundant polling for already-resolved operations.

Bug Fixes:
- Prevent repeated full operation reloads in terminal states and for resolved operation aliases.

Enhancements:
- Add conditional logic to fetch lightweight operation state first and only include scheduler data when needed.
- Refine periodic operation detail updater to skip fetching data for terminal or already-loaded operations.
- Define shared terminal operation states constant for reuse across selectors and components.

Tests:
- Relax operations statistics screenshot test timing by removing strict network-idle wait to reduce flakiness.