### PR TITLE
chore(Accounts): rename selectors in store/selectors/accounts [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
+++ b/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
@@ -10,7 +10,7 @@ import {SelectSingle} from '../../../components/Select/Select';
 
 import ypath from '../../../common/thor/ypath';
 
-import {getActiveAccount} from '../../../store/selectors/accounts/accounts';
+import {selectActiveAccount} from '../../../store/selectors/accounts/accounts';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 
 import {
@@ -202,7 +202,7 @@ class AccountQuotaEditor extends React.Component<Props & ReduxProps, State> {
 
 function AccountQuota(props: Props) {
     const dispatch = useDispatch();
-    const activeAccount = useSelector(getActiveAccount);
+    const activeAccount = useSelector(selectActiveAccount);
     const accountsTree = useSelector(getAccountsTree);
 
     const handleSetQuota = React.useCallback(

--- a/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
+++ b/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
@@ -29,8 +29,8 @@ import {
 import {ProgressStackByTreeItem} from '../tabs/general/ProgressStack';
 import {
     type AccountsTree,
-    getAccountsTree,
-    getEditableAccountQuotaSources,
+    selectAccountsTree,
+    selectEditableAccountQuotaSources,
 } from '../../../store/selectors/accounts/accounts-ts';
 
 import './AccountQuota.scss';
@@ -203,7 +203,7 @@ class AccountQuotaEditor extends React.Component<Props & ReduxProps, State> {
 function AccountQuota(props: Props) {
     const dispatch = useDispatch();
     const activeAccount = useSelector(selectActiveAccount);
-    const accountsTree = useSelector(getAccountsTree);
+    const accountsTree = useSelector(selectAccountsTree);
 
     const handleSetQuota = React.useCallback(
         (params: AccountQuotaParams) => {
@@ -212,7 +212,7 @@ function AccountQuota(props: Props) {
         [dispatch],
     );
 
-    const sources = useSelector(getEditableAccountQuotaSources);
+    const sources = useSelector(selectEditableAccountQuotaSources);
 
     return (
         <AccountQuotaEditor

--- a/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
@@ -18,8 +18,8 @@ import {
     AccountsTab,
 } from '../../../constants/accounts/accounts';
 import {
-    getAccountsIsFinalLoadingStatus,
-    getActiveAccount,
+    selectAccountsIsFinalLoadingStatus,
+    selectActiveAccount,
 } from '../../../store/selectors/accounts/accounts-ts';
 import {getLastVisitedTabs} from '../../../store/selectors/settings';
 import {type TabSettings, makeTabProps} from '../../../utils';
@@ -156,7 +156,7 @@ const mapStateToProps = (state: RootState) => {
 
     return {
         lastVisitedTab: lastVisitedTabs[Page.ACCOUNTS],
-        activeAccount: getActiveAccount(state),
+        activeAccount: selectActiveAccount(state),
         allowUsageTab: state.accounts.accounts.is_accounts_usage_available,
         cluster: selectCluster(state),
     };
@@ -166,7 +166,7 @@ const connector = connect(mapStateToProps);
 export default connector(Accounts);
 
 function AccountsRumMeasure() {
-    const isFinalStatus = useSelector(getAccountsIsFinalLoadingStatus);
+    const isFinalStatus = useSelector(selectAccountsIsFinalLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.ACCOUNTS,

--- a/packages/ui/src/ui/pages/accounts/Accounts/AccountsTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/AccountsTopRowContent.tsx
@@ -11,8 +11,8 @@ import {
 } from '../../../store/selectors/favourites';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {
-    getAccountsMapByName,
-    getActiveAccount,
+    selectAccountsMapByName,
+    selectActiveAccount,
 } from '../../../store/selectors/accounts/accounts-ts';
 import {setActiveAccount} from '../../../store/actions/accounts/accounts';
 import {accountsToggleFavourite} from '../../../store/actions/favourites';
@@ -33,8 +33,8 @@ const block = cn('accounts-top-row-content');
 
 function AccountsTopRowContent() {
     const clusterUiConfig = useSelector(selectClusterUiConfig);
-    const account = useSelector(getActiveAccount);
-    const accountsByName = useSelector(getAccountsMapByName) as any;
+    const account = useSelector(selectActiveAccount);
+    const accountsByName = useSelector(selectAccountsMapByName);
 
     const current = accountsByName[account];
 
@@ -57,7 +57,7 @@ function AccountsFavourites() {
     const isActiveInFavourites = useSelector(selectIsActiveAccountInFavourites);
     const favourites = useSelector(selectFavouriteAccounts);
     const dispatch = useDispatch();
-    const activeAccount = useSelector(getActiveAccount);
+    const activeAccount = useSelector(selectActiveAccount);
 
     const handleFavouriteItemClick = React.useCallback(
         (item: FavouritesItem) => {

--- a/packages/ui/src/ui/pages/accounts/Accounts/AccountsTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/AccountsTopRowContent.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../store/selectors/accounts/accounts-ts';
 import {setActiveAccount} from '../../../store/actions/accounts/accounts';
 import {accountsToggleFavourite} from '../../../store/actions/favourites';
-import {getActiveAccountBreadcrumbs} from '../../../store/selectors/accounts/accounts';
+import {selectActiveAccountBreadcrumbs} from '../../../store/selectors/accounts/accounts';
 
 import AccountCreate from '../tabs/general/Editor/AccountCreate';
 import {useHistory} from 'react-router';
@@ -86,7 +86,7 @@ const ROOT_PLACEHOLDER = '<Root>';
 
 function AccountsBreadcrumbs() {
     // @ts-ignore
-    const bcItems = useSelector(getActiveAccountBreadcrumbs).slice(1);
+    const bcItems = useSelector(selectActiveAccountBreadcrumbs).slice(1);
     const dispatch = useDispatch();
     const cluster = useSelector(selectCluster);
     const history = useHistory();

--- a/packages/ui/src/ui/pages/accounts/Accounts/AccountsUpdater.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/AccountsUpdater.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 
 import {fetchAccounts} from '../../../store/actions/accounts/accounts';
-import {getAccountsEditCounter} from '../../../store/selectors/accounts/accounts-ts';
+import {selectAccountsEditCounter} from '../../../store/selectors/accounts/accounts-ts';
 import {useUpdater} from '../../../hooks/use-updater';
 
 export default function AccountsUpdater() {
     const dispatch = useDispatch();
 
-    const editCounter = useSelector(getAccountsEditCounter);
+    const editCounter = useSelector(selectAccountsEditCounter);
 
     const update = React.useCallback(() => {
         dispatch(fetchAccounts());

--- a/packages/ui/src/ui/pages/accounts/AccountsSuggest.tsx
+++ b/packages/ui/src/ui/pages/accounts/AccountsSuggest.tsx
@@ -11,7 +11,7 @@ import {YTErrorBlock} from '../../components/Error/Error';
 
 import {ROOT_ACCOUNT_NAME} from '../../constants/accounts/accounts';
 import {selectEditableAccountParentSuggests} from '../../store/selectors/accounts/accounts';
-import {getAccountNames} from '../../store/selectors/accounts/accounts-ts';
+import {selectAccountNames} from '../../store/selectors/accounts/accounts-ts';
 
 import './AccountsSuggest.scss';
 import {fetchFullList1M} from '../../utils/users-groups';
@@ -89,7 +89,7 @@ AccountSuggestImpl.hasErrorRenderer = true;
 
 const mapStateToProps = (state: RootState) => {
     return {
-        items: getAccountNames(state),
+        items: selectAccountNames(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/accounts/AccountsSuggest.tsx
+++ b/packages/ui/src/ui/pages/accounts/AccountsSuggest.tsx
@@ -10,7 +10,7 @@ import {type YTError} from '../../../@types/types';
 import {YTErrorBlock} from '../../components/Error/Error';
 
 import {ROOT_ACCOUNT_NAME} from '../../constants/accounts/accounts';
-import {getEditableAccountParentSuggests} from '../../store/selectors/accounts/accounts';
+import {selectEditableAccountParentSuggests} from '../../store/selectors/accounts/accounts';
 import {getAccountNames} from '../../store/selectors/accounts/accounts-ts';
 
 import './AccountsSuggest.scss';
@@ -101,7 +101,7 @@ export default AccountSuggestConnected;
 
 const mapStateToPropsForParents = (state: RootState) => {
     return {
-        items: getEditableAccountParentSuggests(state),
+        items: selectEditableAccountParentSuggests(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/accounts/tabs/acl/AccountsAclTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/acl/AccountsAclTab.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import AccountsNoContent from '../../../../pages/accounts/AccountsNoContent';
 
-import {getActiveAccount} from '../../../../store/selectors/accounts/accounts';
+import {selectActiveAccount} from '../../../../store/selectors/accounts/accounts';
 import {fetchAccounts} from '../../../../store/actions/accounts/accounts';
 import {loadUsers} from '../../../../store/actions/accounts/editor';
 import {AccountsAcl} from '../../../../containers/ACL';
@@ -25,7 +25,7 @@ function AccountsAclTab(props) {
 
 const mapAccountsAclTabStateToProps = (state) => {
     return {
-        activeAccount: getActiveAccount(state),
+        activeAccount: selectActiveAccount(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageTab.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageTab.tsx
@@ -4,8 +4,10 @@ import cn from 'bem-cn-lite';
 import AccountUsageToolbar from './AccountUsageToolbar';
 import AccountUsageDetails from './AccountUsageDetails';
 import WithStickyToolbar from '../../../../components/WithStickyToolbar/WithStickyToolbar';
+
 import {NoContent} from '../../../../components/NoContent';
-import {getActiveAccount} from '../../../../store/selectors/accounts/accounts-ts';
+import {selectActiveAccount} from '../../../../store/selectors/accounts/accounts-ts';
+
 import {useSelector} from '../../../../store/redux-hooks';
 import {getAccountUsageViewType} from '../../../../store/selectors/accounts/account-usage';
 import ErrorBoundary from '../../../../components/ErrorBoundary/ErrorBoundary';
@@ -16,7 +18,7 @@ const block = cn('accounts');
 function AccountDetailedUsageTab() {
     useDisableMaxContentWidth();
 
-    const account = useSelector(getActiveAccount);
+    const account = useSelector(selectActiveAccount);
     const viewType = useSelector(getAccountUsageViewType);
 
     if (!account) {

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountStaticConfiguration/AccountStaticConfiguration.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountStaticConfiguration/AccountStaticConfiguration.tsx
@@ -3,8 +3,8 @@ import cn from 'bem-cn-lite';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {
     type AccountStaticConfigurationItem,
-    getActiveAccount,
-    getActiveAccountStaticConfiguration,
+    selectActiveAccount,
+    selectActiveAccountStaticConfiguration,
 } from '../../../../../store/selectors/accounts/accounts-ts';
 import CollapsibleSection from '../../../../../components/CollapsibleSection/CollapsibleSection';
 import {DataTableYT} from '../../../../../components/DataTableYT';
@@ -67,8 +67,8 @@ const columns: Array<Column<AccountStaticConfigurationItem>> = [
 function AccountStaticConfiguration({className}: Props) {
     const dispatch = useDispatch();
 
-    const account = useSelector(getActiveAccount);
-    const items = useSelector(getActiveAccountStaticConfiguration);
+    const account = useSelector(selectActiveAccount);
+    const items = useSelector(selectActiveAccountStaticConfiguration);
     const expandState = useSelector(getSettingsAccountsExpandStaticConfiguration);
 
     const onToggle = React.useCallback(

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
@@ -12,9 +12,9 @@ import WithStickyToolbar, {
 
 import hammer from '../../../../common/hammer';
 import {
-    getFavouriteAccountsSet,
-    getFilteredAccounts,
-    getFilteredAccountsOfDashboard,
+    selectFavouriteAccountsSet,
+    selectFilteredAccounts,
+    selectFilteredAccountsOfDashboard,
 } from '../../../../store/selectors/accounts/dashboard';
 
 import {
@@ -792,7 +792,7 @@ class AccountsGeneralTab extends Component {
 const makeMapStateToProps = () => {
     return (state, ownProps) => {
         const nameToAccountMap = getAccountsMapByName(state);
-        const favouriteAccountsSet = getFavouriteAccountsSet(state);
+        const favouriteAccountsSet = selectFavouriteAccountsSet(state);
 
         const {
             accounts: {accounts},
@@ -802,8 +802,8 @@ const makeMapStateToProps = () => {
         const isDashboard = viewContext === DASHBOARD_VIEW_CONTEXT;
 
         const contextViewTree = isDashboard
-            ? getFilteredAccountsOfDashboard(state)
-            : getFilteredAccounts(state);
+            ? selectFilteredAccountsOfDashboard(state)
+            : selectFilteredAccounts(state);
 
         return {
             ...accounts,

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
@@ -62,8 +62,8 @@ import {
     showEditorModal,
 } from '../../../../store/actions/accounts/accounts';
 import {
-    getAccountsAbcServiceIdSlugFilter,
-    getActiveAccountAggregationRow,
+    selectAccountsAbcServiceIdSlugFilter,
+    selectActiveAccountAggregationRow,
 } from '../../../../store/selectors/accounts/accounts';
 import {isNull} from '../../../../utils';
 import {DASHBOARD_VIEW_CONTEXT} from '../../../../constants/index';
@@ -818,12 +818,12 @@ const makeMapStateToProps = () => {
 
             cluster: selectCluster(state),
 
-            activeAccountAggregation: getActiveAccountAggregationRow(state),
+            activeAccountAggregation: selectActiveAccountAggregationRow(state),
             favouriteAccountsSet,
             dashboardVisibilityMode: isDashboard
                 ? getAccountsVisibilityModeOfDashboard(state)
                 : getAccountsVisibilityMode(state),
-            abcServiceFilter: getAccountsAbcServiceIdSlugFilter(state),
+            abcServiceFilter: selectAccountsAbcServiceIdSlugFilter(state),
             columnFields: getAccountsColumnFields(state),
 
             enable_per_account_tablet_accounting:

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
@@ -73,10 +73,10 @@ import {ProgressStackByTreeItem} from './ProgressStack';
 
 import './AccountsGeneralTab.scss';
 import {
-    getAccountsColumnFields,
-    getAccountsContentMode,
-    getAccountsMapByName,
-    getAccountsMasterMemoryContentMode,
+    selectAccountsColumnFields,
+    selectAccountsContentMode,
+    selectAccountsMapByName,
+    selectAccountsMasterMemoryContentMode,
 } from '../../../../store/selectors/accounts/accounts-ts';
 import {
     selectCluster,
@@ -791,7 +791,7 @@ class AccountsGeneralTab extends Component {
 
 const makeMapStateToProps = () => {
     return (state, ownProps) => {
-        const nameToAccountMap = getAccountsMapByName(state);
+        const nameToAccountMap = selectAccountsMapByName(state);
         const favouriteAccountsSet = selectFavouriteAccountsSet(state);
 
         const {
@@ -807,7 +807,7 @@ const makeMapStateToProps = () => {
 
         return {
             ...accounts,
-            activeContentModeFilter: getAccountsContentMode(state),
+            activeContentModeFilter: selectAccountsContentMode(state),
 
             clusterUiConfig: selectClusterUiConfig(state),
 
@@ -824,14 +824,14 @@ const makeMapStateToProps = () => {
                 ? getAccountsVisibilityModeOfDashboard(state)
                 : getAccountsVisibilityMode(state),
             abcServiceFilter: selectAccountsAbcServiceIdSlugFilter(state),
-            columnFields: getAccountsColumnFields(state),
+            columnFields: selectAccountsColumnFields(state),
 
             enable_per_account_tablet_accounting:
                 selectClusterUiConfigEnablePerAccountTabletAccounting(state),
 
             collapsibleSize: UI_COLLAPSIBLE_SIZE,
 
-            masterMemoryContentMode: getAccountsMasterMemoryContentMode(state),
+            masterMemoryContentMode: selectAccountsMasterMemoryContentMode(state),
         };
     };
 };

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreate.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreate.tsx
@@ -6,7 +6,7 @@ import {Tooltip} from '@ytsaurus/components';
 import AccountCreateDialog from '../../../../../pages/accounts/tabs/general/Editor/AccountCreateDialog';
 import {openCreateModal} from '../../../../../store/actions/accounts/editor';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
-import {getActiveAccount} from '../../../../../store/selectors/accounts/accounts-ts';
+import {selectActiveAccount} from '../../../../../store/selectors/accounts/accounts-ts';
 import {selectCurrentClusterConfig} from '../../../../../store/selectors/global/cluster';
 import {selectIsAdmin} from '../../../../../store/selectors/global/is-developer';
 import UIFactory from '../../../../../UIFactory';
@@ -16,7 +16,7 @@ interface Props {
 }
 
 function AccountCreate({className}: Props) {
-    const currentAccount = useSelector(getActiveAccount);
+    const currentAccount = useSelector(selectActiveAccount);
     const clusterConfig = useSelector(selectCurrentClusterConfig);
     const isDeveloper = useSelector(selectIsAdmin);
 

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
@@ -8,7 +8,7 @@ import {loadEditedAccount} from '../../../../../store/actions/accounts/accounts'
 import {createAccountFromInfo} from '../../../../../utils/accounts/editor';
 import {selectCluster, selectCurrentUserName} from '../../../../../store/selectors/global';
 import {selectIsAdmin} from '../../../../../store/selectors/global/is-developer';
-import {getActiveAccount} from '../../../../../store/selectors/accounts/accounts';
+import {selectActiveAccount} from '../../../../../store/selectors/accounts/accounts';
 import {ROOT_ACCOUNT_NAME} from '../../../../../constants/accounts/accounts';
 
 import './AccountCreateDialog.scss';
@@ -143,7 +143,7 @@ const mapStateToProps = (state: RootState) => {
     } = state;
     return {
         currentUserName: selectCurrentUserName(state),
-        activeAccount: getActiveAccount(state),
+        activeAccount: selectActiveAccount(state),
         visible: editor.createModalVisible,
         newAccountInfo: editor.newAccountInfo as FormValues,
         cluster: selectCluster(state),

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountTransferQuotaMessage.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountTransferQuotaMessage.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import {useSelector} from '../../../../../store/redux-hooks';
 
 import {
-    getEditableAccount,
-    isEditableAccountOfTopLevel,
+    selectEditableAccount,
+    selectIsEditableAccountOfTopLevel,
 } from '../../../../../store/selectors/accounts/accounts-ts';
 import UIFactory from '../../../../../UIFactory';
 import {selectClusterUiConfig} from '../../../../../store/selectors/global';
 
 function AccountTransferQuotaMessage() {
-    const isTopLevel = useSelector(isEditableAccountOfTopLevel);
-    const account = useSelector(getEditableAccount);
+    const isTopLevel = useSelector(selectIsEditableAccountOfTopLevel);
+    const account = useSelector(selectEditableAccount);
     const clusterUiConfig = useSelector(selectClusterUiConfig);
 
     return (

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/MasterMemoryContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/MasterMemoryContent.tsx
@@ -6,7 +6,7 @@ import format from '../../../../../../common/hammer/format';
 
 import AccountQuota from '../../../../AccountQuota/AccountQuota';
 import {AccountResourceName} from '../../../../../../constants/accounts/accounts';
-import {getAccountMasterMemoryMedia} from '../../../../../../store/selectors/accounts/accounts-ts';
+import {selectAccountMasterMemoryMedia} from '../../../../../../store/selectors/accounts/accounts-ts';
 import {useSelector} from '../../../../../../store/redux-hooks';
 import AccountTransferQuotaMessage from '../AccountTransferQuotaMessage';
 
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export default function MasterMemoryContent(props: Props) {
-    const media = useSelector(getAccountMasterMemoryMedia);
+    const media = useSelector(selectAccountMasterMemoryMedia);
     const {account} = props;
 
     return (

--- a/packages/ui/src/ui/pages/accounts/tabs/general/MasterMemoryTableMode.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/MasterMemoryTableMode.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import map_ from 'lodash/map';
 
 import {
-    getAccountMasterMemoryMedia,
-    getAccountsContentMode,
-    getAccountsMasterMemoryContentMode,
+    selectAccountMasterMemoryMedia,
+    selectAccountsContentMode,
+    selectAccountsMasterMemoryContentMode,
 } from '../../../../store/selectors/accounts/accounts-ts';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
@@ -26,9 +26,9 @@ function Item({text}: {text: string}) {
 
 function MasterMemoryTableMode() {
     const dispatch = useDispatch();
-    const mode = useSelector(getAccountsContentMode);
-    const value = useSelector(getAccountsMasterMemoryContentMode);
-    const media = useSelector(getAccountMasterMemoryMedia);
+    const mode = useSelector(selectAccountsContentMode);
+    const value = useSelector(selectAccountsMasterMemoryContentMode);
+    const media = useSelector(selectAccountMasterMemoryMedia);
 
     const handleUpdate = React.useCallback(
         (vals: Array<string>) => {

--- a/packages/ui/src/ui/pages/accounts/tabs/monitor/AccountsMonitorPrometheus/AccountsMonitorPrometheus.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/monitor/AccountsMonitorPrometheus/AccountsMonitorPrometheus.tsx
@@ -7,7 +7,7 @@ import uniq_ from 'lodash/uniq';
 import ypath from '../../../../../common/thor/ypath';
 
 import {PrometheusDashboardLazy} from '../../../../../containers/PrometheusDashboard/lazy';
-import {getAccountsMapByName} from '../../../../../store/selectors/accounts/accounts-ts';
+import {selectAccountsMapByName} from '../../../../../store/selectors/accounts/accounts-ts';
 import {getMediumList} from '../../../../../store/selectors/thor';
 import {usePrometheusDashboardParams} from '../../../../../store/reducers/prometheusDashboard/prometheusDashboard-hooks';
 
@@ -31,7 +31,7 @@ export function AccountsMonitorPrometheus({cluster, account}: {cluster: string; 
 
 function useAccountMonitoringParams({cluster, account}: {cluster: string; account: string}) {
     const mediumList: Array<string> = useSelector(getMediumList);
-    const accountData = useSelector(getAccountsMapByName)[account];
+    const accountData = useSelector(selectAccountsMapByName)[account];
 
     const {params: selection, setParams: setSelection} =
         usePrometheusDashboardParams<LeftRightMedium>(ACCOUNTS_DASHBOARD_TYPE);

--- a/packages/ui/src/ui/pages/accounts/tabs/monitor/AccountsMonitorTab.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/monitor/AccountsMonitorTab.tsx
@@ -3,7 +3,7 @@ import {useSelector} from '../../../../store/redux-hooks';
 
 import AccountsNoContent from '../../AccountsNoContent';
 
-import {getActiveAccount} from '../../../../store/selectors/accounts/accounts';
+import {selectActiveAccount} from '../../../../store/selectors/accounts/accounts';
 import {selectCluster} from '../../../../store/selectors/global';
 import ErrorBoundary from '../../../../components/ErrorBoundary/ErrorBoundary';
 
@@ -13,8 +13,9 @@ function AccountsMonitorTab(props: {
     component: React.ComponentType<{cluster: string; account: string}>;
 }) {
     const {component: AccountMonitor} = props;
-    const account = useSelector(getActiveAccount);
+
     const cluster = useSelector(selectCluster);
+    const account = useSelector(selectActiveAccount);
 
     if (!account) {
         return <AccountsNoContent hint={i18n('please-choose-one-to-display')} />;

--- a/packages/ui/src/ui/pages/accounts/tabs/statistic/AccountStatisticTab.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/statistic/AccountStatisticTab.tsx
@@ -4,15 +4,15 @@ import {useSelector} from '../../../../store/redux-hooks';
 import AccountsNoContent from '../../../../pages/accounts/AccountsNoContent';
 import {selectCluster, selectTheme} from '../../../../store/selectors/global';
 import {
-    getActiveAccount,
-    getActiveAccountSubtreeNames,
+    selectActiveAccount,
+    selectActiveAccountSubtreeNames,
 } from '../../../../store/selectors/accounts/accounts';
 import UIFactory from '../../../../UIFactory';
 
 function AccountStatisticTab() {
     const cluster = useSelector(selectCluster);
-    const account = useSelector(getActiveAccount);
-    const accountSubtreeAllNames = useSelector(getActiveAccountSubtreeNames);
+    const account = useSelector(selectActiveAccount);
+    const accountSubtreeAllNames = useSelector(selectActiveAccountSubtreeNames);
     const theme = useSelector(selectTheme);
 
     if (!account) {

--- a/packages/ui/src/ui/pages/dashboard/Dashboard/Dashboard.js
+++ b/packages/ui/src/ui/pages/dashboard/Dashboard/Dashboard.js
@@ -6,7 +6,7 @@ import {useSelector} from '../../../store/redux-hooks';
 import {setActiveAccount} from '../../../store/actions/accounts/accounts';
 
 import Operations from '../../../pages/operations/Operations/Operations';
-import {getActiveAccount} from '../../../store/selectors/accounts/accounts';
+import {selectActiveAccount} from '../../../store/selectors/accounts/accounts';
 import Links from '../Links/Links';
 import AccountsGeneralTab from '../../../pages/accounts/tabs/general/AccountsGeneralTab';
 import {DASHBOARD_VIEW_CONTEXT} from '../../../constants/index';
@@ -78,7 +78,7 @@ function Dashboard({currentAccount, setActiveAccount}) {
 
 const mapStateToProps = (state) => {
     return {
-        currentAccount: getActiveAccount(state),
+        currentAccount: selectActiveAccount(state),
     };
 };
 

--- a/packages/ui/src/ui/store/actions/accounts/account-usage.ts
+++ b/packages/ui/src/ui/store/actions/accounts/account-usage.ts
@@ -37,7 +37,7 @@ import {
     getAccountUsageTreeRequestParams,
     getAccountUsageViewType,
 } from '../../selectors/accounts/account-usage';
-import {getActiveAccount} from '../../../store/selectors/accounts/accounts-ts';
+import {selectActiveAccount} from '../../../store/selectors/accounts/accounts-ts';
 import {getSettingsAccountUsageViewType} from '../../../store/selectors/settings/settings-ts';
 import {type SortState} from '../../../types';
 import {
@@ -122,7 +122,7 @@ export function fetchAccountsUsageSnapshots(cluster: string): SnapshotsThunkActi
 type UsageListThunkAction = ThunkAction<any, RootState, any, AccountUsageListAction>;
 
 export function getFilterParameters(state: RootState): AccountUsageDataParams {
-    const account = getActiveAccount(state);
+    const account = selectActiveAccount(state);
     const cluster = selectCluster(state);
     const sortStates = getAccountUsageSortState(state);
     const path_regexp = getAccountUsagePathFilter(state);

--- a/packages/ui/src/ui/store/actions/accounts/accounts.js
+++ b/packages/ui/src/ui/store/actions/accounts/accounts.js
@@ -29,8 +29,8 @@ import {ACCOUNTS_DATA_FIELDS_ACTION} from '../../../constants/accounts';
 import {USE_CACHE, USE_MAX_SIZE} from '../../../../shared/constants/yt-api';
 import {selectCluster, selectCurrentUserName} from '../../../store/selectors/global';
 import {
-    getAccountsDisabledCacheForNextFetch,
-    getAccountsEditCounter,
+    selectAccountsDisabledCacheForNextFetch,
+    selectAccountsEditCounter,
 } from '../../../store/selectors/accounts/accounts-ts';
 import {RumWrapper, YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
 import {parseAccountsData} from './accounts-ts';
@@ -63,7 +63,7 @@ export function fetchAccounts() {
         const state = getState();
         const cluster = selectCluster(state);
         const userName = selectCurrentUserName(state);
-        const disableCacheForNextFetch = getAccountsDisabledCacheForNextFetch(state);
+        const disableCacheForNextFetch = selectAccountsDisabledCacheForNextFetch(state);
 
         const cacheParams = disableCacheForNextFetch ? {} : USE_CACHE;
 
@@ -186,7 +186,7 @@ export function fetchAccounts() {
 
 export function accountsIncreaseEditCounter() {
     return (dispatch, getState) => {
-        const editCounter = getAccountsEditCounter(getState());
+        const editCounter = selectAccountsEditCounter(getState());
         return {
             type: ACCOUNTS_DATA_FIELDS_ACTION,
             data: {editCounter: editCounter + 1, disableCacheForNextFetch: true},

--- a/packages/ui/src/ui/store/actions/favourites.js
+++ b/packages/ui/src/ui/store/actions/favourites.js
@@ -11,14 +11,15 @@ import {
 } from '../../store/selectors/settings';
 import {SettingName} from '../../../shared/constants/settings';
 import {reloadSetting, setSetting} from '../../store/actions/settings';
-import {getActiveAccount} from '../../store/selectors/accounts/accounts';
+
+import {selectActiveAccount} from '../../store/selectors/accounts/accounts';
 import {selectTabletsActiveBundle} from '../selectors/tablet_cell_bundles';
 
 const LAST_VISITED_BUFFER_SIZE = 15;
 
 export function accountsTrackVisit(account) {
     return (dispatch, getState) => {
-        const activeAccount = getActiveAccount(getState());
+        const activeAccount = selectActiveAccount(getState());
         if (account === activeAccount) {
             return;
         }

--- a/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
@@ -26,31 +26,31 @@ function isTopLevelAccount(account: AccountSelector) {
     return !parent || parent === ROOT_ACCOUNT_NAME;
 }
 
-const getAccountsLoading = (state: RootState) => state.accounts.accounts.fetching;
-const getAccountsLoaded = (state: RootState) => state.accounts.accounts.wasLoaded;
-const getAccountsError = (state: RootState) => state.accounts.accounts.error;
+const selectAccountsLoading = (state: RootState) => state.accounts.accounts.fetching;
+const selectAccountsLoaded = (state: RootState) => state.accounts.accounts.wasLoaded;
+const selectAccountsError = (state: RootState) => state.accounts.accounts.error;
 
-export const getAccountsIsFinalLoadingStatus = createSelector(
-    [getAccountsLoading, getAccountsLoaded, getAccountsError],
+export const selectAccountsIsFinalLoadingStatus = createSelector(
+    [selectAccountsLoading, selectAccountsLoaded, selectAccountsError],
     (loading, loaded, error) => {
         const status = calculateLoadingStatus(loading, loaded, error);
         return isFinalLoadingStatus(status);
     },
 );
 
-export const getActiveAccount = (state: RootState) => state.accounts.accounts.activeAccount;
-export const getActiveMediumFilter = (state: RootState) =>
+export const selectActiveAccount = (state: RootState) => state.accounts.accounts.activeAccount;
+export const selectActiveMediumFilter = (state: RootState) =>
     state.accounts.accounts.activeMediumFilter;
-export const getAccountsContentMode = (state: RootState) =>
+export const selectAccountsContentMode = (state: RootState) =>
     state.accounts.accounts.activeContentModeFilter;
-export const getAccountsMasterMemoryContentMode = (state: RootState) =>
+export const selectAccountsMasterMemoryContentMode = (state: RootState) =>
     state.accounts.accounts.masterMemoryContentMode;
-export const getEditableAccount = (state: RootState) =>
+export const selectEditableAccount = (state: RootState) =>
     state.accounts.accounts.editableAccount as AccountSelector;
 
-export const getAccountsDisabledCacheForNextFetch = (state: RootState) =>
+export const selectAccountsDisabledCacheForNextFetch = (state: RootState) =>
     state.accounts.accounts.disableCacheForNextFetch;
-export const getAccountsEditCounter = (state: RootState) => state.accounts.accounts.editCounter;
+export const selectAccountsEditCounter = (state: RootState) => state.accounts.accounts.editCounter;
 
 export interface AccountSelector {
     name: string;
@@ -120,14 +120,14 @@ export interface AccountStaticConfigurationItem {
     free?: number;
 }
 
-const getAccounts = (state: RootState) =>
+const selectAccounts = (state: RootState) =>
     state.accounts.accounts.accounts as Array<AccountSelector>;
 
-export const getAccountNames = createSelector(getAccounts, (items: Array<FIX_MY_TYPE>) =>
+export const selectAccountNames = createSelector(selectAccounts, (items: Array<FIX_MY_TYPE>) =>
     map_(items, (i) => i.$value).sort(),
 );
 
-export const getAccountsMapByName = createSelector(getAccounts, (accounts) => {
+export const selectAccountsMapByName = createSelector(selectAccounts, (accounts) => {
     const nameToAccountMap: Record<string, AccountSelector> = {};
     forEach_(accounts, (item) => {
         nameToAccountMap[item.name] = item;
@@ -135,7 +135,7 @@ export const getAccountsMapByName = createSelector(getAccounts, (accounts) => {
     return nameToAccountMap;
 });
 
-export const getAccountsTree = createSelector([getAccountsMapByName], prepareAccountsTree);
+export const selectAccountsTree = createSelector([selectAccountsMapByName], prepareAccountsTree);
 
 type Tree<T> = {
     attributes: T;
@@ -184,8 +184,8 @@ function makeStaticConfigurationItem(
     ];
 }
 
-export const getActiveAccountStaticConfiguration = createSelector(
-    [getActiveAccount, getAccountsTree, getMediumListNoCache],
+export const selectActiveAccountStaticConfiguration = createSelector(
+    [selectActiveAccount, selectAccountsTree, getMediumListNoCache],
     (activeAccount, tree = {}, mediums = []) => {
         const item = tree[activeAccount];
         if (!item) {
@@ -288,7 +288,7 @@ function getResourceInfo(
     return getInfo(entry.attributes, recursive, mediumType);
 }
 
-export const getAccountMasterMemoryMedia = createSelector([getAccounts], (items = []) => {
+export const selectAccountMasterMemoryMedia = createSelector([selectAccounts], (items = []) => {
     const [item] = items;
     if (!item) {
         return [];
@@ -302,8 +302,8 @@ export const getAccountMasterMemoryMedia = createSelector([getAccounts], (items 
     return ['total', 'chunk_host', ...mediums];
 });
 
-const getAccountsMasterMemoryColumns = createSelector(
-    [getActiveAccount, getAccountsMasterMemoryContentMode],
+const selectAccountsMasterMemoryColumns = createSelector(
+    [selectActiveAccount, selectAccountsMasterMemoryContentMode],
     (activeAccount, medium) => {
         return {
             master_memory_percentage: {
@@ -398,8 +398,8 @@ const getAccountsMasterMemoryColumns = createSelector(
     },
 );
 
-export const getAccountsColumnFields = createSelector(
-    [getActiveAccount, getActiveMediumFilter, getAccountsMasterMemoryColumns],
+export const selectAccountsColumnFields = createSelector(
+    [selectActiveAccount, selectActiveMediumFilter, selectAccountsMasterMemoryColumns],
     (activeAccount, mediumType, accountsColumns) => {
         const res = {
             name: {
@@ -590,8 +590,8 @@ export function getAccountName(treeItem?: {attributes: AccountSelector}) {
     return account && account.name;
 }
 
-export const getEditableAccountQuotaSources = createSelector(
-    [getAccountsTree, getEditableAccount],
+export const selectEditableAccountQuotaSources = createSelector(
+    [selectAccountsTree, selectEditableAccount],
     (tree, account) => {
         if (!account?.name || !tree) {
             return [];
@@ -632,8 +632,8 @@ function collectSubtreeItems(
     return res;
 }
 
-export const isEditableAccountOfTopLevel = createSelector(
-    [getAccountsMapByName, getEditableAccount],
+export const selectIsEditableAccountOfTopLevel = createSelector(
+    [selectAccountsMapByName, selectEditableAccount],
     (mapByName, account) => {
         return isTopLevelAccount(mapByName[account?.name]);
     },

--- a/packages/ui/src/ui/store/selectors/accounts/accounts.js
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts.js
@@ -11,11 +11,11 @@ import {getTables} from '../../../store/selectors/tables';
 import hammer from '../../../common/hammer';
 import ypath from '../../../common/thor/ypath';
 import {
-    getAccountMasterMemoryMedia,
-    getAccountNames,
-    getAccountsColumnFields,
-    getAccountsMapByName,
-    getAccountsTree,
+    selectAccountMasterMemoryMedia,
+    selectAccountNames,
+    selectAccountsColumnFields,
+    selectAccountsMapByName,
+    selectAccountsTree,
 } from './accounts-ts';
 import {concatByAnd} from '../../../common/hammer/predicate';
 import {accountMemoryMediumToFieldName} from '../../../utils/accounts/accounts-selector';
@@ -31,13 +31,13 @@ export const selectAccountsSortInfo = (state) => getTables(state)[ACCOUNTS_TABLE
 
 export const selectEditableAccount = (state) => state.accounts.accounts.editableAccount;
 
-const getEditableAccountSubtreeNames = createSelector(
-    [getAccountsTree, selectEditableAccount],
+const selectEditableAccountSubtreeNames = createSelector(
+    [selectAccountsTree, selectEditableAccount],
     prepareSubtreeNames,
 );
 
 export const selectEditableAccountParentSuggests = createSelector(
-    [getAccountNames, getEditableAccountSubtreeNames],
+    [selectAccountNames, selectEditableAccountSubtreeNames],
     (allNames, excludeNames) => {
         const excludeNamesSet = new Set(excludeNames);
         return filter_(allNames, (name) => !excludeNamesSet.has(name));
@@ -46,7 +46,7 @@ export const selectEditableAccountParentSuggests = createSelector(
 
 const selectFlattenTree = createSelector(
     [
-        getAccountsTree,
+        selectAccountsTree,
         selectActiveAccount,
         selectAccountsNameFilter,
         selectAccountsAbcServiceIdSlugFilter,
@@ -61,7 +61,7 @@ export const selectActiveAccountSubtree = createSelector(
 );
 
 export const selectActiveAccountAggregationRow = createSelector(
-    [selectActiveAccountSubtree, getAccountMasterMemoryMedia],
+    [selectActiveAccountSubtree, selectAccountMasterMemoryMedia],
     ({activeTreeItem}, masterMemoryMedia) => calcAggregationRow(activeTreeItem, masterMemoryMedia),
 );
 
@@ -71,7 +71,7 @@ export const selectActiveAccountSubtreeNames = createSelector(
 );
 
 export const selectAccountsFlattenTree = createSelector(
-    [selectAccountsSortInfo, selectFlattenTree, getAccountsColumnFields],
+    [selectAccountsSortInfo, selectFlattenTree, selectAccountsColumnFields],
     sortFlattenTree,
 );
 
@@ -255,7 +255,7 @@ function getActiveAccountSubtreeNamesImpl({activeTreeItem}) {
 
 export const selectActiveAccountBreadcrumbs = createSelector(
     selectActiveAccount,
-    getAccountsMapByName,
+    selectAccountsMapByName,
     (activeAccount, nameToAccountMap) => {
         const parentNode = (name) => {
             const account = nameToAccountMap[name] || {attributes: {}};

--- a/packages/ui/src/ui/store/selectors/accounts/accounts.js
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts.js
@@ -21,22 +21,22 @@ import {concatByAnd} from '../../../common/hammer/predicate';
 import {accountMemoryMediumToFieldName} from '../../../utils/accounts/accounts-selector';
 import {visitTreeItems} from '../../../utils/utils';
 
-export const getActiveAccount = (state) => state.accounts.accounts.activeAccount;
-export const getActiveMediumFilter = (state) => state.accounts.accounts.activeMediumFilter;
-export const getUsableAccounts = (state) => state.accounts.accounts.usableAccounts;
-export const getAccountsNameFilter = (state) => state.accounts.accounts.activeNameFilter;
-export const getAccountsAbcServiceIdSlugFilter = (state) =>
+export const selectActiveAccount = (state) => state.accounts.accounts.activeAccount;
+export const selectActiveMediumFilter = (state) => state.accounts.accounts.activeMediumFilter;
+export const selectUsableAccounts = (state) => state.accounts.accounts.usableAccounts;
+export const selectAccountsNameFilter = (state) => state.accounts.accounts.activeNameFilter;
+export const selectAccountsAbcServiceIdSlugFilter = (state) =>
     state.accounts.accounts.abcServiceFilter;
-export const getAccountsSortInfo = (state) => getTables(state)[ACCOUNTS_TABLE_ID];
+export const selectAccountsSortInfo = (state) => getTables(state)[ACCOUNTS_TABLE_ID];
 
-export const getEditableAccount = (state) => state.accounts.accounts.editableAccount;
+export const selectEditableAccount = (state) => state.accounts.accounts.editableAccount;
 
 const getEditableAccountSubtreeNames = createSelector(
-    [getAccountsTree, getEditableAccount],
+    [getAccountsTree, selectEditableAccount],
     prepareSubtreeNames,
 );
 
-export const getEditableAccountParentSuggests = createSelector(
+export const selectEditableAccountParentSuggests = createSelector(
     [getAccountNames, getEditableAccountSubtreeNames],
     (allNames, excludeNames) => {
         const excludeNamesSet = new Set(excludeNames);
@@ -44,29 +44,34 @@ export const getEditableAccountParentSuggests = createSelector(
     },
 );
 
-const getFlattenTree = createSelector(
-    [getAccountsTree, getActiveAccount, getAccountsNameFilter, getAccountsAbcServiceIdSlugFilter],
+const selectFlattenTree = createSelector(
+    [
+        getAccountsTree,
+        selectActiveAccount,
+        selectAccountsNameFilter,
+        selectAccountsAbcServiceIdSlugFilter,
+    ],
     prepareAccountsFlattenTreeImpl,
 );
 
-export const getActiveAccountSubtree = createSelector(
-    getActiveAccount,
-    getFlattenTree,
+export const selectActiveAccountSubtree = createSelector(
+    selectActiveAccount,
+    selectFlattenTree,
     getActiveAccountSubtreeImpl,
 );
 
-export const getActiveAccountAggregationRow = createSelector(
-    [getActiveAccountSubtree, getAccountMasterMemoryMedia],
+export const selectActiveAccountAggregationRow = createSelector(
+    [selectActiveAccountSubtree, getAccountMasterMemoryMedia],
     ({activeTreeItem}, masterMemoryMedia) => calcAggregationRow(activeTreeItem, masterMemoryMedia),
 );
 
-export const getActiveAccountSubtreeNames = createSelector(
-    getActiveAccountSubtree,
+export const selectActiveAccountSubtreeNames = createSelector(
+    selectActiveAccountSubtree,
     getActiveAccountSubtreeNamesImpl,
 );
 
-export const prepareAccountsFlattenTree = createSelector(
-    [getAccountsSortInfo, getFlattenTree, getAccountsColumnFields],
+export const selectAccountsFlattenTree = createSelector(
+    [selectAccountsSortInfo, selectFlattenTree, getAccountsColumnFields],
     sortFlattenTree,
 );
 
@@ -248,8 +253,8 @@ function getActiveAccountSubtreeNamesImpl({activeTreeItem}) {
     return res;
 }
 
-export const getActiveAccountBreadcrumbs = createSelector(
-    getActiveAccount,
+export const selectActiveAccountBreadcrumbs = createSelector(
+    selectActiveAccount,
     getAccountsMapByName,
     (activeAccount, nameToAccountMap) => {
         const parentNode = (name) => {

--- a/packages/ui/src/ui/store/selectors/accounts/dashboard.js
+++ b/packages/ui/src/ui/store/selectors/accounts/dashboard.js
@@ -1,8 +1,8 @@
 import map_ from 'lodash/map';
 import {createSelector} from 'reselect';
 import {
-    getUsableAccounts,
-    prepareAccountsFlattenTree,
+    selectAccountsFlattenTree,
+    selectUsableAccounts,
 } from '../../../store/selectors/accounts/accounts';
 import {selectFavouriteAccounts} from '../../../store/selectors/favourites';
 import {
@@ -12,7 +12,7 @@ import {
 import {filterFlattenTreeByViewContext} from '../../../utils/accounts';
 import {getActiveAccount} from './accounts-ts';
 
-export const selectUsableAccountsSet = createSelector([getUsableAccounts], (items) => {
+export const selectUsableAccountsSet = createSelector([selectUsableAccounts], (items) => {
     return new Set(items);
 });
 
@@ -26,7 +26,7 @@ export const selectFavouriteAccountsSet = createSelector([selectFavouriteAccount
 
 export const selectFilteredAccountsOfDashboard = createSelector(
     [
-        prepareAccountsFlattenTree,
+        selectAccountsFlattenTree,
         selectUsableAccountsSet,
         getAccountsVisibilityModeOfDashboard,
         selectFavouriteAccountsSet,
@@ -36,7 +36,7 @@ export const selectFilteredAccountsOfDashboard = createSelector(
 
 export const selectFilteredAccounts = createSelector(
     [
-        prepareAccountsFlattenTree,
+        selectAccountsFlattenTree,
         selectUsableAccountsSet,
         getAccountsVisibilityMode,
         selectFavouriteAccountsSet,

--- a/packages/ui/src/ui/store/selectors/accounts/dashboard.js
+++ b/packages/ui/src/ui/store/selectors/accounts/dashboard.js
@@ -12,7 +12,7 @@ import {
 import {filterFlattenTreeByViewContext} from '../../../utils/accounts';
 import {getActiveAccount} from './accounts-ts';
 
-export const getUsableAccountsSet = createSelector([getUsableAccounts], (items) => {
+export const selectUsableAccountsSet = createSelector([getUsableAccounts], (items) => {
     return new Set(items);
 });
 
@@ -20,26 +20,26 @@ export const getUsableAccountsSet = createSelector([getUsableAccounts], (items) 
  * This selector cannot be moved to 'store/selectors/accounts/accounts'
  * because of cyclic dependencies.
  */
-export const getFavouriteAccountsSet = createSelector([selectFavouriteAccounts], (items) => {
+export const selectFavouriteAccountsSet = createSelector([selectFavouriteAccounts], (items) => {
     return new Set(map_(items, 'path'));
 });
 
-export const getFilteredAccountsOfDashboard = createSelector(
+export const selectFilteredAccountsOfDashboard = createSelector(
     [
         prepareAccountsFlattenTree,
-        getUsableAccountsSet,
+        selectUsableAccountsSet,
         getAccountsVisibilityModeOfDashboard,
-        getFavouriteAccountsSet,
+        selectFavouriteAccountsSet,
     ],
     filterFlattenTreeByViewContext,
 );
 
-export const getFilteredAccounts = createSelector(
+export const selectFilteredAccounts = createSelector(
     [
         prepareAccountsFlattenTree,
-        getUsableAccountsSet,
+        selectUsableAccountsSet,
         getAccountsVisibilityMode,
-        getFavouriteAccountsSet,
+        selectFavouriteAccountsSet,
         getActiveAccount,
     ],
     filterFlattenTreeByViewContext,

--- a/packages/ui/src/ui/store/selectors/accounts/dashboard.js
+++ b/packages/ui/src/ui/store/selectors/accounts/dashboard.js
@@ -10,7 +10,7 @@ import {
     getAccountsVisibilityModeOfDashboard,
 } from '../../../store/selectors/settings';
 import {filterFlattenTreeByViewContext} from '../../../utils/accounts';
-import {getActiveAccount} from './accounts-ts';
+import {selectActiveAccount} from './accounts-ts';
 
 export const selectUsableAccountsSet = createSelector([selectUsableAccounts], (items) => {
     return new Set(items);
@@ -40,7 +40,7 @@ export const selectFilteredAccounts = createSelector(
         selectUsableAccountsSet,
         getAccountsVisibilityMode,
         selectFavouriteAccountsSet,
-        getActiveAccount,
+        selectActiveAccount,
     ],
     filterFlattenTreeByViewContext,
 );

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -13,7 +13,7 @@ import {
     selectChaosBundlesNS,
 } from '../../store/selectors/settings';
 import {SettingName} from '../../../shared/constants/settings';
-import {getActiveAccount} from '../../store/selectors/accounts/accounts';
+import {selectActiveAccount} from '../../store/selectors/accounts/accounts';
 import {getPath} from '../../store/selectors/navigation';
 import {getPool, getTree} from '../../store/selectors/scheduling/scheduling';
 import {selectTabletsActiveBundle} from './tablet_cell_bundles';
@@ -35,7 +35,7 @@ export const selectLastVisitedAccounts = createSelector(
 export const selectPopularAccounts = createSelector([selectLastVisitedAccounts], preparePopulars);
 
 export const selectIsActiveAccountInFavourites = createSelector(
-    [getActiveAccount, selectFavouriteAccounts],
+    [selectActiveAccount, selectFavouriteAccounts],
     prepareIsInFavourites,
 );
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/vvxkSzlg7Y73cH
<!-- nda-end -->      ## Summary by Sourcery

Rename accounts-related selectors across the store and UI to use a unified select* naming convention.

Enhancements:
- Standardize accounts selector names in JS/TS modules from get* to select* for consistency and clarity.
- Update all components, actions, and selectors to consume the renamed accounts selectors without changing behavior.