### PR TITLE
fix(oauth): added embedding custom ca certs to k8s deployment

### DIFF
--- a/packages/ui-helm-chart/templates/deployment.yaml
+++ b/packages/ui-helm-chart/templates/deployment.yaml
@@ -35,9 +35,9 @@ spec:
               value: custom
             - name: YT_AUTH_ALLOW_INSECURE
               value: "1"
-              {{- if $.Values.ui.caCerts.useExtraCerts }}
+              {{- with $.Values.caRootBundle }}
             - name: NODE_EXTRA_CA_CERTS
-              value: /opt/app/certs/extra_ca_certs.crt
+              value: /etc/ssl/certs/ca-certificates.crt
               {{- end }}
           {{- end }}
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Chart.AppVersion }}"
@@ -74,10 +74,10 @@ spec:
               readOnly: true
             - mountPath: /opt/app/secrets
               name: secrets
-            {{- if .Values.ui.caCerts.useExtraCerts }}
-            - mountPath: /opt/app/certs/extra_ca_certs.crt
-              name: extra-ca-certs
-              subPath: "{{ .Values.ui.caCerts.configMapKey }}"
+            {{- with .Values.caRootBundle }}
+            - mountPath: /etc/ssl/certs
+              name: ca-root-bundle
+              readOnly: true
             {{- end }}
       initContainers:
         - command:
@@ -132,9 +132,20 @@ spec:
         - emptyDir:
             sizeLimit: 1Mi
           name: secrets
-        {{- if .Values.ui.caCerts.useExtraCerts }}
-        - configMap:
-            defaultMode: 420
-            name: "{{ .Values.ui.caCerts.configMapName }}"
-          name: extra-ca-certs
+        {{- with .Values.caRootBundle }}
+        {{- if eq .kind "ConfigMap" }}
+        - name: ca-root-bundle
+          configMap:
+            name: {{ .name }}
+            items:
+            - key: {{ .key }}
+              path: ca-certificates.crt
+        {{- else if eq .kind "Secret" }}
+        - name: ca-root-bundle
+          secret:
+            secretName: {{ .name }}
+            items:
+            - key: {{ .key }}
+              path: ca-certificates.crt
+        {{- end }}
         {{- end }}

--- a/packages/ui-helm-chart/templates/deployment.yaml
+++ b/packages/ui-helm-chart/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             {{- if .Values.ui.caCerts.useExtraCerts }}
             - mountPath: /opt/app/certs/extra_ca_certs.crt
               name: extra-ca-certs
-              subPath: {{.Values.ui.caCerts.configMapKey}}
+              subPath: "{{ .Values.ui.caCerts.configMapKey }}"
             {{- end }}
       initContainers:
         - command:
@@ -135,6 +135,6 @@ spec:
         {{- if .Values.ui.caCerts.useExtraCerts }}
         - configMap:
             defaultMode: 420
-            name: {{.Values.ui.caCerts.configMapName }}
+            name: "{{ .Values.ui.caCerts.configMapName }}"
           name: extra-ca-certs
         {{- end }}

--- a/packages/ui-helm-chart/templates/deployment.yaml
+++ b/packages/ui-helm-chart/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
               value: custom
             - name: YT_AUTH_ALLOW_INSECURE
               value: "1"
+              {{- if $.Values.ui.caCerts.useExtraCerts }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /opt/app/certs/extra_ca_certs.crt
+              {{- end }}
           {{- end }}
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
@@ -70,6 +74,11 @@ spec:
               readOnly: true
             - mountPath: /opt/app/secrets
               name: secrets
+            {{- if .Values.ui.caCerts.useExtraCerts }}
+            - mountPath: /opt/app/certs/extra_ca_certs.crt
+              name: extra-ca-certs
+              subPath: {{.Values.ui.caCerts.configMapKey}}
+            {{- end }}
       initContainers:
         - command:
           - bash
@@ -123,3 +132,9 @@ spec:
         - emptyDir:
             sizeLimit: 1Mi
           name: secrets
+        {{- if .Values.ui.caCerts.useExtraCerts }}
+        - configMap:
+            defaultMode: 420
+            name: {{.Values.ui.caCerts.configMapName }}
+          name: extra-ca-certs
+        {{- end }}

--- a/packages/ui-helm-chart/values.yaml
+++ b/packages/ui-helm-chart/values.yaml
@@ -1,3 +1,8 @@
+# caRootBundle:
+#   kind: ConfigMap
+#   name: ca-root-bundle
+#   key: ca-certificates.crt
+
 ui:
   replicaCount: 1
   image:
@@ -28,11 +33,6 @@ ui:
       # see https://github.com/ytsaurus/ytsaurus-ui/tree/main/packages/ui#how-to-work-with-the-repo
       secretName: "yt-ui-secret"
       secretKey: "yt-interface-secret.json"
-
-  caCerts:
-    useExtraCerts: false
-    configMapName: ca-certs
-    configMapKey: ca.crt
 
 service:
   type: NodePort

--- a/packages/ui-helm-chart/values.yaml
+++ b/packages/ui-helm-chart/values.yaml
@@ -29,6 +29,11 @@ ui:
       secretName: "yt-ui-secret"
       secretKey: "yt-interface-secret.json"
 
+  caCerts:
+    useExtraCerts: false
+    configMapName: ca-certs
+    configMapKey: ca.crt
+
 service:
   type: NodePort
   port: 80


### PR DESCRIPTION
I had some problems setting up the SSO. My oauth server is accessible via https, but uses a self-signed certificate for this. Therefore, when ui pod tried to establish a connection with the oauth server, the error "unable to get local issuer certificate" was displayed. That's why I added the ability to embed self-signed certificates in ui deployment.

## Summary by Sourcery

Enhancements:
- Add optional mounting of a ConfigMap containing extra CA certificates into the UI pod and expose it via NODE_EXTRA_CA_CERTS environment variable.