### PR TITLE
chore: redefine body-1 variant text size [YTFRONT-5693]

### DIFF
--- a/packages/ui/src/ui/styles/redefinitions/common/common.scss
+++ b/packages/ui/src/ui/styles/redefinitions/common/common.scss
@@ -11,3 +11,7 @@
 .gn-composite-bar_autosizer .gn-composite-bar-item__icon {
     color: var(--gn-aside-header-item-icon-color, var(--g-color-text-misc));
 }
+
+.g-text_variant_body-1 {
+    --g-text-body-1-font-size: 14px;
+}


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/boQnig1H7YBQHb
<!-- nda-end -->## Summary by Sourcery

Enhancements:
- Adjust the body-1 text variant font size to 14px through a shared SCSS redefinition.