### PR TITLE
feat(Navigation/tablets): add new columns to tables [YTFRONT-5611]

### DIFF
--- a/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.js
+++ b/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.js
@@ -27,6 +27,7 @@ import {
     getHistogram,
     getNavigationTabletsLoadingStatus,
     getTablets,
+    hasReplicationData,
 } from '../../../../store/selectors/navigation/tabs/tablets';
 
 import {NAVIGATION_TABLETS_TABLE_ID} from '../../../../constants/navigation/tabs/tablets';
@@ -85,6 +86,8 @@ class Tablets extends Component {
         statistics: PropTypes.object,
 
         pivot_key: PropTypes.arrayOf(Tablets.typedValueProps),
+        replication_lag_time: PropTypes.number,
+        replication_mode: PropTypes.string,
     });
 
     static propTypes = {
@@ -269,6 +272,15 @@ class Tablets extends Component {
         );
     }
 
+    static renderReplicationMode(item, columnName) {
+        const replicationMode = item[columnName];
+        return typeof replicationMode !== 'undefined' ? (
+            <Label theme="info" text={replicationMode} />
+        ) : (
+            hammer.format.NO_VALUE
+        );
+    }
+
     static renderActions(item) {
         if (item.index === 'aggregation' || Tablets.isTopLevel(item)) {
             return null;
@@ -307,7 +319,7 @@ class Tablets extends Component {
     }
 
     get defaultItems() {
-        const {type} = this.props;
+        const {type, hasReplication} = this.props;
 
         const newDefaultItemsForReplicatedTable = [
             'index',
@@ -330,6 +342,16 @@ class Tablets extends Component {
             'pivot_key',
             'actions',
         ];
+
+        if (hasReplication) {
+            newDefaultItemsForReplicatedTable.splice(
+                7,
+                0,
+                'replication_lag_time',
+                'replication_mode',
+            );
+            newDefaultItemsForTable.splice(6, 0, 'replication_lag_time', 'replication_mode');
+        }
 
         const newDefaultItems =
             type === 'replicated_table'
@@ -448,6 +470,8 @@ class Tablets extends Component {
                 dynamic_delete: asNumber,
                 unmerged_row_read_rate: asNumber,
                 merged_row_read_rate: asNumber,
+                replication_lag_time: asNumber,
+                replication_mode: this.renderReplicationMode,
             },
             computeKey(item) {
                 return item.name || item.tablet_id;
@@ -635,6 +659,7 @@ const mapStateToProps = (state) => {
     const histogram = getHistogram(state);
     const activeHistogram = getActiveHistogram(state);
     const type = getType(state);
+    const hasReplication = hasReplicationData(state);
 
     return {
         loading,
@@ -650,6 +675,7 @@ const mapStateToProps = (state) => {
         activeHistogram,
         histogram,
         type,
+        hasReplication,
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
     };
 };

--- a/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.scss
+++ b/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.scss
@@ -65,6 +65,7 @@
             &_type_store-preload {
                 width: 250px;
             }
+
             &_type_name-tablet-id,
             &_type_name-cell-id {
                 width: 260px;
@@ -77,7 +78,9 @@
             &_type_chunks,
             &_type_partitions,
             &_type_stores,
-            &_type_overlapping-stores {
+            &_type_overlapping-stores,
+            &_type_replication-lag-time,
+            &_type_replication-mode {
                 width: 140px;
             }
 
@@ -95,6 +98,7 @@
             &_type_replication-errors,
             &_type_cell-leader-address {
                 width: 120px;
+
                 .yt-host {
                     overflow: visible;
                 }
@@ -150,6 +154,7 @@
     &__name {
         display: flex;
         white-space: nowrap;
+
         &_level_1 {
             padding-left: 40px;
             cursor: default;

--- a/packages/ui/src/ui/store/actions/navigation/tabs/tablets.js
+++ b/packages/ui/src/ui/store/actions/navigation/tabs/tablets.js
@@ -26,17 +26,19 @@ export function loadTablets() {
 
         return ytApiV3Id
             .get(YTApiId.navigationTablets, {
-                parameters: prepareRequest('/@tablets', {
+                parameters: prepareRequest('/@', {
                     path,
                     transaction,
+                    attributes: ['tablets', 'replication_lag_times'],
                     output_format: TYPED_OUTPUT_FORMAT,
                 }),
                 cancellation: requests.saveCancelToken,
             })
-            .then((tablets) => {
+            .then((data) => {
+                const {tablets, replication_lag_times} = data;
                 dispatch({
                     type: GET_TABLETS.SUCCESS,
-                    data: {tablets},
+                    data: {tablets, replication_lag_times},
                 });
             })
             .catch((error) => {

--- a/packages/ui/src/ui/store/reducers/navigation/tabs/tablets/tablets.js
+++ b/packages/ui/src/ui/store/reducers/navigation/tabs/tablets/tablets.js
@@ -21,6 +21,7 @@ const ephemeralState = {
     errorData: {},
 
     tablets: [],
+    replicationLagTimes: [],
 
     expandedHosts: [],
 };
@@ -36,11 +37,11 @@ const reducer = (state = initialState, action) => {
             return {...state, loading: true};
 
         case GET_TABLETS.SUCCESS: {
-            const {tablets} = action.data;
-
+            const {tablets, replication_lag_times} = action.data;
             return {
                 ...state,
                 tablets,
+                replicationLagTimes: replication_lag_times || [],
                 loaded: true,
                 loading: false,
                 error: false,

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
@@ -11,6 +11,27 @@ import {calculateLoadingStatus} from '../../../../utils/utils';
 export const getTabletsMode = (state) => state.navigation.tabs.tablets.tabletsMode;
 
 const getRawTablets = (state) => state.navigation.tabs.tablets.tablets;
+const getRawReplicationLagTimes = (state) => state.navigation.tabs.tablets.replicationLagTimes;
+
+const getPreparedReplicationLagTimes = createSelector([getRawReplicationLagTimes], (items) => {
+    const res = prepareDataForColumns(items);
+    return res;
+});
+
+const getReplicationLagTimesMap = createSelector(
+    [getPreparedReplicationLagTimes],
+    (replicationLagTimes) => {
+        const map = new Map();
+        replicationLagTimes.forEach((item) => {
+            map.set(item.tablet_id, {
+                replication_lag_time: item.replication_lag_time,
+                replication_mode: item.replication_mode,
+            });
+        });
+        return map;
+    },
+);
+
 /** @returns { OldSortState } */
 export const getTabletsSortState = (state) => state.tables[NAVIGATION_TABLETS_TABLE_ID];
 const getTabletsFilter = (state) => state.navigation.tabs.tablets.tabletsFilter;
@@ -50,7 +71,33 @@ export const getPreparedDataForColumns = createSelector([getFilteredTablets], (i
     return res;
 });
 
-export const getTablets = createSelector(getPreparedDataForColumns, (filteredTablets) => {
+const getMergedPreparedTablets = createSelector(
+    [getPreparedDataForColumns, getReplicationLagTimesMap],
+    (tablets, replicationLagMap) => {
+        return tablets.map((tablet) => {
+            const replicationData = replicationLagMap.get(tablet.tablet_id);
+            if (replicationData) {
+                return {
+                    ...tablet,
+                    replication_lag_time: replicationData.replication_lag_time,
+                    replication_mode: replicationData.replication_mode,
+                };
+            }
+            return tablet;
+        });
+    },
+);
+
+export const hasReplicationData = createSelector([getMergedPreparedTablets], (tablets) => {
+    if (!tablets || tablets.length === 0) {
+        return false;
+    }
+    return tablets.some(
+        (tablet) => tablet && (tablet.replication_lag_time || Boolean(tablet.replication_mode)),
+    );
+});
+
+export const getTablets = createSelector(getMergedPreparedTablets, (filteredTablets) => {
     const aggregation = prepareAggregation(filteredTablets);
     return [aggregation, ...filteredTablets];
 });

--- a/packages/ui/src/ui/utils/navigation/tabs/tables.js
+++ b/packages/ui/src/ui/utils/navigation/tabs/tables.js
@@ -70,6 +70,23 @@ export const tableItems = {
         allowedOrderTypes: DESC_ASC_UNORDERED,
         overall: 'sum',
     },
+    replication_lag_time: {
+        sort: true,
+        align: 'right',
+        caption: 'Replication Lag',
+        get(tablet) {
+            return ypath.getNumberDeprecated(tablet, '/replication_lag_time', undefined);
+        },
+        allowedOrderTypes: DESC_ASC_UNORDERED,
+    },
+    replication_mode: {
+        sort: true,
+        align: 'center',
+        caption: 'Replication Mode',
+        get(tablet) {
+            return ypath.getValue(tablet, '/replication_mode');
+        },
+    },
     pivot_key: {
         sort: false,
         align: 'left',


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/ToLShRNh7YhBAd
<!-- nda-end -->    ## Summary by Sourcery

Add replication lag time and replication mode columns to the tablets navigation view and wire them through from the backend response to the UI.

New Features:
- Display per-tablet replication lag time and replication mode as sortable columns in the tablets navigation table when replication data is available.

Enhancements:
- Fetch replication lag times alongside tablets, store them in Redux, and merge them into the prepared tablets data used by the navigation view.
- Adjust default tablet column sets and styling to conditionally include the new replication-related columns.