### PR TITLE
fix(Bundles): progress tooltip in safari [YTFRONT-5514]

### DIFF
--- a/packages/components/src/components/MetaTable/MetaTable.scss
+++ b/packages/components/src/components/MetaTable/MetaTable.scss
@@ -34,6 +34,11 @@
     }
 }
 
+.g-tooltip:has(.meta-table) {
+    display: block;
+    overflow: visible;
+}
+
 .meta-table-item {
     $item-height: 22px;
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/p8lgmonm7YmVMz
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Ensure the bundle resource progress tooltip content is fully visible in Safari by wrapping it in a dedicated container and updating tooltip CSS.