### PR TITLE
chore(ACL): rename selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,7 @@
     "lint": "npm run lint:i18n && npm run lint:lodash-imports && npm run lint:file-names && npm run lint:js && npm run lint:styles",
     "lint:file-names": "./scripts/check-file-names-for-js-duplicates.sh",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:styles -- --fix",
-    "lint:js": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --ignore-pattern src/ui/vendor",
+    "lint:js": "eslint \"${FILES:-src}\" --ignore-pattern src/ui/vendor",
     "lint:styles": "stylelint 'src/ui/**/*.scss' --customSyntax postcss-scss",
     "lint:lodash-imports": "scripts/check-lodash-imports.sh ./src",
     "lint:i18n": "scripts/check-i18n-duplicated-keysets.sh ./src",

--- a/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
@@ -22,10 +22,10 @@ import {
 import {getType} from '../../store/selectors/navigation';
 
 import {
-    getAclCurrentTab,
-    getAclFilterColumnGroupName,
-    getAclFilterColumns,
-    getAclFilterRowGroupName,
+    selectAclCurrentTab,
+    selectAclFilterColumnGroupName,
+    selectAclFilterColumns,
+    selectAclFilterRowGroupName,
 } from '../../store/selectors/acl/acl-filters';
 
 import {
@@ -84,7 +84,7 @@ const makeAclMapStateToProps = (inputIdmKind: IdmKindType) => {
         const rowGroups = selectAllRowGroupsActual(state, idmKind);
         const userPermissions = selectAllUserPermissions(state, idmKind);
 
-        const columnsFilter = getAclFilterColumns(state);
+        const columnsFilter = selectAclFilterColumns(state);
 
         const auditors = selectNotInheritedAuditors(state, idmKind);
         const readApprovers = selectNotInheritedReadApprovers(state, idmKind);
@@ -128,15 +128,15 @@ const makeAclMapStateToProps = (inputIdmKind: IdmKindType) => {
 
             columnGroups,
             columnsFilter,
-            columnGroupNameFilter: getAclFilterColumnGroupName(state),
+            columnGroupNameFilter: selectAclFilterColumnGroupName(state),
 
             rowGroups,
-            rowGroupNameFilter: getAclFilterRowGroupName(state),
+            rowGroupNameFilter: selectAclFilterRowGroupName(state),
 
             normalizedPoolTree,
             aclRequestOptions,
 
-            aclMode: idmKind !== 'path' ? AclMode.MAIN_PERMISSIONS : getAclCurrentTab(state),
+            aclMode: idmKind !== 'path' ? AclMode.MAIN_PERMISSIONS : selectAclCurrentTab(state),
             allowSwitchMode: idmKind === 'path',
         };
     };

--- a/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
@@ -1,22 +1,22 @@
 import {type ConnectedProps, connect} from 'react-redux';
 
 import {
-    getAllAccessColumnsNames,
-    getAllColumnGroupsActual,
-    getAllRowGroupsActual,
-    getAllUserPermissions,
-    getApproversFilteredAndOrdered,
-    getHasApprovers,
-    getIdmManageAclRequestError,
-    getIdmPathVersion,
-    getIdmPermissionsRequestError,
-    getLastDeletedPermissionKey,
-    getNotInheritedAuditors,
-    getNotInheritedReadApprovers,
-    getNotInheritedResponsibles,
-    getObjectPermissionsAggregated,
-    isPermissionDeleted,
-    permissionDeletionError,
+    selectAllAccessColumnsNames,
+    selectAllColumnGroupsActual,
+    selectAllRowGroupsActual,
+    selectAllUserPermissions,
+    selectApproversFilteredAndOrdered,
+    selectHasApprovers,
+    selectIdmManageAclRequestError,
+    selectIdmPathVersion,
+    selectIdmPermissionsRequestError,
+    selectIsPermissionDeleted,
+    selectLastDeletedPermissionKey,
+    selectNotInheritedAuditors,
+    selectNotInheritedReadApprovers,
+    selectNotInheritedResponsibles,
+    selectObjectPermissionsAggregated,
+    selectPermissionDeletionError,
 } from '../../store/selectors/acl/acl';
 
 import {getType} from '../../store/selectors/navigation';
@@ -76,19 +76,19 @@ const makeAclMapStateToProps = (inputIdmKind: IdmKindType) => {
             inheritAcl,
         } = state.acl[idmKind];
 
-        const hasApprovers = getHasApprovers(state, idmKind);
-        const approversFiltered = getApproversFilteredAndOrdered(state, idmKind);
+        const hasApprovers = selectHasApprovers(state, idmKind);
+        const approversFiltered = selectApproversFilteredAndOrdered(state, idmKind);
         const {mainPermissions, columnsPermissions, rowPermissions} =
-            getObjectPermissionsAggregated(state, idmKind);
-        const columnGroups = getAllColumnGroupsActual(state, idmKind);
-        const rowGroups = getAllRowGroupsActual(state, idmKind);
-        const userPermissions = getAllUserPermissions(state, idmKind);
+            selectObjectPermissionsAggregated(state, idmKind);
+        const columnGroups = selectAllColumnGroupsActual(state, idmKind);
+        const rowGroups = selectAllRowGroupsActual(state, idmKind);
+        const userPermissions = selectAllUserPermissions(state, idmKind);
 
         const columnsFilter = getAclFilterColumns(state);
 
-        const auditors = getNotInheritedAuditors(state, idmKind);
-        const readApprovers = getNotInheritedReadApprovers(state, idmKind);
-        const responsible = getNotInheritedResponsibles(state, idmKind);
+        const auditors = selectNotInheritedAuditors(state, idmKind);
+        const readApprovers = selectNotInheritedReadApprovers(state, idmKind);
+        const responsible = selectNotInheritedResponsibles(state, idmKind);
 
         const nodeType = getType(state);
 
@@ -102,7 +102,7 @@ const makeAclMapStateToProps = (inputIdmKind: IdmKindType) => {
 
             path,
             nodeType,
-            version: getIdmPathVersion(state, idmKind),
+            version: selectIdmPathVersion(state, idmKind),
             idmKind,
             disableAclInheritance,
             inheritAcl,
@@ -118,13 +118,13 @@ const makeAclMapStateToProps = (inputIdmKind: IdmKindType) => {
             responsible,
 
             userPermissions,
-            userPermissionsRequestError: getIdmPermissionsRequestError(state, idmKind),
-            userPermissionsAccessColumns: getAllAccessColumnsNames(state, idmKind),
-            userPermissionsUpdateAclError: getIdmManageAclRequestError(state, idmKind),
+            userPermissionsRequestError: selectIdmPermissionsRequestError(state, idmKind),
+            userPermissionsAccessColumns: selectAllAccessColumnsNames(state, idmKind),
+            userPermissionsUpdateAclError: selectIdmManageAclRequestError(state, idmKind),
 
-            isPermissionDeleted: isPermissionDeleted(state, idmKind),
-            deletePermissionsLastItemKey: getLastDeletedPermissionKey(state, idmKind),
-            deletePermissionsError: permissionDeletionError(state, idmKind),
+            isPermissionDeleted: selectIsPermissionDeleted(state, idmKind),
+            deletePermissionsLastItemKey: selectLastDeletedPermissionKey(state, idmKind),
+            deletePermissionsError: selectPermissionDeletionError(state, idmKind),
 
             columnGroups,
             columnsFilter,

--- a/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
@@ -17,7 +17,7 @@ import {
     getObjectPermissionsAggregated,
     isPermissionDeleted,
     permissionDeletionError,
-} from '../../store/selectors/acl';
+} from '../../store/selectors/acl/acl';
 
 import {getType} from '../../store/selectors/navigation';
 

--- a/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL-connect-helpers.tsx
@@ -26,7 +26,7 @@ import {
     getAclFilterColumnGroupName,
     getAclFilterColumns,
     getAclFilterRowGroupName,
-} from '../../store/selectors/acl-filters';
+} from '../../store/selectors/acl/acl-filters';
 
 import {
     cancelRequestPermissions,

--- a/packages/ui/src/ui/containers/ACL/ACL.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL.tsx
@@ -20,7 +20,10 @@ import WithStickyToolbar from '../../components/WithStickyToolbar/WithStickyTool
 import {isIdmAclAvailable} from '../../config';
 import {AclMode, IdmObjectType} from '../../constants/acl';
 import withVisible, {type WithVisibleProps} from '../../hocs/withVisible';
-import {type ObjectPermissionRowWithExpand, type PreparedApprover} from '../../store/selectors/acl/acl';
+import {
+    type ObjectPermissionRowWithExpand,
+    type PreparedApprover,
+} from '../../store/selectors/acl/acl';
 import UIFactory, {type AclRoleActionsType} from '../../UIFactory';
 import {type PreparedRole, isGranted} from '../../utils/acl';
 import {type PreparedAclSubject} from '../../utils/acl/acl-types';

--- a/packages/ui/src/ui/containers/ACL/ACL.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL.tsx
@@ -20,7 +20,7 @@ import WithStickyToolbar from '../../components/WithStickyToolbar/WithStickyTool
 import {isIdmAclAvailable} from '../../config';
 import {AclMode, IdmObjectType} from '../../constants/acl';
 import withVisible, {type WithVisibleProps} from '../../hocs/withVisible';
-import {type ObjectPermissionRowWithExpand, type PreparedApprover} from '../../store/selectors/acl';
+import {type ObjectPermissionRowWithExpand, type PreparedApprover} from '../../store/selectors/acl/acl';
 import UIFactory, {type AclRoleActionsType} from '../../UIFactory';
 import {type PreparedRole, isGranted} from '../../utils/acl';
 import {type PreparedAclSubject} from '../../utils/acl/acl-types';

--- a/packages/ui/src/ui/containers/ACL/ApproversFilters/ApproversFilters.tsx
+++ b/packages/ui/src/ui/containers/ACL/ApproversFilters/ApproversFilters.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import cn from 'bem-cn-lite';
 import {changeApproversSubjectFilter} from '../../../store/actions/acl-filters';
-import {getApproversSubjectFilter} from '../../../store/selectors/acl-filters';
+import {getApproversSubjectFilter} from '../../../store/selectors/acl/acl-filters';
 import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import Filter from '../../../components/Filter/Filter';
 import i18n from './i18n';

--- a/packages/ui/src/ui/containers/ACL/ApproversFilters/ApproversFilters.tsx
+++ b/packages/ui/src/ui/containers/ACL/ApproversFilters/ApproversFilters.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import cn from 'bem-cn-lite';
 import {changeApproversSubjectFilter} from '../../../store/actions/acl-filters';
-import {getApproversSubjectFilter} from '../../../store/selectors/acl/acl-filters';
+import {selectApproversSubjectFilter} from '../../../store/selectors/acl/acl-filters';
 import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import Filter from '../../../components/Filter/Filter';
 import i18n from './i18n';
@@ -12,7 +12,7 @@ const block = cn('approvers-filters');
 
 export default function ApproversFilters() {
     const dispatch = useDispatch();
-    const subjectFilter = useSelector(getApproversSubjectFilter);
+    const subjectFilter = useSelector(selectApproversSubjectFilter);
 
     return (
         <Toolbar

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
@@ -6,7 +6,7 @@ import Filter from '../../../components/Filter/Filter';
 import Select from '../../../components/Select/Select';
 import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import {AclMode} from '../../../constants/acl';
-import {getObjectPermissionsTypesList} from '../../../store/selectors/acl/acl';
+import {selectObjectPermissionsTypesList} from '../../../store/selectors/acl/acl';
 import {
     getAclRowAccessPredicateFilter,
     getObjectPermissionsFilter,
@@ -35,7 +35,7 @@ export default function ObjectPermissionsFilters({
     const dispatch = useDispatch();
     const subjectFilter = useSelector(getObjectSubjectFilter);
     const selectedPermissons = useSelector(getObjectPermissionsFilter);
-    const permissionList = useSelector(getObjectPermissionsTypesList(idmKind));
+    const permissionList = useSelector(selectObjectPermissionsTypesList(idmKind));
 
     const rowAccessPredicateFilter = useSelector(getAclRowAccessPredicateFilter);
 

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
@@ -8,10 +8,10 @@ import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import {AclMode} from '../../../constants/acl';
 import {selectObjectPermissionsTypesList} from '../../../store/selectors/acl/acl';
 import {
-    getAclRowAccessPredicateFilter,
-    getObjectPermissionsFilter,
-    getObjectSubjectFilter,
-} from '../../../store/selectors/acl-filters';
+    selectAclRowAccessPredicateFilter,
+    selectObjectPermissionsFilter,
+    selectObjectSubjectFilter,
+} from '../../../store/selectors/acl/acl-filters';
 import {type ACLReduxProps} from '../ACL-connect-helpers';
 import {ColumnGroupsFilter} from '../ColumnGroups/ColumnGroups';
 import i18nPermissionValues from '../i18n-permission-values';
@@ -33,11 +33,11 @@ export default function ObjectPermissionsFilters({
     userPermissionsAccessColumns,
 }: Props) {
     const dispatch = useDispatch();
-    const subjectFilter = useSelector(getObjectSubjectFilter);
-    const selectedPermissons = useSelector(getObjectPermissionsFilter);
+    const subjectFilter = useSelector(selectObjectSubjectFilter);
+    const selectedPermissons = useSelector(selectObjectPermissionsFilter);
     const permissionList = useSelector(selectObjectPermissionsTypesList(idmKind));
 
-    const rowAccessPredicateFilter = useSelector(getAclRowAccessPredicateFilter);
+    const rowAccessPredicateFilter = useSelector(selectAclRowAccessPredicateFilter);
 
     return (
         <Toolbar

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
@@ -6,7 +6,7 @@ import Filter from '../../../components/Filter/Filter';
 import Select from '../../../components/Select/Select';
 import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import {AclMode} from '../../../constants/acl';
-import {getObjectPermissionsTypesList} from '../../../store/selectors/acl';
+import {getObjectPermissionsTypesList} from '../../../store/selectors/acl/acl';
 import {
     getAclRowAccessPredicateFilter,
     getObjectPermissionsFilter,

--- a/packages/ui/src/ui/pages/navigation/tabs/ACL/ACL.js
+++ b/packages/ui/src/ui/pages/navigation/tabs/ACL/ACL.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import {AccessContentAcl, NavigationAcl} from '../../../../containers/ACL';
-import {getAclLoadState} from '../../../../store/selectors/acl/acl';
+import {selectAclLoadState} from '../../../../store/selectors/acl/acl';
 import {getAttributes, getRawPath} from '../../../../store/selectors/navigation';
 import {IdmObjectType} from '../../../../constants/acl';
 import {useRumMeasureStop} from '../../../../rum/RumUiContext';
@@ -53,7 +53,7 @@ const makeMapStateToProps = (idmKind) => {
             props.mode === 'content' && props.type === 'access_control_object';
 
         return {
-            loadState: getAclLoadState(state, idmKind),
+            loadState: selectAclLoadState(state, idmKind),
             path,
             idmKind: isPrincipalACLtab ? IdmObjectType.ACCESS_CONTROL_OBJECT : IdmObjectType.PATH,
         };

--- a/packages/ui/src/ui/pages/navigation/tabs/ACL/ACL.js
+++ b/packages/ui/src/ui/pages/navigation/tabs/ACL/ACL.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import {AccessContentAcl, NavigationAcl} from '../../../../containers/ACL';
-import {getAclLoadState} from '../../../../store/selectors/acl';
+import {getAclLoadState} from '../../../../store/selectors/acl/acl';
 import {getAttributes, getRawPath} from '../../../../store/selectors/navigation';
 import {IdmObjectType} from '../../../../constants/acl';
 import {useRumMeasureStop} from '../../../../rum/RumUiContext';

--- a/packages/ui/src/ui/pages/navigation/tabs/ACL/RequestPermissions/RequestPermissions.js
+++ b/packages/ui/src/ui/pages/navigation/tabs/ACL/RequestPermissions/RequestPermissions.js
@@ -4,7 +4,7 @@ import RequestPermissions from '../../../../../containers/ACL/RequestPermissions
 import {
     getDenyColumnsItems,
     getIdmPermissionsRequestError,
-} from '../../../../../store/selectors/acl';
+} from '../../../../../store/selectors/acl/acl';
 import {cancelRequestPermissions, requestPermissions} from '../../../../../store/actions/acl';
 import {IdmObjectType} from '../../../../../constants/acl';
 

--- a/packages/ui/src/ui/pages/navigation/tabs/ACL/RequestPermissions/RequestPermissions.js
+++ b/packages/ui/src/ui/pages/navigation/tabs/ACL/RequestPermissions/RequestPermissions.js
@@ -2,8 +2,8 @@ import {connect} from 'react-redux';
 
 import RequestPermissions from '../../../../../containers/ACL/RequestPermissions/RequestPermissions';
 import {
-    getDenyColumnsItems,
-    getIdmPermissionsRequestError,
+    selectDenyColumnsItems,
+    selectIdmPermissionsRequestError,
 } from '../../../../../store/selectors/acl/acl';
 import {cancelRequestPermissions, requestPermissions} from '../../../../../store/actions/acl';
 import {IdmObjectType} from '../../../../../constants/acl';
@@ -11,12 +11,12 @@ import {IdmObjectType} from '../../../../../constants/acl';
 const idmKind = IdmObjectType.PATH;
 
 const mapStateToProps = (state) => {
-    const denyColumns = getDenyColumnsItems(state, idmKind);
+    const denyColumns = selectDenyColumnsItems(state, idmKind);
 
     return {
         idmKind,
         denyColumns,
-        error: getIdmPermissionsRequestError(state, idmKind),
+        error: selectIdmPermissionsRequestError(state, idmKind),
     };
 };
 

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAcl/PoolAcl.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAcl/PoolAcl.tsx
@@ -17,7 +17,7 @@ import {PoolAclPanel} from '../../../../../containers/ACL';
 import {RumMeasureTypes} from '../../../../../rum/rum-measure-types';
 import {useRumMeasureStop} from '../../../../../rum/RumUiContext';
 import {isFinalLoadingStatus} from '../../../../../utils/utils';
-import {getAclLoadState} from '../../../../../store/selectors/acl';
+import {getAclLoadState} from '../../../../../store/selectors/acl/acl';
 import {type LoadingStatus} from '../../../../../constants';
 import {IdmObjectType} from '../../../../../constants/acl';
 import {useAppRumMeasureStart} from '../../../../../rum/rum-app-measures';

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAcl/PoolAcl.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAcl/PoolAcl.tsx
@@ -17,8 +17,8 @@ import {PoolAclPanel} from '../../../../../containers/ACL';
 import {RumMeasureTypes} from '../../../../../rum/rum-measure-types';
 import {useRumMeasureStop} from '../../../../../rum/RumUiContext';
 import {isFinalLoadingStatus} from '../../../../../utils/utils';
-import {getAclLoadState} from '../../../../../store/selectors/acl/acl';
 import {type LoadingStatus} from '../../../../../constants';
+import {selectAclLoadState} from '../../../../../store/selectors/acl/acl';
 import {IdmObjectType} from '../../../../../constants/acl';
 import {useAppRumMeasureStart} from '../../../../../rum/rum-app-measures';
 
@@ -66,7 +66,7 @@ function PoolAclWithRum({loadState}: {loadState: LoadingStatus}) {
 
 const mapStateToProps = (state: RootState) => {
     return {
-        loadState: getAclLoadState(state, IdmObjectType.POOL),
+        loadState: selectAclLoadState(state, IdmObjectType.POOL),
     };
 };
 

--- a/packages/ui/src/ui/store/actions/acl-filters.ts
+++ b/packages/ui/src/ui/store/actions/acl-filters.ts
@@ -1,5 +1,5 @@
 import {type ThunkAction} from 'redux-thunk';
-import {getAclFilterExpandedSubjects} from '../../store/selectors/acl-filters';
+import {getAclFilterExpandedSubjects} from '../../store/selectors/acl/acl-filters';
 import {ACL_CHANGE_FILTERS} from '../../constants/acl';
 
 import {type AclFiltersAction, type AclFiltersState} from '../reducers/acl/acl-filters';

--- a/packages/ui/src/ui/store/actions/acl-filters.ts
+++ b/packages/ui/src/ui/store/actions/acl-filters.ts
@@ -1,5 +1,5 @@
 import {type ThunkAction} from 'redux-thunk';
-import {getAclFilterExpandedSubjects} from '../../store/selectors/acl/acl-filters';
+import {selectAclFilterExpandedSubjects} from '../../store/selectors/acl/acl-filters';
 import {ACL_CHANGE_FILTERS} from '../../constants/acl';
 
 import {type AclFiltersAction, type AclFiltersState} from '../reducers/acl/acl-filters';
@@ -26,7 +26,7 @@ export function toggleExpandAclSubject(subject?: string | number): AclFilterThun
             return;
         }
 
-        const expandedSubjects = new Set(getAclFilterExpandedSubjects(getState()));
+        const expandedSubjects = new Set(selectAclFilterExpandedSubjects(getState()));
         if (expandedSubjects.has(subject)) {
             expandedSubjects.delete(subject);
         } else {

--- a/packages/ui/src/ui/store/selectors/acl/acl-filters.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl-filters.ts
@@ -1,6 +1,6 @@
 import {createSelector} from 'reselect';
-import {type RootState} from '../reducers';
-import {ACL_MODES, AclMode} from '../../constants/acl';
+import {type RootState} from '../../../store/reducers';
+import {ACL_MODES, AclMode} from '../../../constants/acl';
 
 export function getExecuteBatchState(state: RootState) {
     return state.executeBatch;

--- a/packages/ui/src/ui/store/selectors/acl/acl-filters.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl-filters.ts
@@ -2,21 +2,29 @@ import {createSelector} from 'reselect';
 import {type RootState} from '../../../store/reducers';
 import {ACL_MODES, AclMode} from '../../../constants/acl';
 
-export function getExecuteBatchState(state: RootState) {
-    return state.executeBatch;
-}
+export const selectApproversSubjectFilter = (state: RootState) => state.aclFilters.approversSubject;
 
-export const getApproversSubjectFilter = (state: RootState) => state.aclFilters.approversSubject;
-export const getObjectSubjectFilter = (state: RootState) => state.aclFilters.objectSubject;
-export const getObjectPermissionsFilter = (state: RootState) => state.aclFilters.objectPermissions;
-export const getAclFilterColumns = (state: RootState) => state.aclFilters.columnsFilter;
-export const getAclFilterColumnGroupName = (state: RootState) =>
+export const selectObjectSubjectFilter = (state: RootState) => state.aclFilters.objectSubject;
+
+export const selectObjectPermissionsFilter = (state: RootState) =>
+    state.aclFilters.objectPermissions;
+
+export const selectAclFilterColumns = (state: RootState) => state.aclFilters.columnsFilter;
+
+export const selectAclFilterColumnGroupName = (state: RootState) =>
     state.aclFilters.columnGroupNameFilter;
-export const getAclFilterRowGroupName = (state: RootState) => state.aclFilters.rowGroupNameFilter;
-export const getAclFilterExpandedSubjects = (state: RootState) => state.aclFilters.expandedSubjects;
-const getAclCurrentTabRaw = (state: RootState) => state.aclFilters.aclCurrentTab;
-export const getAclCurrentTab = createSelector([getAclCurrentTabRaw], (value) => {
+
+export const selectAclFilterRowGroupName = (state: RootState) =>
+    state.aclFilters.rowGroupNameFilter;
+
+export const selectAclFilterExpandedSubjects = (state: RootState) =>
+    state.aclFilters.expandedSubjects;
+
+const selectAclCurrentTabRaw = (state: RootState) => state.aclFilters.aclCurrentTab;
+
+export const selectAclCurrentTab = createSelector([selectAclCurrentTabRaw], (value) => {
     return -1 !== ACL_MODES.indexOf(value) ? value : AclMode.MAIN_PERMISSIONS;
 });
-export const getAclRowAccessPredicateFilter = (state: RootState) =>
+
+export const selectAclRowAccessPredicateFilter = (state: RootState) =>
     state.aclFilters.rowAccessPredicateFilter;

--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -61,21 +61,21 @@ function prepareApprovers(
 
 export type PreparedApprover = ReturnType<typeof prepareApprovers>[number];
 
-export const getAllUserPermissions = (state: RootState, idmKind: IdmKindType) =>
+export const selectAllUserPermissions = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].userPermissions;
-const getAllObjectPermissions = (state: RootState, idmKind: IdmKindType) =>
+const selectAllObjectPermissions = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].objectPermissions;
 
-const getAllObjectPermissionsWithSplittedSubjects = createSelector(
-    [getAllObjectPermissions],
+const selectAllObjectPermissionsWithSplittedSubjects = createSelector(
+    [selectAllObjectPermissions],
     splitSubjects,
 );
 
-export const getObjectPermissionsTypesList = (idmKind: IdmKindType) => {
+export const selectObjectPermissionsTypesList = (idmKind: IdmKindType) => {
     return createSelector(
         [
             getObjectPermissionsFilter,
-            (state) => getAllObjectPermissionsWithSplittedSubjects(state, idmKind),
+            (state) => selectAllObjectPermissionsWithSplittedSubjects(state, idmKind),
         ],
         (permissionsFilter, items) => {
             const uniquePermisions = new Set<YTPermissionTypeUI>();
@@ -151,9 +151,9 @@ const permissionsFilterPredicate = (item: PreparedAclSubject, filter: Set<YTPerm
 
 type ObjectPermissionsRow = PreparedAclSubject & HasSplitted;
 
-export const getAllObjectPermissionsFiltered = createSelector(
+export const selectAllObjectPermissionsFiltered = createSelector(
     [
-        getAllObjectPermissionsWithSplittedSubjects,
+        selectAllObjectPermissionsWithSplittedSubjects,
         getObjectSubjectFilter,
         getObjectPermissionsFilter,
         getAclFilterColumns,
@@ -229,8 +229,8 @@ export const getAllObjectPermissionsFiltered = createSelector(
     },
 );
 
-export const getObjectPermissionsAggregated = createSelector(
-    [getAllObjectPermissionsFiltered, getAclFilterExpandedSubjects],
+export const selectObjectPermissionsAggregated = createSelector(
+    [selectAllObjectPermissionsFiltered, getAclFilterExpandedSubjects],
     (data, expandedSubjects) => {
         const keys = Object.keys(data) as Array<keyof typeof data>;
         return keys.reduce(
@@ -407,14 +407,14 @@ function aggregateBySubject(
     };
 }
 
-export const getAllObjectPermissionsOrderedByStatus = createSelector(
-    [getAllObjectPermissions],
+export const selectAllObjectPermissionsOrderedByStatus = createSelector(
+    [selectAllObjectPermissions],
     OrderByRoleStatus,
 );
-export const getAllColumnGroups = (state: RootState, idmKind: IdmKindType) =>
+export const selectAllColumnGroups = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].columnGroups;
-export const getAllColumnGroupsActual = createSelector(
-    [getAllColumnGroups, getAclFilterColumns, getAclFilterColumnGroupName],
+export const selectAllColumnGroupsActual = createSelector(
+    [selectAllColumnGroups, getAclFilterColumns, getAclFilterColumnGroupName],
     (items, columnsFilter, nameFilter) => {
         const visibleColumns = new Set(columnsFilter);
         type ItemType = (typeof items)[number];
@@ -440,9 +440,9 @@ export const getAllColumnGroupsActual = createSelector(
     },
 );
 
-export const getAllRowGroups = (state: RootState, idmKind: IdmKindType) =>
+export const selectAllRowGroups = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].rowGroups;
-export const getAllRowGroupsActual = createSelector([getAllRowGroups], (rowGroups) => {
+export const selectAllRowGroupsActual = createSelector([selectAllRowGroups], (rowGroups) => {
     return rowGroups;
 });
 
@@ -483,23 +483,25 @@ function OrderByInheritanceAndSubject<T extends {inherited?: boolean; subjects: 
     return res;
 }
 
-const getReadApprovers = (state: RootState, idmKind: IdmKindType) =>
+const selectReadApprovers = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].readApprovers;
-const getResponsibles = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].responsible;
-const getAuditors = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].auditors;
+const selectResponsibles = (state: RootState, idmKind: IdmKindType) =>
+    state.acl[idmKind].responsible;
+const selectAuditors = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].auditors;
 
-export const getNotInheritedReadApprovers = createSelector([getReadApprovers], (readApprovers) =>
-    filter_(readApprovers, (readApprover) => !readApprover.inherited),
+export const selectNotInheritedReadApprovers = createSelector(
+    [selectReadApprovers],
+    (readApprovers) => filter_(readApprovers, (readApprover) => !readApprover.inherited),
 );
-export const getNotInheritedResponsibles = createSelector([getResponsibles], (responsibles) =>
+export const selectNotInheritedResponsibles = createSelector([selectResponsibles], (responsibles) =>
     filter_(responsibles, (responsible) => !responsible.inherited),
 );
-export const getNotInheritedAuditors = createSelector([getAuditors], (auditros) =>
+export const selectNotInheritedAuditors = createSelector([selectAuditors], (auditros) =>
     filter_(auditros, (auditro) => !auditro.inherited),
 );
 
-const getAllApprovers = createSelector(
-    [getReadApprovers, getResponsibles, getAuditors],
+const selectAllApprovers = createSelector(
+    [selectReadApprovers, selectResponsibles, selectAuditors],
     (readApprovers, responsibles, auditros) => {
         return [
             ...prepareApprovers(readApprovers, 'read_approver'),
@@ -509,22 +511,22 @@ const getAllApprovers = createSelector(
     },
 );
 
-export const getHasApprovers = createSelector([getAllApprovers], (items) => items.length > 0);
+export const selectHasApprovers = createSelector([selectAllApprovers], (items) => items.length > 0);
 
-export const getApproversFiltered = createSelector(
-    [getAllApprovers, getApproversSubjectFilter],
+export const selectApproversFiltered = createSelector(
+    [selectAllApprovers, getApproversSubjectFilter],
     FilterBySubject,
 );
 
-export const getApproversFilteredAndOrdered = createSelector(
-    [getApproversFiltered],
+export const selectApproversFilteredAndOrdered = createSelector(
+    [selectApproversFiltered],
     OrderByInheritanceAndSubject,
 );
 
-export const getApprovers = createSelector([getAllApprovers], OrderByRoleStatus);
+export const selectApprovers = createSelector([selectAllApprovers], OrderByRoleStatus);
 
-export const getAllAccessColumnsPermissions = createSelector(
-    [getAllObjectPermissions],
+export const selectAllAccessColumnsPermissions = createSelector(
+    [selectAllObjectPermissions],
     (objectPermissions) => {
         const filteredPermissions = filter_(
             objectPermissions,
@@ -539,8 +541,8 @@ export const getAllAccessColumnsPermissions = createSelector(
     },
 );
 
-const getAllDenyColumnsPermissions = createSelector(
-    [getAllObjectPermissions],
+const selectAllDenyColumnsPermissions = createSelector(
+    [selectAllObjectPermissions],
     (objectPermissions) => {
         const filteredPermissions = filter_(
             objectPermissions,
@@ -558,39 +560,39 @@ const getAllDenyColumnsPermissions = createSelector(
     },
 );
 
-export const getAllAccessColumnsNames = createSelector(
-    [getAllAccessColumnsPermissions],
+export const selectAllAccessColumnsNames = createSelector(
+    [selectAllAccessColumnsPermissions],
     prepareColumnsNames,
 );
 
-export const getAllDenyColumnsNames = createSelector(
-    [getAllDenyColumnsPermissions],
+export const selectAllDenyColumnsNames = createSelector(
+    [selectAllDenyColumnsPermissions],
     prepareColumnsNames,
 );
 
-export const getDenyColumnsItems = createSelector([getAllDenyColumnsNames], (names) =>
+export const selectDenyColumnsItems = createSelector([selectAllDenyColumnsNames], (names) =>
     map_(names, (name) => ({key: name, value: name, title: name})),
 );
 
-export const isPermissionDeleted = (state: RootState, idmKind: IdmKindType) =>
+export const selectIsPermissionDeleted = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].isPermissionDeleted;
-export const permissionDeletionError = (state: RootState, idmKind: IdmKindType) =>
+export const selectPermissionDeletionError = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].deletionError;
-export const getLastDeletedPermissionKey = (state: RootState, idmKind: IdmKindType) =>
+export const selectLastDeletedPermissionKey = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].deletedItemKey;
-export const getIdmPermissionsRequestError = (state: RootState, idmKind: IdmKindType) =>
+export const selectIdmPermissionsRequestError = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].idmPermissionsRequestError;
-export const getIdmManageAclRequestError = (state: RootState, idmKind: IdmKindType) =>
+export const selectIdmManageAclRequestError = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].idmManageAclRequestError;
-export const getIdmPathVersion = (state: RootState, idmKind: IdmKindType) =>
+export const selectIdmPathVersion = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].version;
 
-const getAclLoading = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].loading;
-const getAclLoaded = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].loaded;
-const getAclError = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].error;
+const selectAclLoading = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].loading;
+const selectAclLoaded = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].loaded;
+const selectAclError = (state: RootState, idmKind: IdmKindType) => state.acl[idmKind].error;
 
-export const getAclLoadState = createSelector(
-    [getAclLoading, getAclLoaded, getAclError],
+export const selectAclLoadState = createSelector(
+    [selectAclLoading, selectAclLoaded, selectAclError],
     (loading, loaded, error) => {
         return calculateLoadingStatus(loading, loaded, error);
     },

--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -12,6 +12,7 @@ import sortBy_ from 'lodash/sortBy';
 import uniq_ from 'lodash/uniq';
 
 import {concatByAnd} from '../../../common/hammer/predicate';
+import {RootState} from '../../../store/reducers';
 import {
     getAclFilterColumnGroupName,
     getAclFilterColumns,
@@ -22,7 +23,6 @@ import {
     getObjectSubjectFilter,
 } from '../../../store/selectors/acl/acl-filters';
 import UIFactory from '../../../UIFactory';
-
 import {type RootState} from '../../../store/reducers';
 import {type IdmKindType, type PreparedAclSubject} from '../../../utils/acl/acl-types';
 import {type YTPermissionTypeUI} from '../../../utils/acl/acl-api';

--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -12,15 +12,14 @@ import sortBy_ from 'lodash/sortBy';
 import uniq_ from 'lodash/uniq';
 
 import {concatByAnd} from '../../../common/hammer/predicate';
-import {RootState} from '../../../store/reducers';
 import {
-    getAclFilterColumnGroupName,
-    getAclFilterColumns,
-    getAclFilterExpandedSubjects,
-    getAclRowAccessPredicateFilter,
-    getApproversSubjectFilter,
-    getObjectPermissionsFilter,
-    getObjectSubjectFilter,
+    selectAclFilterColumnGroupName,
+    selectAclFilterColumns,
+    selectAclFilterExpandedSubjects,
+    selectAclRowAccessPredicateFilter,
+    selectApproversSubjectFilter,
+    selectObjectPermissionsFilter,
+    selectObjectSubjectFilter,
 } from '../../../store/selectors/acl/acl-filters';
 import UIFactory from '../../../UIFactory';
 import {type RootState} from '../../../store/reducers';
@@ -74,7 +73,7 @@ const selectAllObjectPermissionsWithSplittedSubjects = createSelector(
 export const selectObjectPermissionsTypesList = (idmKind: IdmKindType) => {
     return createSelector(
         [
-            getObjectPermissionsFilter,
+            selectObjectPermissionsFilter,
             (state) => selectAllObjectPermissionsWithSplittedSubjects(state, idmKind),
         ],
         (permissionsFilter, items) => {
@@ -154,10 +153,10 @@ type ObjectPermissionsRow = PreparedAclSubject & HasSplitted;
 export const selectAllObjectPermissionsFiltered = createSelector(
     [
         selectAllObjectPermissionsWithSplittedSubjects,
-        getObjectSubjectFilter,
-        getObjectPermissionsFilter,
-        getAclFilterColumns,
-        getAclRowAccessPredicateFilter,
+        selectObjectSubjectFilter,
+        selectObjectPermissionsFilter,
+        selectAclFilterColumns,
+        selectAclRowAccessPredicateFilter,
     ],
     (items, subjectFilter, permissionsFilter, columns, rowAccessPredicateFilter) => {
         const {mainPermissions, columnPermissions, rowPermissions} = items.reduce(
@@ -230,7 +229,7 @@ export const selectAllObjectPermissionsFiltered = createSelector(
 );
 
 export const selectObjectPermissionsAggregated = createSelector(
-    [selectAllObjectPermissionsFiltered, getAclFilterExpandedSubjects],
+    [selectAllObjectPermissionsFiltered, selectAclFilterExpandedSubjects],
     (data, expandedSubjects) => {
         const keys = Object.keys(data) as Array<keyof typeof data>;
         return keys.reduce(
@@ -414,7 +413,7 @@ export const selectAllObjectPermissionsOrderedByStatus = createSelector(
 export const selectAllColumnGroups = (state: RootState, idmKind: IdmKindType) =>
     state.acl[idmKind].columnGroups;
 export const selectAllColumnGroupsActual = createSelector(
-    [selectAllColumnGroups, getAclFilterColumns, getAclFilterColumnGroupName],
+    [selectAllColumnGroups, selectAclFilterColumns, selectAclFilterColumnGroupName],
     (items, columnsFilter, nameFilter) => {
         const visibleColumns = new Set(columnsFilter);
         type ItemType = (typeof items)[number];
@@ -514,7 +513,7 @@ const selectAllApprovers = createSelector(
 export const selectHasApprovers = createSelector([selectAllApprovers], (items) => items.length > 0);
 
 export const selectApproversFiltered = createSelector(
-    [selectAllApprovers, getApproversSubjectFilter],
+    [selectAllApprovers, selectApproversSubjectFilter],
     FilterBySubject,
 );
 

--- a/packages/ui/src/ui/store/selectors/acl/index.ts
+++ b/packages/ui/src/ui/store/selectors/acl/index.ts
@@ -4,15 +4,14 @@ import compact_ from 'lodash/compact';
 import filter_ from 'lodash/filter';
 import flatten_ from 'lodash/flatten';
 import forEach_ from 'lodash/forEach';
+import isEqual_ from 'lodash/isEqual';
 import map_ from 'lodash/map';
+import partition_ from 'lodash/partition';
+import some_ from 'lodash/some';
 import sortBy_ from 'lodash/sortBy';
 import uniq_ from 'lodash/uniq';
-import partition_ from 'lodash/partition';
-import isEqual_ from 'lodash/isEqual';
-import some_ from 'lodash/some';
 
-import {calculateLoadingStatus} from '../../utils/utils';
-import {concatByAnd} from '../../common/hammer/predicate';
+import {concatByAnd} from '../../../common/hammer/predicate';
 import {
     getAclFilterColumnGroupName,
     getAclFilterColumns,
@@ -21,12 +20,14 @@ import {
     getApproversSubjectFilter,
     getObjectPermissionsFilter,
     getObjectSubjectFilter,
-} from './acl-filters';
-import UIFactory from '../../UIFactory';
-import {type RootState} from '../../store/reducers';
-import {type IdmKindType, type PreparedAclSubject} from '../../utils/acl/acl-types';
-import {type YTPermissionTypeUI} from '../../utils/acl/acl-api';
-import {type PreparedRole} from '../../utils/acl';
+} from '../../../store/selectors/acl/acl-filters';
+import UIFactory from '../../../UIFactory';
+
+import {type RootState} from '../../../store/reducers';
+import {type IdmKindType, type PreparedAclSubject} from '../../../utils/acl/acl-types';
+import {type YTPermissionTypeUI} from '../../../utils/acl/acl-api';
+import {type PreparedRole} from '../../../utils/acl';
+import {calculateLoadingStatus} from '../../../utils/utils';
 
 export type PreparedAclSubjectColumn = Omit<PreparedAclSubject, 'type'> & {type: 'columns'};
 

--- a/packages/ui/src/ui/utils/acl/external-acl-api.ts
+++ b/packages/ui/src/ui/utils/acl/external-acl-api.ts
@@ -25,7 +25,7 @@ import {
     type UpdateAclParams,
     type UpdateResponse,
 } from './acl-types';
-import {type PreparedApprover} from '../../store/selectors/acl';
+import {type PreparedApprover} from '../../store/selectors/acl/acl';
 
 export interface AclApi {
     isAllowed: boolean;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/QoTN9p7Z7Y7B4e
<!-- nda-end -->    ## Summary by Sourcery

Rename ACL selectors to use a unified `select*` naming convention and reorganize them under a dedicated `acl` selector module.

Enhancements:
- Extract ACL filter-related selectors into a separate `acl-filters` selector module and update imports across the ACL UI.
- Standardize ACL selector names (e.g. permissions, approvers, load state) to the `select*` prefix throughout containers, pages, and utilities.