### PR TITLE
chore(Operations): selector prefix changed [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/ExperimentAssignments/ExperimentAssignments.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/ExperimentAssignments/ExperimentAssignments.tsx
@@ -8,8 +8,8 @@ import ypath from '../../../../common/thor/ypath';
 import {CollapsibleSectionStateLess} from '../../../../components/CollapsibleSection/CollapsibleSection';
 import {
     OperationExperimentItem,
-    getOperationExperimentAssignments,
-    getOperationId,
+    selectOperationExperimentAssignments,
+    selectOperationId,
 } from '../../../../store/selectors/operations/operation';
 import {ClickableText} from '../../../../components/ClickableText/ClickableText';
 import {MetaTable} from '@ytsaurus/components';
@@ -26,8 +26,8 @@ export default React.memo(ExperimentAssignments);
 const ExperimentsItem = React.memo(ExperimentAssignmentsItem);
 
 function ExperimentAssignments({className}: {className: string}) {
-    const items = useSelector(getOperationExperimentAssignments);
-    const operationId = useSelector(getOperationId);
+    const items = useSelector(selectOperationExperimentAssignments);
+    const operationId = useSelector(selectOperationId);
     const [collapsed, setCollapsed] = React.useState(true);
 
     const onToggleCollapse = React.useCallback(() => {

--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -40,10 +40,10 @@ import {promptAction} from '../../../store/actions/actions';
 import {showEditPoolsWeightsModal} from '../../../store/actions/operations';
 import {getOperation} from '../../../store/actions/operations/detail';
 import {
-    getOperationDetailsLoadingStatus,
-    getOperationErasedTrees,
-    getOperationPerformanceUrlTemplate,
     selectIsOperationInGpuTree,
+    selectOperationDetailsLoadingStatus,
+    selectOperationErasedTrees,
+    selectOperationPerformanceUrlTemplate,
 } from '../../../store/selectors/operations/operation';
 import {TabSettings, makeTabProps} from '../../../utils';
 import {
@@ -63,12 +63,12 @@ import {updateListJobsFilter} from '../../../store/actions/operations/jobs';
 import {getOperationEvents, listOperationEventsApi} from '../../../store/api/yt';
 import {RootState} from '../../../store/reducers';
 import {RuntimeItem} from '../../../store/reducers/operations/detail';
-import {getJobsMonitorTabVisible} from '../../../store/selectors/operations/jobs-monitor';
+import {selectJobsMonitorTabVisible} from '../../../store/selectors/operations/jobs-monitor';
 import {
     JobState,
-    getOperationStatiscsHasData,
-    getTotalCpuTimeSpent,
-    getTotalJobWallTime,
+    selectOperationStatisticsHasData,
+    selectTotalCpuTimeSpent,
+    selectTotalJobWallTime,
 } from '../../../store/selectors/operations/statistics-v2';
 import {selectIsIncarnationNextFeatureEnabled} from '../../../store/selectors/settings/settings-development';
 import {getCurrentCluster} from '../../../store/selectors/thor';
@@ -532,9 +532,9 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
 const mapStateToProps = (state: RootState, routerProps: RouteProps) => {
     const {operation, errorData, loading, loaded, error, actions, details} =
         state.operations.detail;
-    const totalJobWallTime = getTotalJobWallTime(state);
-    const cpuTimeSpent = getTotalCpuTimeSpent(state);
-    const erasedTrees = getOperationErasedTrees(state);
+    const totalJobWallTime = selectTotalJobWallTime(state);
+    const cpuTimeSpent = selectTotalCpuTimeSpent(state);
+    const erasedTrees = selectOperationErasedTrees(state);
     const {runtime} = details;
 
     const {operationId} = routerProps.match.params;
@@ -569,10 +569,10 @@ const mapStateToProps = (state: RootState, routerProps: RouteProps) => {
         monitoringComponent,
         timelineTabVisible: operation?.type === 'vanilla',
         jobsMonitorIsSupported: Boolean(UIFactory.getMonitorComponentForJob()),
-        jobsMonitorVisible: getJobsMonitorTabVisible(state),
-        hasStatististicsTab: getOperationStatiscsHasData(state),
+        jobsMonitorVisible: selectJobsMonitorTabVisible(state),
+        hasStatististicsTab: selectOperationStatisticsHasData(state),
         isGpuOperation: selectIsOperationInGpuTree(state),
-        operationPerformanceUrlTemplate: getOperationPerformanceUrlTemplate(state),
+        operationPerformanceUrlTemplate: selectOperationPerformanceUrlTemplate(state),
         operationEvents,
         ysonSettings: getYsonSettingsDisableDecode(state),
         isIncarnationNextFeatureEnabled: selectIsIncarnationNextFeatureEnabled(state),
@@ -596,7 +596,7 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 const OperationDetailConnected = connector(OperationDetail);
 
 export default function OperationDetailsWithRum(props: RouteProps) {
-    const loadState = useSelector(getOperationDetailsLoadingStatus);
+    const loadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/Jobs.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/Jobs.js
@@ -9,8 +9,8 @@ import OperationJobsToolbar from './OperationJobsToolbar/OperationJobsToolbar';
 
 import {useUpdater} from '../../../../../hooks/use-updater';
 import {
-    getOperationDetailsLoadingStatus,
-    getOperationJobsLoadingStatus,
+    selectOperationDetailsLoadingStatus,
+    selectOperationJobsLoadingStatus,
 } from '../../../../../store/selectors/operations/operation';
 import {useAppRumMeasureStart} from '../../../../../rum/rum-app-measures';
 import {RumMeasureTypes} from '../../../../../rum/rum-measure-types';
@@ -46,14 +46,14 @@ function Jobs({className}) {
 }
 
 export default function JobsWithRum(props) {
-    const loadState = useSelector(getOperationJobsLoadingStatus);
+    const loadState = useSelector(selectOperationJobsLoadingStatus);
     /**
      * Selection of this value involves additional rerenders of the component
      * but without it RUM-measures will be wrongly too big it.
      * OperationDetail cannot stop measure for RumMeasureTypes.OPERATION by self,
      * it must be done by nesting tab-content.
      */
-    const operationLoadState = useSelector(getOperationDetailsLoadingStatus);
+    const operationLoadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION_TAB_JOBS,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsErrors/OperationJobsErrors.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsErrors/OperationJobsErrors.tsx
@@ -3,7 +3,7 @@ import map_ from 'lodash/map';
 import cn from 'bem-cn-lite';
 
 import {useSelector} from '../../../../../../store/redux-hooks';
-import {getJobsErrors} from '../../../../../../store/selectors/operations/jobs';
+import {selectJobsErrors} from '../../../../../../store/selectors/operations/jobs';
 import {YTErrorBlock} from '../../../../../../components/Error/Error';
 
 import './OperationJobsErrors.scss';
@@ -11,7 +11,7 @@ import './OperationJobsErrors.scss';
 const block = cn('operation-jobs-errors');
 
 function OperationJobsErrors() {
-    const errors = useSelector(getJobsErrors);
+    const errors = useSelector(selectJobsErrors);
 
     return (
         <div className={block()}>

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
@@ -32,10 +32,10 @@ import {performJobAction} from '../utils';
 import {LOADING_STATUS} from '../../../../../../constants/index';
 import {PLEASE_PROCEED_TEXT} from '../../../../../../utils/actions';
 import {getShowCompetitiveJobs} from '../../../../../../pages/operations/selectors';
-import {getJobsOperationId} from '../../../../../../store/selectors/operations/jobs';
+import {selectJobsOperationId} from '../../../../../../store/selectors/operations/jobs';
 import {
-    getOperationId,
-    getOperationTasksNames,
+    selectOperationId,
+    selectOperationTasksNames,
 } from '../../../../../../store/selectors/operations/operation';
 import UIFactory from '../../../../../../UIFactory';
 import {StaleJobIcon} from '../StaleJobIcon';
@@ -515,9 +515,9 @@ function mapStateToProps(state, props) {
     const {operations, global} = state;
     const {cluster, login} = global;
     const showCompetitiveJobs = getShowCompetitiveJobs(state);
-    const taskNamesNumber = getOperationTasksNames(state)?.length;
-    const jobsOperationId = getJobsOperationId(state);
-    const operationId = getOperationId(state);
+    const taskNamesNumber = selectOperationTasksNames(state)?.length;
+    const jobsOperationId = selectJobsOperationId(state);
+    const operationId = selectOperationId(state);
     const {jobs, job, competitiveJobs, inputPaths} = operations.jobs;
     return {
         jobs: operationId !== jobsOperationId ? [] : jobs,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsToolbar/JobsOperationsIncarnationsFilter.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsToolbar/JobsOperationsIncarnationsFilter.tsx
@@ -5,8 +5,8 @@ import cn from 'bem-cn-lite';
 import {updateJobsOperationIncarnationFilter} from '../../../../../../store/actions/operations/jobs-operation-incarnations';
 import OperationSelectFilter from '../../../../../../pages/operations/OperationSelectFilter/OperationSelectFilter';
 import {
-    getJobsOperationIncarnationsFilter,
-    getJobsOperationIncarnationsValues,
+    selectJobsOperationIncarnationsFilter,
+    selectJobsOperationIncarnationsValues,
 } from '../../../../../../store/selectors/operations/jobs';
 
 import './JobsOperationsIncarnationsFilter.scss';
@@ -22,8 +22,8 @@ export function JobsOperationIncarnationsFilter({
 }) {
     const dispatch = useDispatch();
 
-    const filter = useSelector(getJobsOperationIncarnationsFilter);
-    const values = useSelector(getJobsOperationIncarnationsValues);
+    const filter = useSelector(selectJobsOperationIncarnationsFilter);
+    const values = useSelector(selectJobsOperationIncarnationsValues);
 
     return !values?.length
         ? null

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsToolbar/OperationJobsToolbar.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsToolbar/OperationJobsToolbar.tsx
@@ -11,7 +11,7 @@ import JobsFilterBy from './JobsFilterBy';
 import JobsAttributesFilter from './JobsAttributesFilter';
 
 import {getShowCompetitiveJobs} from '../../../../../../pages/operations/selectors';
-import {getOperationTasksNames} from '../../../../../../store/selectors/operations/operation';
+import {selectOperationTasksNames} from '../../../../../../store/selectors/operations/operation';
 
 import {JobsOperationIncarnationsFilter} from './JobsOperationsIncarnationsFilter';
 import './OperationJobsToolbar.scss';
@@ -33,7 +33,7 @@ const tbComp = tbBlock('component');
 export default function OperationJobsToolbar() {
     const showCompetitiveJobs = useSelector(getShowCompetitiveJobs);
 
-    const taskNames = useSelector(getOperationTasksNames);
+    const taskNames = useSelector(selectOperationTasksNames);
     const allTaskNames = React.useMemo(() => {
         return [
             '',

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/JobsMonitor.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsMonitor/JobsMonitor.tsx
@@ -6,14 +6,14 @@ import ErrorBoundary from '../../../../../components/ErrorBoundary/ErrorBoundary
 import Loader from '../../../../../components/Loader/Loader';
 import {NoContent} from '../../../../../components/NoContent';
 import {
-    getJobsMonitorError,
-    getJobsMonitorFromTo,
-    getJobsMonitorItemsLoaded,
-    getJobsMonitorItemsLoading,
-    getJobsMonitoringItemsWithDescriptor,
+    selectJobsMonitorError,
+    selectJobsMonitorFromTo,
+    selectJobsMonitorItemsLoaded,
+    selectJobsMonitorItemsLoading,
+    selectJobsMonitoringItemsWithDescriptor,
 } from '../../../../../store/selectors/operations/jobs-monitor';
 import {selectCluster} from '../../../../../store/selectors/global';
-import {getOperation} from '../../../../../store/selectors/operations/operation';
+import {selectOperation} from '../../../../../store/selectors/operations/operation';
 import UIFactory from '../../../../../UIFactory';
 import {Flex} from '@gravity-ui/uikit';
 
@@ -21,12 +21,12 @@ import i18n from './i18n';
 
 function JobsMonitor() {
     const cluster = useSelector(selectCluster);
-    const allJobs = useSelector(getJobsMonitoringItemsWithDescriptor);
-    const operation = useSelector(getOperation);
-    const {from, to} = useSelector(getJobsMonitorFromTo);
-    const error = useSelector(getJobsMonitorError);
-    const loaded = useSelector(getJobsMonitorItemsLoaded);
-    const loading = useSelector(getJobsMonitorItemsLoading);
+    const allJobs = useSelector(selectJobsMonitoringItemsWithDescriptor);
+    const operation = useSelector(selectOperation);
+    const {from, to} = useSelector(selectJobsMonitorFromTo);
+    const error = useSelector(selectJobsMonitorError);
+    const loaded = useSelector(selectJobsMonitorItemsLoaded);
+    const loading = useSelector(selectJobsMonitorItemsLoading);
 
     if (!loaded && loading) {
         return <Loader visible centered />;

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsTimeline/EventsSidePanel/EventsSidePanel.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsTimeline/EventsSidePanel/EventsSidePanel.tsx
@@ -1,15 +1,15 @@
 import React, {FC, useRef} from 'react';
 import {useSelector} from '../../../../../../store/redux-hooks';
 import {
-    getSelectedJob,
     selectActiveJob,
+    selectSelectedJob,
 } from '../../../../../../store/selectors/operations/jobs-timeline';
 import {Flex, Text} from '@gravity-ui/uikit';
 import Link from '../../../../../../components/Link/Link';
 import cn from 'bem-cn-lite';
 import {EventsTable} from './EventsTable';
 import {selectCluster} from '../../../../../../store/selectors/global';
-import {getOperationId} from '../../../../../../store/selectors/operations/operation';
+import {selectOperationId} from '../../../../../../store/selectors/operations/operation';
 import './EventsSidePanel.scss';
 import {MetaData} from '../EventsTimeline/MetaData';
 import {SidePanelEmpty} from './SidePanelEmpty';
@@ -19,9 +19,9 @@ const block = cn('yt-events-side-panel');
 export const EventsSidePanel: FC = () => {
     const containerRef = useRef<HTMLDivElement>(null);
     const id = useSelector(selectActiveJob);
-    const job = useSelector(getSelectedJob);
+    const job = useSelector(selectSelectedJob);
     const cluster = useSelector(selectCluster);
-    const operationId = useSelector(getOperationId);
+    const operationId = useSelector(selectOperationId);
 
     if (!id || !job) return <SidePanelEmpty />;
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/attributes/OperationAttributes.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/attributes/OperationAttributes.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import {useSelector} from '../../../../../store/redux-hooks';
 
 import {
-    getOperationDetailsLoadingStatus,
-    getOperationId,
-    getOperationTypedAttributes,
+    selectOperationDetailsLoadingStatus,
+    selectOperationId,
+    selectOperationTypedAttributes,
 } from '../../../../../store/selectors/operations/operation';
 import Yson from '../../../../../components/Yson/Yson';
 import {getYsonSettingsDisableDecode} from '../../../../../store/selectors/thor/unipika';
@@ -15,7 +15,7 @@ import {useAppRumMeasureStart} from '../../../../../rum/rum-app-measures';
 import {YsonDownloadButton} from '../../../../../components/DownloadAttributesButton';
 
 function useOperationAttributesRumMesures() {
-    const loadState = useSelector(getOperationDetailsLoadingStatus);
+    const loadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION_TAB_ATTRIBUTES,
@@ -36,9 +36,9 @@ function useOperationAttributesRumMesures() {
 }
 
 function OperationAttributes({className}: {className: string}) {
-    const typedAttributes = useSelector(getOperationTypedAttributes);
+    const typedAttributes = useSelector(selectOperationTypedAttributes);
     const settings = useSelector(getYsonSettingsDisableDecode);
-    const id = useSelector(getOperationId);
+    const id = useSelector(selectOperationId);
 
     useOperationAttributesRumMesures();
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Details/Details.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Details/Details.tsx
@@ -15,9 +15,9 @@ import {RootState} from '../../../../../../store/reducers';
 import {showEditPoolsWeightsModal} from '../../../../../../store/actions/operations';
 import {selectCluster} from '../../../../../../store/selectors/global';
 import {
-    getOperationAlertEvents,
-    getOperationDetailsLoadingStatus,
     selectIsOperationInGpuTree,
+    selectOperationAlertEvents,
+    selectOperationDetailsLoadingStatus,
 } from '../../../../../../store/selectors/operations/operation';
 
 import {useRumMeasureStop} from '../../../../../../rum/RumUiContext';
@@ -254,7 +254,7 @@ const mapStateToProps = (state: RootState) => {
         treeConfigs: state.operations.detail.treeConfigs,
         ...state.operations.detail.details,
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
-        alertEvents: getOperationAlertEvents(state),
+        alertEvents: selectOperationAlertEvents(state),
         isVanillaGpuOperation: operation.type === 'vanilla' && isOperationInGpuTree,
         isOperationInGpuTree,
     };
@@ -269,7 +269,7 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 const DetailsConnected = connector(Details);
 
 export default function DetailsWithRum() {
-    const loadState = useSelector(getOperationDetailsLoadingStatus);
+    const loadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION_TAB_DETAILS,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Tasks/Tasks.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Tasks/Tasks.tsx
@@ -19,7 +19,7 @@ import {hasProgressTasks} from '../../../../../../utils/operations/tabs/details/
 import ClickableAttributesButton from '../../../../../../components/AttributesButton/ClickableAttributesButton';
 import ExpandIcon from '../../../../../../components/ExpandIcon/ExpandIcon';
 import {RootState} from '../../../../../../store/reducers';
-import {getOperationDetailTasksData} from '../../../../../../store/selectors/operations/statistics-v2';
+import {selectOperationDetailTasksData} from '../../../../../../store/selectors/operations/statistics-v2';
 
 const block = cn('jobs');
 
@@ -454,7 +454,7 @@ function TaskInfo(props: ItemTaskInfo) {
 }
 
 const connector = connect((state: RootState) => {
-    const taskData = getOperationDetailTasksData(state);
+    const taskData = selectOperationDetailTasksData(state);
     return {jobs: taskData, operation: state.operations.detail.operation};
 });
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/IncarnationCardHeader.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/IncarnationCardHeader.tsx
@@ -12,7 +12,7 @@ import AttributesButton from '../../../../../components/AttributesButton/Attribu
 import {toggleIncarnationInfoDialog} from '../../../../../store/reducers/operations/incarnations';
 import type {Incarnation} from '../../../../../store/selectors/operations/incarnations';
 import {selectCluster} from '../../../../../store/selectors/global';
-import {getOperation} from '../../../../../store/selectors/operations/operation';
+import {selectOperation} from '../../../../../store/selectors/operations/operation';
 
 import {IncarnationButton} from './IncarnationButton';
 
@@ -29,7 +29,7 @@ export function IncarnationCardHeader(props: Props) {
     const dispatch = useDispatch();
 
     const cluster = useSelector(selectCluster);
-    const operation = useSelector(getOperation);
+    const operation = useSelector(selectOperation);
 
     return (
         <Flex justifyContent={'space-between'} style={{overflow: 'hidden'}}>

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/IncarnationMeta.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/IncarnationMeta.tsx
@@ -8,7 +8,7 @@ import {Page} from '../../../../../../shared/constants/settings';
 import format from '../../../../../common/hammer/format';
 
 import {selectCluster} from '../../../../../store/selectors/global';
-import {getOperation} from '../../../../../store/selectors/operations/operation';
+import {selectOperation} from '../../../../../store/selectors/operations/operation';
 import type {Incarnation} from '../../../../../store/selectors/operations/incarnations';
 import {showErrorModal} from '../../../../../store/actions/actions';
 
@@ -28,7 +28,7 @@ export function IncarnationMeta(props: Props) {
     const dispatch = useDispatch();
 
     const cluster = useSelector(selectCluster);
-    const operation = useSelector(getOperation);
+    const operation = useSelector(selectOperation);
 
     const {switch_info} = incarnation;
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/Incarnations.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/Incarnations.tsx
@@ -6,7 +6,7 @@ import {Alert, Card, Disclosure, Flex, Loader} from '@gravity-ui/uikit';
 
 import type {YTError} from '../../../../../../@types/types';
 
-import {getIncarnationsInfo} from '../../../../../store/selectors/operations/incarnations';
+import {selectIncarnationsInfo} from '../../../../../store/selectors/operations/incarnations';
 import type {Incarnations as YTIncarnations} from '../../../../../store/selectors/operations/incarnations';
 
 import {YTErrorBlock} from '../../../../../components/Error/Error';
@@ -34,7 +34,7 @@ export type IncarnationProps = {
 };
 
 export default function Incarnations() {
-    const {incarnations, error, isLoading} = useSelector(getIncarnationsInfo);
+    const {incarnations, error, isLoading} = useSelector(selectIncarnationsInfo);
 
     return (
         <IncarnationsTemplate

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/IncarnationsCount.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/IncarnationsCount.tsx
@@ -3,7 +3,7 @@ import {useSelector} from '../../../../../store/redux-hooks';
 
 import {CountsList} from '../../../../../components/CountsList/CountsList';
 
-import {getIncarnationsInfo} from '../../../../../store/selectors/operations/incarnations';
+import {selectIncarnationsInfo} from '../../../../../store/selectors/operations/incarnations';
 
 import i18n from './i18n';
 
@@ -15,7 +15,7 @@ export type IncarnationsCountProps = {
 };
 
 export function IncarnationsCount() {
-    const {count} = useSelector(getIncarnationsInfo);
+    const {count} = useSelector(selectIncarnationsInfo);
 
     return (
         <IncarnationsCountTemplate

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/job-sizes/JobSizes/JobSizes.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/job-sizes/JobSizes/JobSizes.tsx
@@ -17,7 +17,7 @@ import {selectTheme} from '../../../../../../store/selectors/global';
 import WithStickyToolbar from '../../../../../../components/WithStickyToolbar/WithStickyToolbar';
 import {Toolbar} from '../../../../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import {hasTaskHistograms} from '../../../../../../utils/operations/jobs';
-import {getOperationDetailsLoadingStatus} from '../../../../../../store/selectors/operations/operation';
+import {selectOperationDetailsLoadingStatus} from '../../../../../../store/selectors/operations/operation';
 import {useAppRumMeasureStart} from '../../../../../../rum/rum-app-measures';
 import {RumMeasureTypes} from '../../../../../../rum/rum-measure-types';
 import {isFinalLoadingStatus} from '../../../../../../utils/utils';
@@ -197,7 +197,7 @@ const connector = connect(mapStateToProps);
 const JobSizesConnected = connector(JobSizes);
 
 export default function JobSizesWithRum(props: {className?: string}) {
-    const loadState = useSelector(getOperationDetailsLoadingStatus);
+    const loadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION_TAB_JOB_SIZES,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/monitor/OperationDetailsMonitor.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/monitor/OperationDetailsMonitor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useSelector} from '../../../../../store/redux-hooks';
 
-import {getOperation} from '../../../../../store/selectors/operations/operation';
+import {selectOperation} from '../../../../../store/selectors/operations/operation';
 import {selectCluster} from '../../../../../store/selectors/global';
 import ErrorBoundary from '../../../../../components/ErrorBoundary/ErrorBoundary';
 import {OperationMonitoringTabProps} from '../../../../../UIFactory';
@@ -10,7 +10,7 @@ function OperationDetailsMonitor(props: {
     component: React.ComponentType<OperationMonitoringTabProps>;
 }) {
     const {component: OperationMonitor} = props;
-    const operation = useSelector(getOperation);
+    const operation = useSelector(selectOperation);
     const cluster = useSelector(selectCluster);
 
     return (

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/partition-sizes/PartitionSizes/PartitionSizes.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/partition-sizes/PartitionSizes/PartitionSizes.tsx
@@ -10,7 +10,7 @@ import ErrorBoundary from '../../../../../../components/ErrorBoundary/ErrorBound
 
 import {selectTheme} from '../../../../../../store/selectors/global';
 
-import {getOperationDetailsLoadingStatus} from '../../../../../../store/selectors/operations/operation';
+import {selectOperationDetailsLoadingStatus} from '../../../../../../store/selectors/operations/operation';
 import {useAppRumMeasureStart} from '../../../../../../rum/rum-app-measures';
 import {RumMeasureTypes} from '../../../../../../rum/rum-measure-types';
 import {isFinalLoadingStatus} from '../../../../../../utils/utils';
@@ -92,7 +92,7 @@ const connector = connect(mapStateToProps);
 const PartitionSizesConnected = connector(PartitionSizes);
 
 export default function PartitionSizesWithRum() {
-    const loadState = useSelector(getOperationDetailsLoadingStatus);
+    const loadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION_TAB_PARTITION_SIZES,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/specification/Specification.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/specification/Specification.js
@@ -15,8 +15,8 @@ import HelpLink from '../../../../../components/HelpLink/HelpLink';
 import Yson from '../../../../../components/Yson/Yson';
 
 import {
-    getOperationDetailsLoadingStatus,
-    getOperationId,
+    selectOperationDetailsLoadingStatus,
+    selectOperationId,
 } from '../../../../../store/selectors/operations/operation';
 import {RumMeasureTypes} from '../../../../../rum/rum-measure-types';
 import {isFinalLoadingStatus} from '../../../../../utils/utils';
@@ -163,13 +163,13 @@ Specification.propTypes = {
 
 const mapStateToProps = (state) => ({
     operation: state.operations.detail.operation,
-    operationId: getOperationId(state),
+    operationId: selectOperationId(state),
 });
 
 const SpecificationConnected = connect(mapStateToProps)(Specification);
 
 export default function SpecificationWithRum() {
-    const loadState = useSelector(getOperationDetailsLoadingStatus);
+    const loadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION_TAB_SPECIFICATION,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/statistics/Statistics.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/statistics/Statistics.tsx
@@ -30,11 +30,11 @@ import {statisticsTableProps} from '../../../../../utils/operations/tabs/statist
 import {makeRadioButtonProps} from '../../../../../utils';
 
 import {RootState} from '../../../../../store/reducers';
-import {getOperationDetailsLoadingStatus} from '../../../../../store/selectors/operations/operation';
+import {selectOperationDetailsLoadingStatus} from '../../../../../store/selectors/operations/operation';
 import {
-    getOperationStatisticsActiveFilterValues,
-    getOperationStatisticsAvailableValues,
-    getOperationStatisticsFiltered,
+    selectOperationStatisticsActiveFilterValues,
+    selectOperationStatisticsAvailableValues,
+    selectOperationStatisticsFiltered,
 } from '../../../../../store/selectors/operations/statistics-v2';
 import {RumMeasureTypes} from '../../../../../rum/rum-measure-types';
 import {useRumMeasureStop} from '../../../../../rum/RumUiContext';
@@ -50,7 +50,7 @@ import './Statistics.scss';
 const statisticsBlock = cn('operation-statistics');
 const toolbarBlock = cn('elements-toolbar');
 
-type ItemType = ReturnType<typeof getOperationStatisticsFiltered>[0];
+type ItemType = ReturnType<typeof selectOperationStatisticsFiltered>[0];
 
 interface ItemState {
     collapsed?: boolean;
@@ -255,15 +255,16 @@ export class Statistics extends Component<Props> {
 const mapStateToProps = (state: RootState) => {
     const {treeState, activeAggregation} = state.operations.statistics;
 
-    const {job_type: jobTypes, pool_tree: poolTrees} = getOperationStatisticsAvailableValues(state);
+    const {job_type: jobTypes, pool_tree: poolTrees} =
+        selectOperationStatisticsAvailableValues(state);
 
     return {
-        items: getOperationStatisticsFiltered(state),
+        items: selectOperationStatisticsFiltered(state),
         treeState,
         activeAggregation,
         jobTypes,
         poolTrees,
-        ...getOperationStatisticsActiveFilterValues(state),
+        ...selectOperationStatisticsActiveFilterValues(state),
     };
 };
 
@@ -280,7 +281,7 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 const StatisticsConnected = connector(Statistics);
 
 export default function SpecificationWithRum(props: {className: string}) {
-    const loadState = useSelector(getOperationDetailsLoadingStatus);
+    const loadState = useSelector(selectOperationDetailsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATION_TAB_STATISTICS,

--- a/packages/ui/src/ui/pages/operations/OperationsList/OperationsList.js
+++ b/packages/ui/src/ui/pages/operations/OperationsList/OperationsList.js
@@ -14,7 +14,7 @@ import {useMemoizedIfEqual, useUpdater} from '../../../hooks';
 import {useAppRumMeasureStart} from '../../../rum/rum-app-measures';
 import {RumMeasureTypes} from '../../../rum/rum-measure-types';
 import {useRumMeasureStop} from '../../../rum/RumUiContext';
-import {getOperationsListIsFinalState} from '../../../store/selectors/operations/operations-list';
+import {selectOperationsListIsFinalState} from '../../../store/selectors/operations/operations-list';
 import {selectCluster} from '../../../store/selectors/global';
 import {getListRequestParameters} from '../../../store/actions/operations/utils';
 
@@ -123,7 +123,7 @@ function mapStateToProps({operations}) {
 const OperationsListConnected = connect(mapStateToProps)(OperationsList);
 
 function OperationsListWithRum() {
-    const isFinalStatus = useSelector(getOperationsListIsFinalState);
+    const isFinalStatus = useSelector(selectOperationsListIsFinalState);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.OPERATIONS_LIST,

--- a/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsFilterPresets.js
+++ b/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsFilterPresets.js
@@ -20,8 +20,8 @@ import {OPERATIONS_LIST_RUNNING_PRESET} from '../../../../constants/operations/l
 
 import {makeGetSetting} from '../../../../store/selectors/settings';
 import {
-    getOperationsListActivePresets,
-    getOperationsListFilterPresets,
+    selectOperationsListActivePresets,
+    selectOperationsListFilterPresets,
 } from '../../../../store/selectors/operations/operations-list';
 import Modal from '../../../../components/Modal/Modal';
 import Icon from '../../../../components/Icon/Icon';
@@ -186,7 +186,7 @@ function mapStateToProps(state) {
 
     const getSetting = makeGetSetting(state);
     let defaultPreset = getSetting(DEFAULT_PRESET_SETTING, NAMESPACES.OPERATION);
-    const presets = getOperationsListFilterPresets(state);
+    const presets = selectOperationsListFilterPresets(state);
 
     if (!presets[defaultPreset]) {
         defaultPreset = OPERATIONS_LIST_RUNNING_PRESET;
@@ -194,7 +194,7 @@ function mapStateToProps(state) {
 
     return {
         presets,
-        activePresets: getOperationsListActivePresets(state),
+        activePresets: selectOperationsListActivePresets(state),
         defaultPreset,
         dialog: operations.list.savePresetDialog,
     };

--- a/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsListSuggestFilters.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsListSuggestFilters.tsx
@@ -6,18 +6,18 @@ import OperationSuggestFilter from '../../../../pages/operations/OperationSugges
 import {updateFilter} from '../../../../store/actions/operations/list';
 import {getActualValue} from '../../../../pages/operations/selectors';
 import {
-    getOperationsListFilters,
-    getOperationsListFixedStartedByFilter_FOR_YTFRONT_2838,
-    getOperationsPoolSuggestions,
-    getOperationsPoolTreeSuggestions,
-    getOperationsUserSuggestions,
+    selectOperationsListFilters,
+    selectOperationsListFixedStartedByFilter_FOR_YTFRONT_2838,
+    selectOperationsPoolSuggestions,
+    selectOperationsPoolTreeSuggestions,
+    selectOperationsUserSuggestions,
 } from '../../../../store/selectors/operations';
 import {RootState} from '../../../../store/reducers';
 import {OperationsListFilterName} from '../../../../store/reducers/operations/list/list';
 import UIFactory from '../../../../UIFactory';
 
 const mapStateToPropsByFilterName = (state: RootState, name: OperationsListFilterName) => {
-    const filters = getOperationsListFilters(state);
+    const filters = selectOperationsListFilters(state);
     const {defaultValue, value} = filters[name];
 
     return {
@@ -30,7 +30,7 @@ const mapStateToPropsByFilterName = (state: RootState, name: OperationsListFilte
 const mapPoolTreeStateToProps = (state: RootState) => {
     return {
         ...mapStateToPropsByFilterName(state, 'poolTree'),
-        states: getOperationsPoolTreeSuggestions(state),
+        states: selectOperationsPoolTreeSuggestions(state),
         placeholder: 'Pool tree...',
     };
 };
@@ -42,7 +42,7 @@ export const OperationsListPoolTreeSuggestFilter = connect(mapPoolTreeStateToPro
 const mapPoolStateToProps = (state: RootState) => {
     return {
         ...mapStateToPropsByFilterName(state, 'pool'),
-        states: getOperationsPoolSuggestions(state),
+        states: selectOperationsPoolSuggestions(state),
         placeholder: 'Filter pool...',
     };
 };
@@ -51,11 +51,11 @@ export const OperationsListPoolSuggestFilter = connect(mapPoolStateToProps, {
 })(OperationSuggestFilter);
 
 const mapUserStateToProps = (state: RootState) => {
-    const fixedStartedByFilter = getOperationsListFixedStartedByFilter_FOR_YTFRONT_2838(state);
+    const fixedStartedByFilter = selectOperationsListFixedStartedByFilter_FOR_YTFRONT_2838(state);
 
     return {
         ...mapStateToPropsByFilterName(state, 'user'),
-        states: getOperationsUserSuggestions(state),
+        states: selectOperationsUserSuggestions(state),
         placeholder: fixedStartedByFilter || 'Started by...',
     };
 };
@@ -67,7 +67,7 @@ function OperationsAccessibleForFilterImpl() {
     const dispatch = useDispatch();
     const {
         subject: {value},
-    } = useSelector(getOperationsListFilters);
+    } = useSelector(selectOperationsListFilters);
 
     return (
         <div>

--- a/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsListToolbar.js
+++ b/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsListToolbar.js
@@ -24,7 +24,7 @@ import {
     OperationsListPoolTreeSuggestFilter,
     OperationsListUserSuggestFilter,
 } from '../../../../pages/operations/OperationsList/OperationsListToolbar/OperationsListSuggestFilters';
-import {getOperationsListFixedStartedByFilter_FOR_YTFRONT_2838} from '../../../../store/selectors/operations';
+import {selectOperationsListFixedStartedByFilter_FOR_YTFRONT_2838} from '../../../../store/selectors/operations';
 import Button, {SelectButton} from '../../../../components/Button/Button';
 import Icon from '../../../../components/Icon/Icon';
 import {PoolTreesLoader} from '../../../../hooks/global-pool-trees';
@@ -261,7 +261,7 @@ function OperationsListToolbarHooked({children}) {
     const subjects = useSelector(selectAllUserNames);
     const {failedJobs} = useSelector((state) => state.operations.list.filters) || {};
     const fixedStartedByFilter = useSelector(
-        getOperationsListFixedStartedByFilter_FOR_YTFRONT_2838,
+        selectOperationsListFixedStartedByFilter_FOR_YTFRONT_2838,
     );
 
     const dispatch = useDispatch();

--- a/packages/ui/src/ui/store/actions/operations/jobs-monitor.ts
+++ b/packages/ui/src/ui/store/actions/operations/jobs-monitor.ts
@@ -3,7 +3,7 @@ import {ThunkAction} from 'redux-thunk';
 import {YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
 import {RootState} from '../../../store/reducers';
 import {JobsMonitorAction} from '../../../store/reducers/operations/jobs/jobs-monitor';
-import {getOperationMonitoredJobCount} from '../../../store/selectors/operations/operation';
+import {selectOperationMonitoredJobCount} from '../../../store/selectors/operations/operation';
 import CancelHelper, {isCancelled} from '../../../utils/cancel-helper';
 
 type JobsMonitorThunkAction = ThunkAction<unknown, RootState, unknown, JobsMonitorAction>;
@@ -12,7 +12,7 @@ const cancelHelper = new CancelHelper();
 
 export function getJobsMonitoringDescriptors(operation_id: string): JobsMonitorThunkAction {
     return (dispatch, getState) => {
-        const jobsCount = getOperationMonitoredJobCount(getState());
+        const jobsCount = selectOperationMonitoredJobCount(getState());
         if (jobsCount === 0) {
             return undefined;
         }

--- a/packages/ui/src/ui/store/actions/operations/jobs-timeline.ts
+++ b/packages/ui/src/ui/store/actions/operations/jobs-timeline.ts
@@ -4,7 +4,7 @@ import {RootState} from '../../reducers';
 import {Action} from 'redux';
 
 import format from '../../../common/hammer/format';
-import {getOperationId} from '../../selectors/operations/operation';
+import {selectOperationId} from '../../selectors/operations/operation';
 import {RawJob} from '../../../types/operations/job';
 import CancelHelper, {isCancelled} from '../../../utils/cancel-helper';
 import {
@@ -46,7 +46,7 @@ export const getJobsWithEvents =
     (firstRequest?: boolean): AsyncAction =>
     async (dispatch, getState) => {
         const state = getState();
-        const operationId = getOperationId(state);
+        const operationId = selectOperationId(state);
         const sameIntervals = selectIntervalsIsSame(state);
 
         if (firstRequest) {

--- a/packages/ui/src/ui/store/actions/operations/jobs.ts
+++ b/packages/ui/src/ui/store/actions/operations/jobs.ts
@@ -33,7 +33,7 @@ import {OldSortState} from '../../../types';
 import {ListJobsParameters} from '../../../../shared/yt-types';
 import {KeysByType} from '../../../../@types/types';
 import {TablesSortOrderAction} from '../../../store/reducers/tables';
-import {getJobsOperationIncarnationsFilter} from '../../../store/selectors/operations/jobs';
+import {selectJobsOperationIncarnationsFilter} from '../../../store/selectors/operations/jobs';
 import {fetchOperationIncarnationAvailableItems} from './jobs-operation-incarnations';
 
 const requests = new CancelHelper();
@@ -129,7 +129,7 @@ function getJobsRequestParameters(state: RootState): ListJobsParameters {
     const {filters, pagination} = state.operations.jobs;
     const sortState = state.tables[OPERATION_JOBS_TABLE_ID];
 
-    const incarnation = getJobsOperationIncarnationsFilter(state);
+    const incarnation = selectJobsOperationIncarnationsFilter(state);
 
     return {
         operation_id: operation.$value,

--- a/packages/ui/src/ui/store/actions/operations/monitor.ts
+++ b/packages/ui/src/ui/store/actions/operations/monitor.ts
@@ -1,5 +1,5 @@
 import {OPERATION_DETAIL_PARTIAL} from '../../../constants/operations/detail';
-import {getOperationMonitorChartStates} from '../../../store/selectors/operations/operation';
+import {selectOperationMonitorChartStates} from '../../../store/selectors/operations/operation';
 import {ThunkAction} from 'redux-thunk';
 
 export function resetOperationmonitorChartStates() {
@@ -10,7 +10,7 @@ export function updateOperationMonitorChartStates(states: {
     [name: string]: boolean;
 }): ThunkAction<any, any, any, any> {
     return (dispatch, getState) => {
-        const old = getOperationMonitorChartStates(getState());
+        const old = selectOperationMonitorChartStates(getState());
         return dispatch({
             type: OPERATION_DETAIL_PARTIAL,
             data: {monitorChartStates: {...old, ...states}},

--- a/packages/ui/src/ui/store/actions/operations/statistics.js
+++ b/packages/ui/src/ui/store/actions/operations/statistics.js
@@ -4,7 +4,7 @@ import {
     OPERATION_STATISTICS_PARTIAL,
     SET_TREE_STATE,
 } from '../../../constants/operations/statistics';
-import {getOperation} from '../../../store/selectors/operations/operation';
+import {selectOperation} from '../../../store/selectors/operations/operation';
 import {getSettingOperationStatisticsActiveJobTypes} from '../../../store/selectors/settings/settings-ts';
 import {setSettingsStatisticsActiveJobTypes} from '../../../store/actions/settings/settings';
 
@@ -37,7 +37,7 @@ export function changeJobType(jobType) {
         });
 
         const state = getState();
-        const operationType = getOperation(state).type;
+        const operationType = selectOperation(state).type;
         const settingsJobTypes = getSettingOperationStatisticsActiveJobTypes(state);
 
         if (settingsJobTypes && settingsJobTypes[operationType] !== jobType) {

--- a/packages/ui/src/ui/store/actions/operations/utils.js
+++ b/packages/ui/src/ui/store/actions/operations/utils.js
@@ -2,8 +2,8 @@ import moment from 'moment';
 
 import {OPERATIONS_DATA_MODE} from '../../../constants/operations';
 import {
-    getOperationsListFiltersParameters_FOR_YTFRONT_2838,
-    getOperationsListTimeRange,
+    selectOperationsListFiltersParameters_FOR_YTFRONT_2838,
+    selectOperationsListTimeRange,
 } from '../../../store/selectors/operations';
 import {USE_CACHE} from '../../../../shared/constants/yt-api';
 
@@ -22,7 +22,7 @@ export function getDefaultFromTime(currentTime, dataMode) {
 }
 
 function getFilterParameters(state) {
-    return getOperationsListFiltersParameters_FOR_YTFRONT_2838(state);
+    return selectOperationsListFiltersParameters_FOR_YTFRONT_2838(state);
 }
 
 function getCursorParams({operations}) {
@@ -37,7 +37,7 @@ function getCursorParams({operations}) {
 export function getListRequestParameters(state) {
     return {
         ...getFilterParameters(state),
-        ...getOperationsListTimeRange(state),
+        ...selectOperationsListTimeRange(state),
         ...getCursorParams(state),
         include_archive: state.operations.list.dataMode === OPERATIONS_DATA_MODE.ARCHIVE,
         // TODO: make limit configurable by using settings, 20 | 50 | 100

--- a/packages/ui/src/ui/store/api/yt/listOperationEvents/index.ts
+++ b/packages/ui/src/ui/store/api/yt/listOperationEvents/index.ts
@@ -1,6 +1,6 @@
 import {ListOperationEventsParameters} from '../../../../../shared/yt-types';
 import type {RootState} from '../../../../store/reducers';
-import {getOperation} from '../../../../store/selectors/operations/operation';
+import {selectOperation} from '../../../../store/selectors/operations/operation';
 import {ytApi} from '../ytApi';
 import {listOperationEvents} from './endpoint';
 
@@ -18,7 +18,7 @@ export const getOperationEvents = (
 ) => listOperationEventsApi.endpoints.listOperationEvents.select({operation_id, event_type})(state);
 
 export const getIncarnations = (state: RootState) => {
-    const operation = getOperation(state);
+    const operation = selectOperation(state);
     return listOperationEventsApi.endpoints.listOperationEvents.select({
         operation_id: operation.id,
         event_type: 'incarnation_started',

--- a/packages/ui/src/ui/store/selectors/operations/incarnations.ts
+++ b/packages/ui/src/ui/store/selectors/operations/incarnations.ts
@@ -13,7 +13,7 @@ import {ViewState} from '../../../components/StatusLabel/StatusLabel';
 import {formatInterval} from '../../../components/common/Timeline';
 import {dateTimeParse} from '../../../utils/date-utils';
 
-import {getOperation} from './operation';
+import {selectOperation} from './operation';
 
 export type IncarnationFinishReason =
     | IncarnationSwitchReason
@@ -81,8 +81,8 @@ function makeInterval(startDatetime: string, finishDatetime: string) {
     return format.NO_VALUE;
 }
 
-export const getIncarnationsInfo = createSelector(
-    [getOperation, getIncarnationsList, getIdFilter, getIncarnations],
+export const selectIncarnationsInfo = createSelector(
+    [selectOperation, getIncarnationsList, getIdFilter, getIncarnations],
     (operation, operationEvents, idFilter, incarnationsReqInfo) => {
         let incarnations: Incarnations = [];
 

--- a/packages/ui/src/ui/store/selectors/operations/index.ts
+++ b/packages/ui/src/ui/store/selectors/operations/index.ts
@@ -18,62 +18,62 @@ import sortBy_ from 'lodash/sortBy';
 import {RootState} from '../../reducers';
 import {OperationsListFilterValue} from '../../reducers/operations/list/list';
 
-export const getOperationsListFilters = (state: RootState) => state.operations.list.filters;
-export const getOperationsPoolFilterData = (state: RootState) =>
-    getOperationsListFilters(state)['pool'];
-export const getOperationsUserFilterData = (state: RootState) =>
-    getOperationsListFilters(state)['user'];
-export const getOperationsPoolTreeRawCounters = (state: RootState) =>
+export const selectOperationsListFilters = (state: RootState) => state.operations.list.filters;
+export const selectOperationsPoolFilterData = (state: RootState) =>
+    selectOperationsListFilters(state)['pool'];
+export const selectOperationsUserFilterData = (state: RootState) =>
+    selectOperationsListFilters(state)['user'];
+export const selectOperationsPoolTreeRawCounters = (state: RootState) =>
     state.operations.list.filters.poolTree.counters?.pool_tree_counts || {};
-export const getOperationsPoolRawCounters = (state: RootState) =>
-    getOperationsPoolFilterData(state).counters?.pool_counts || {};
-export const getOperationsUserRawCounter = (state: RootState) =>
-    getOperationsUserFilterData(state).counters?.user_counts || {};
+export const selectOperationsPoolRawCounters = (state: RootState) =>
+    selectOperationsPoolFilterData(state).counters?.pool_counts || {};
+export const selectOperationsUserRawCounter = (state: RootState) =>
+    selectOperationsUserFilterData(state).counters?.user_counts || {};
 
-export const getOperationsPoolTreeCountersItems = createSelector(
-    [getOperationsPoolTreeRawCounters],
+export const selectOperationsPoolTreeCountersItems = createSelector(
+    [selectOperationsPoolTreeRawCounters],
     convertCountersToItems,
 );
 
-export const getOperationsPoolTreeItemsWithoutCounter = createSelector(
-    [selectAllPoolTreeNames, getOperationsPoolTreeRawCounters],
+export const selectOperationsPoolTreeItemsWithoutCounter = createSelector(
+    [selectAllPoolTreeNames, selectOperationsPoolTreeRawCounters],
     (f, s) => {
         return calculateItemsWithoutCounter(f, s);
     },
 );
 
-export const getOperationsPoolTreeSuggestions = createSelector(
-    [getOperationsPoolTreeCountersItems, getOperationsPoolTreeItemsWithoutCounter],
+export const selectOperationsPoolTreeSuggestions = createSelector(
+    [selectOperationsPoolTreeCountersItems, selectOperationsPoolTreeItemsWithoutCounter],
     concat_,
 );
 
-export const getOperationsPoolCountersItems = createSelector(
-    [getOperationsPoolRawCounters],
+export const selectOperationsPoolCountersItems = createSelector(
+    [selectOperationsPoolRawCounters],
     convertCountersToItems,
 );
 
-export const getOperationsPoolItemsWithoutCounter = createSelector(
-    [selectAllPoolNames, getOperationsPoolRawCounters],
+export const selectOperationsPoolItemsWithoutCounter = createSelector(
+    [selectAllPoolNames, selectOperationsPoolRawCounters],
     calculateItemsWithoutCounter,
 );
 
-export const getOperationsPoolSuggestions = createSelector(
-    [getOperationsPoolCountersItems, getOperationsPoolItemsWithoutCounter],
+export const selectOperationsPoolSuggestions = createSelector(
+    [selectOperationsPoolCountersItems, selectOperationsPoolItemsWithoutCounter],
     concat_,
 );
 
-export const getOperationsUserCountersItems = createSelector(
-    [getOperationsUserRawCounter],
+export const selectOperationsUserCountersItems = createSelector(
+    [selectOperationsUserRawCounter],
     convertCountersToItems,
 );
 
-export const getOperationsUserItemsWithoutCounter = createSelector(
-    [selectAllUserNames, getOperationsUserRawCounter],
+export const selectOperationsUserItemsWithoutCounter = createSelector(
+    [selectAllUserNames, selectOperationsUserRawCounter],
     calculateItemsWithoutCounter,
 );
 
-export const getOperationsUserSuggestions = createSelector(
-    [getOperationsUserCountersItems, getOperationsUserItemsWithoutCounter],
+export const selectOperationsUserSuggestions = createSelector(
+    [selectOperationsUserCountersItems, selectOperationsUserItemsWithoutCounter],
     concat_,
 );
 
@@ -129,35 +129,35 @@ export const ATTRIBUTE_ITEMS = [
 ];
 export const ATTRIBUTE_ITEM_NAMES = map_(ATTRIBUTE_ITEMS, ({value}) => value);
 
-export const getOperationsListFilterParameters = createSelector(
-    [getOperationsListFilters],
+export const selectOperationsListFilterParameters = createSelector(
+    [selectOperationsListFilters],
     (filters) => {
         const {text, user, subject, permissions, pool, poolTree, state, type, failedJobs} = filters;
 
-        const actualSubject = getValueIfNotDefault(subject);
-        const actualPermissions = getValueIfNotDefault(permissions) as string;
+        const actualSubject = selectValueIfNotDefault(subject);
+        const actualPermissions = selectValueIfNotDefault(permissions) as string;
         const access =
             actualSubject || actualPermissions?.length > 0
                 ? {subject: actualSubject, permissions: actualPermissions || []}
                 : undefined;
 
         const res = {
-            filter: getValueIfNotDefault(text),
-            user: getValueIfNotDefault(user),
-            pool: getValueIfNotDefault(pool),
-            pool_tree: getValueIfNotDefault(poolTree),
-            type: getValueIfNotDefault(type),
-            with_failed_jobs: getValueIfNotDefault(failedJobs),
+            filter: selectValueIfNotDefault(text),
+            user: selectValueIfNotDefault(user),
+            pool: selectValueIfNotDefault(pool),
+            pool_tree: selectValueIfNotDefault(poolTree),
+            type: selectValueIfNotDefault(type),
+            with_failed_jobs: selectValueIfNotDefault(failedJobs),
             access,
         };
         return {
-            state: getValueIfNotDefault(state),
+            state: selectValueIfNotDefault(state),
             ...res,
         };
     },
 );
 
-export function getOperationsListTimeRange(state: RootState) {
+export function selectOperationsListTimeRange(state: RootState) {
     const {from, to} = state.operations.list.timeRange;
 
     return {
@@ -166,11 +166,11 @@ export function getOperationsListTimeRange(state: RootState) {
     };
 }
 
-export const getOperationsListFiltersParameters_FOR_YTFRONT_2838 = createSelector(
+export const selectOperationsListFiltersParameters_FOR_YTFRONT_2838 = createSelector(
     [
-        getOperationsListFilterParameters,
+        selectOperationsListFilterParameters,
         selectCurrentUserName,
-        getOperationsListTimeRange,
+        selectOperationsListTimeRange,
         selectCluster,
     ],
     (filters, login, {from_time, to_time}, cluster) => {
@@ -191,8 +191,8 @@ export const getOperationsListFiltersParameters_FOR_YTFRONT_2838 = createSelecto
     },
 );
 
-export const getOperationsListFixedStartedByFilter_FOR_YTFRONT_2838 = createSelector(
-    [getOperationsListFilterParameters, getOperationsListFiltersParameters_FOR_YTFRONT_2838],
+export const selectOperationsListFixedStartedByFilter_FOR_YTFRONT_2838 = createSelector(
+    [selectOperationsListFilterParameters, selectOperationsListFiltersParameters_FOR_YTFRONT_2838],
     (filters, fixedFilters) => {
         if (isEqual_(filters, fixedFilters)) {
             return undefined;
@@ -201,6 +201,6 @@ export const getOperationsListFixedStartedByFilter_FOR_YTFRONT_2838 = createSele
     },
 );
 
-export function getValueIfNotDefault(filter: OperationsListFilterValue) {
+export function selectValueIfNotDefault(filter: OperationsListFilterValue) {
     return filter.value === filter.defaultValue ? undefined : filter.value;
 }

--- a/packages/ui/src/ui/store/selectors/operations/jobs-monitor.ts
+++ b/packages/ui/src/ui/store/selectors/operations/jobs-monitor.ts
@@ -8,25 +8,26 @@ import min_ from 'lodash/min';
 import moment from 'moment';
 import {createSelector} from 'reselect';
 import {RootState} from '../../../store/reducers';
-import {getOperationId} from './operation';
+import {selectOperationId} from './operation';
 
-export const getJobsMonitorError = (state: RootState) => state.operations.jobsMonitor.error;
-export const getJobsMonitorOperationId = (state: RootState) =>
+export const selectJobsMonitorError = (state: RootState) => state.operations.jobsMonitor.error;
+export const selectJobsMonitorOperationId = (state: RootState) =>
     state.operations.jobsMonitor.operation_id;
-export const getJobsMonitorItems = (state: RootState) => state.operations.jobsMonitor.jobs;
-export const getJobsMonitorItemsLoading = (state: RootState) =>
+export const selectJobsMonitorItems = (state: RootState) => state.operations.jobsMonitor.jobs;
+export const selectJobsMonitorItemsLoading = (state: RootState) =>
     state.operations.jobsMonitor.loading;
-export const getJobsMonitorItemsLoaded = (state: RootState) => state.operations.jobsMonitor.loaded;
+export const selectJobsMonitorItemsLoaded = (state: RootState) =>
+    state.operations.jobsMonitor.loaded;
 
-export const getJobsMonitoringItemsWithDescriptor = createSelector(
-    [getJobsMonitorItems],
+export const selectJobsMonitoringItemsWithDescriptor = createSelector(
+    [selectJobsMonitorItems],
     (items) => {
         return filter_(items, ({monitoring_descriptor}) => Boolean(monitoring_descriptor));
     },
 );
 
-export const getJobsMonitorFromTo = createSelector(
-    [getJobsMonitoringItemsWithDescriptor],
+export const selectJobsMonitorFromTo = createSelector(
+    [selectJobsMonitoringItemsWithDescriptor],
     (items) => {
         let from: number | undefined;
         let to: number | undefined;
@@ -44,20 +45,20 @@ export const getJobsMonitorFromTo = createSelector(
     },
 );
 
-export const getUniqueJobsMonitorDescriptors = createSelector(
-    [getJobsMonitoringItemsWithDescriptor],
+export const selectUniqueJobsMonitorDescriptors = createSelector(
+    [selectJobsMonitoringItemsWithDescriptor],
     (jobs) => {
         const descriptors = new Set(map_(jobs, 'monitoring_descriptor'));
         return [...descriptors];
     },
 );
 
-export const getJobsMonitorTabVisible = createSelector(
+export const selectJobsMonitorTabVisible = createSelector(
     [
-        getOperationId,
-        getJobsMonitorOperationId,
-        getUniqueJobsMonitorDescriptors,
-        getJobsMonitorError,
+        selectOperationId,
+        selectJobsMonitorOperationId,
+        selectUniqueJobsMonitorDescriptors,
+        selectJobsMonitorError,
     ],
     (opId, jobMonId, jobsDescriptorArray, error) => {
         if (opId !== jobMonId) {

--- a/packages/ui/src/ui/store/selectors/operations/jobs-timeline.ts
+++ b/packages/ui/src/ui/store/selectors/operations/jobs-timeline.ts
@@ -36,11 +36,14 @@ export const selectSortedJobs = createSelector([selectJobs], (jobs) => {
     });
 });
 
-export const getSelectedJob = createSelector([selectJobs, selectActiveJob], (jobs, activeJob) => {
-    const result = jobs.find(({id}) => activeJob === id) || null;
+export const selectSelectedJob = createSelector(
+    [selectJobs, selectActiveJob],
+    (jobs, activeJob) => {
+        const result = jobs.find(({id}) => activeJob === id) || null;
 
-    return result;
-});
+        return result;
+    },
+);
 
 export const selectIntervalsIsSame = createSelector(
     [selectInterval, selectEventsInterval],

--- a/packages/ui/src/ui/store/selectors/operations/jobs.ts
+++ b/packages/ui/src/ui/store/selectors/operations/jobs.ts
@@ -1,9 +1,9 @@
 import {RootState} from '../../reducers';
 
-export const getJobsErrors = (state: RootState) => state.operations.jobs.jobsErrors;
-export const getJobsOperationId = (state: RootState) => state.operations.jobs.operationId;
+export const selectJobsErrors = (state: RootState) => state.operations.jobs.jobsErrors;
+export const selectJobsOperationId = (state: RootState) => state.operations.jobs.operationId;
 
-export const getJobsOperationIncarnationsFilter = (state: RootState) =>
+export const selectJobsOperationIncarnationsFilter = (state: RootState) =>
     state.operations.jobsOperationIncarnations.filter;
-export const getJobsOperationIncarnationsValues = (state: RootState) =>
+export const selectJobsOperationIncarnationsValues = (state: RootState) =>
     state.operations.jobsOperationIncarnations.availableValues;

--- a/packages/ui/src/ui/store/selectors/operations/operation.ts
+++ b/packages/ui/src/ui/store/selectors/operations/operation.ts
@@ -12,12 +12,12 @@ import {FIX_MY_TYPE} from '../../../types';
 import {prepareFaqUrl} from '../../../utils/operations/tabs/details/alerts';
 import {selectClusterUiConfig} from '../global';
 
-const getOperationErasedTreesRaw = (state: RootState) => {
+const selectOperationErasedTreesRaw = (state: RootState) => {
     return ypath.getValue(state.operations.detail, '/operation/@runtime_parameters/erased_trees');
 };
 
-export const getOperationErasedTrees = createSelector(
-    [getOperationErasedTreesRaw],
+export const selectOperationErasedTrees = createSelector(
+    [selectOperationErasedTreesRaw],
     (rawTrees: Array<unknown>) => {
         return reduce_(
             rawTrees,
@@ -35,61 +35,64 @@ interface OperationTask {
     task_name: string;
 }
 
-const getOperationAlertEventsImpl = (state: RootState) =>
+const selectOperationAlertEventsImpl = (state: RootState) =>
     state.operations.detail.details.alert_events;
 
-export const getOperationAlertEvents = createSelector([getOperationAlertEventsImpl], (items) => {
-    const appeared: Record<string, AlertInfo> = {};
-    return reduce_(
-        items,
-        (acc, item) => {
-            const type = ypath.getValue(item.alert_type);
-            const code = ypath.getNumberDeprecated(item, '/error/code', NaN);
-            if (!code && appeared[type]) {
-                const last = appeared[type];
-                last.to = ypath.getValue(item.time);
-                delete appeared[type];
-            } else if (code) {
-                acc.push({
-                    from: ypath.getValue(item.time),
-                    type,
-                    error: item.error,
-                    url: prepareFaqUrl(type),
-                });
-                appeared[type] = acc[acc.length - 1];
-            } else {
-                acc.push({
-                    to: ypath.getValue(item.time),
-                    type,
-                    error: item.error,
-                    url: prepareFaqUrl(type),
-                });
-            }
-            return acc;
-        },
-        [] as Array<AlertInfo>,
-    );
-});
+export const selectOperationAlertEvents = createSelector(
+    [selectOperationAlertEventsImpl],
+    (items) => {
+        const appeared: Record<string, AlertInfo> = {};
+        return reduce_(
+            items,
+            (acc, item) => {
+                const type = ypath.getValue(item.alert_type);
+                const code = ypath.getNumberDeprecated(item, '/error/code', NaN);
+                if (!code && appeared[type]) {
+                    const last = appeared[type];
+                    last.to = ypath.getValue(item.time);
+                    delete appeared[type];
+                } else if (code) {
+                    acc.push({
+                        from: ypath.getValue(item.time),
+                        type,
+                        error: item.error,
+                        url: prepareFaqUrl(type),
+                    });
+                    appeared[type] = acc[acc.length - 1];
+                } else {
+                    acc.push({
+                        to: ypath.getValue(item.time),
+                        type,
+                        error: item.error,
+                        url: prepareFaqUrl(type),
+                    });
+                }
+                return acc;
+            },
+            [] as Array<AlertInfo>,
+        );
+    },
+);
 
-export const getOperation = (state: RootState) => state.operations.detail.operation;
-export const getOperationId = (state: RootState) =>
+export const selectOperation = (state: RootState) => state.operations.detail.operation;
+export const selectOperationId = (state: RootState) =>
     ypath.getValue(state.operations.detail.operation);
-export const getOperationTasks = createSelector(
-    [getOperation],
+export const selectOperationTasks = createSelector(
+    [selectOperation],
     (operation): Array<OperationTask> | undefined => {
         return ypath.getValue(operation, '/@progress/tasks');
     },
 );
-export const getOperationTasksNames = createSelector(
-    [getOperationTasks],
+export const selectOperationTasksNames = createSelector(
+    [selectOperationTasks],
     (tasks?: Array<{task_name: string}>) => {
         return map_(tasks, 'task_name').sort();
     },
 );
 
-export const getOperationTreeConfigs = (state: RootState) => state.operations.detail.treeConfigs;
+export const selectOperationTreeConfigs = (state: RootState) => state.operations.detail.treeConfigs;
 
-export const getOperationDetailsLoadingStatus = createSelector(
+export const selectOperationDetailsLoadingStatus = createSelector(
     [
         (state: RootState) => (state.operations.detail as FIX_MY_TYPE).loading,
         (state: RootState) => (state.operations.detail as FIX_MY_TYPE).loaded,
@@ -100,21 +103,24 @@ export const getOperationDetailsLoadingStatus = createSelector(
     },
 );
 
-export const getOperationTypedAttributes = (state: RootState) =>
+export const selectOperationTypedAttributes = (state: RootState) =>
     (state.operations.detail.operation as FIX_MY_TYPE).$typedAttributes;
 
-export const getOperationMonitorChartStates = (state: RootState) =>
+export const selectOperationMonitorChartStates = (state: RootState) =>
     state.operations.detail.monitorChartStates;
 
-export const getOperationPools = (state: RootState) =>
+export const selectOperationPools = (state: RootState) =>
     (state.operations.detail.operation as FIX_MY_TYPE).pools;
 
-export const getOperationPoolNames = createSelector([getOperationPools], (pools): Array<string> => {
-    return map_(pools, 'pool');
-});
+export const selectOperationPoolNames = createSelector(
+    [selectOperationPools],
+    (pools): Array<string> => {
+        return map_(pools, 'pool');
+    },
+);
 
-export const getOperationsMonitorChartStatesFinishedCount = createSelector(
-    [getOperationMonitorChartStates],
+export const selectOperationsMonitorChartStatesFinishedCount = createSelector(
+    [selectOperationMonitorChartStates],
     (states) => {
         return reduce_(
             states,
@@ -126,7 +132,7 @@ export const getOperationsMonitorChartStatesFinishedCount = createSelector(
     },
 );
 
-export const getOperationJobsLoadingStatus = createSelector(
+export const selectOperationJobsLoadingStatus = createSelector(
     [
         (state: RootState) => (state.operations.jobs as FIX_MY_TYPE).loading,
         (state: RootState) => (state.operations.jobs as FIX_MY_TYPE).loaded,
@@ -145,14 +151,14 @@ export interface OperationExperimentItem {
     effect: unknown;
 }
 
-export const getOperationExperimentAssignments = createSelector(
-    [getOperation],
+export const selectOperationExperimentAssignments = createSelector(
+    [selectOperation],
     (operation): Array<OperationExperimentItem> => {
         return ypath.getValue(operation, '/@experiment_assignments');
     },
 );
 
-export const getOperationMonitoredJobCount = createSelector([getOperation], (operation) => {
+export const selectOperationMonitoredJobCount = createSelector([selectOperation], (operation) => {
     const res = ypath.getNumberDeprecated(
         operation,
         '/@brief_progress/registered_monitoring_descriptor_count',
@@ -161,14 +167,14 @@ export const getOperationMonitoredJobCount = createSelector([getOperation], (ope
 });
 
 export const selectIsOperationInGpuTree = createSelector(
-    [getOperationTreeConfigs],
+    [selectOperationTreeConfigs],
     (treeConfigs) => {
         return treeConfigs?.every((item) => item.config.main_resource === 'gpu');
     },
 );
 
-export const getOperationPerformanceUrlTemplate = createSelector(
-    [getOperationId, selectClusterUiConfig],
+export const selectOperationPerformanceUrlTemplate = createSelector(
+    [selectOperationId, selectClusterUiConfig],
     (operationId, uiConfig) => {
         const operationPerformanceUrlTemplate = uiConfig?.operation_performance_url_template;
 

--- a/packages/ui/src/ui/store/selectors/operations/operations-list.ts
+++ b/packages/ui/src/ui/store/selectors/operations/operations-list.ts
@@ -14,13 +14,13 @@ import {
     OPERATIONS_LIST_RUNNING_PRESET,
 } from '../../../constants/operations/list';
 import {selectCurrentUserName} from '../global';
-import {getOperationsListFilters} from '.';
+import {selectOperationsListFilters} from '.';
 import {
     OperationPresetsSettings,
     OperationsListPreset,
 } from '../../../../shared/constants/settings-types';
 
-export const getOperationsListIsFinalState = createSelector(
+export const selectOperationsListIsFinalState = createSelector(
     [
         (state: RootState) => state.operations.list.isLoading,
         (state: RootState) => state.operations.list.hasLoaded,
@@ -33,15 +33,15 @@ export const getOperationsListIsFinalState = createSelector(
 );
 
 /**
- * 
- * 
-  
+ *
+ *
 
-    
 
- * 
- * @param login 
- * @returns 
+
+
+ *
+ * @param login
+ * @returns
  */
 
 function createPreconfiguredPresets(login: string) {
@@ -67,7 +67,7 @@ function createPreconfiguredPresets(login: string) {
     };
 }
 
-export const getOperationsListFilterPresets = createSelector(
+export const selectOperationsListFilterPresets = createSelector(
     [getSettingsDataRaw, selectCurrentUserName],
     (data, login): Record<string, OperationsListPreset> => {
         const collectionKeys: Array<keyof OperationPresetsSettings> = filter_(
@@ -91,8 +91,8 @@ export const getOperationsListFilterPresets = createSelector(
     },
 );
 
-export const getOperationsListActivePresets = createSelector(
-    [getOperationsListFilters, getOperationsListFilterPresets],
+export const selectOperationsListActivePresets = createSelector(
+    [selectOperationsListFilters, selectOperationsListFilterPresets],
     (selectedFilters, presets) => {
         return reduce_(
             presets,

--- a/packages/ui/src/ui/store/selectors/operations/statistics-v2.ts
+++ b/packages/ui/src/ui/store/selectors/operations/statistics-v2.ts
@@ -24,14 +24,14 @@ import {RootState} from '../../../store/reducers';
 import {ValueOf} from '../../../../@types/types';
 import {prepareDataFromGraph} from '../../../utils/operations/tabs/details/tasks';
 
-const getJobTypeFilter = (state: RootState) => state.operations.statistics.jobTypeFilter;
-const getPoolTreeFilter = (state: RootState) => state.operations.statistics.poolTreeFilter;
-const getFilterText = (state: RootState) => state.operations.statistics.filterText;
+const selectJobTypeFilter = (state: RootState) => state.operations.statistics.jobTypeFilter;
+const selectPoolTreeFilter = (state: RootState) => state.operations.statistics.poolTreeFilter;
+const selectFilterText = (state: RootState) => state.operations.statistics.filterText;
 
-const getOperationDetailsOperation = (state: RootState) => state.operations.detail.operation;
+const selectOperationDetailsOperation = (state: RootState) => state.operations.detail.operation;
 
-export const getOperationStatisticsV2 = createSelector(
-    [getOperationDetailsOperation],
+export const selectOperationStatisticsV2 = createSelector(
+    [selectOperationDetailsOperation],
     (operation) => {
         return ypath.getValue(operation, '/@progress/job_statistics_v2') as
             | StatisticTreeRoot
@@ -75,8 +75,8 @@ export function isStatisticItem(v?: ValueOf<StatisticTree>): v is Array<Statisti
     return Array.isArray(v);
 }
 
-export const getOperationStatisticsAvailableValues = createSelector(
-    [getOperationStatisticsV2],
+export const selectOperationStatisticsAvailableValues = createSelector(
+    [selectOperationStatisticsV2],
     (stats) => {
         const total = stats?.time?.total ?? [];
         const tmp = reduce_(
@@ -107,8 +107,13 @@ export const getOperationStatisticsAvailableValues = createSelector(
     },
 );
 
-export const getOperationStatisticsActiveFilterValues = createSelector(
-    [getJobTypeFilter, getPoolTreeFilter, getFilterText, getOperationStatisticsAvailableValues],
+export const selectOperationStatisticsActiveFilterValues = createSelector(
+    [
+        selectJobTypeFilter,
+        selectPoolTreeFilter,
+        selectFilterText,
+        selectOperationStatisticsAvailableValues,
+    ],
     (jobTypeFilter, poolTreeFilter, filterText, {job_type, pool_tree}) => {
         return {
             activeJobType:
@@ -124,12 +129,12 @@ export const getOperationStatisticsActiveFilterValues = createSelector(
     },
 );
 
-export const getOperationStatiscsHasData = (state: RootState) => {
-    return !isEmpty_(getOperationStatisticsV2(state));
+export const selectOperationStatisticsHasData = (state: RootState) => {
+    return !isEmpty_(selectOperationStatisticsV2(state));
 };
 
-export const getOperationStatisticsFilteredTree = createSelector(
-    [getOperationStatisticsActiveFilterValues, getOperationStatisticsV2],
+export const selectOperationStatisticsFilteredTree = createSelector(
+    [selectOperationStatisticsActiveFilterValues, selectOperationStatisticsV2],
     ({activeJobType, activePoolTree, filterText}, tree) => {
         if (!activeJobType && !activePoolTree && !filterText) {
             return tree;
@@ -166,8 +171,8 @@ export const getOperationStatisticsFilteredTree = createSelector(
     },
 );
 
-export const getOperationStatisticsFiltered = createSelector(
-    [getOperationStatisticsFilteredTree],
+export const selectOperationStatisticsFiltered = createSelector(
+    [selectOperationStatisticsFilteredTree],
     (tree) => {
         const res: Array<{
             name: string;
@@ -213,7 +218,7 @@ function mergeSummary(summary: StatisticItemSummary, current?: StatisticItemSumm
     };
 }
 
-export const getTotalJobWallTime = createSelector(getOperationStatisticsV2, (tree) => {
+export const selectTotalJobWallTime = createSelector(selectOperationStatisticsV2, (tree) => {
     const item = tree?.time?.total;
     return excludeRunningAndCalcSum(item);
 });
@@ -231,7 +236,7 @@ const CPU_TIME_SPENT_PART_NAMES = [
     'user_job.cpu.system',
 ];
 
-export const getTotalCpuTimeSpent = createSelector([getOperationStatisticsV2], (tree) => {
+export const selectTotalCpuTimeSpent = createSelector([selectOperationStatisticsV2], (tree) => {
     const items = reduce_(
         CPU_TIME_SPENT_PART_NAMES,
         (acc, path) => {
@@ -249,8 +254,8 @@ export const getTotalCpuTimeSpent = createSelector([getOperationStatisticsV2], (
     return items.length ? sum_(items) : format.NO_VALUE;
 });
 
-export const getOperationDetailTasksData = createSelector(
-    [getOperationDetailsOperation, getOperationStatisticsV2],
+export const selectOperationDetailTasksData = createSelector(
+    [selectOperationDetailsOperation, selectOperationStatisticsV2],
     (operation, stats) => {
         const items = prepareDataFromGraph(operation);
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/-PKY7h9a7YnmTp
<!-- nda-end --> ## Summary by Sourcery

Rename operations-related selectors from a `get*` prefix to a `select*` prefix and update all usages accordingly.

Enhancements:
- Align selector naming across operations, jobs, statistics, and incarnations modules to use a consistent `select*` prefix.
- Adjust connected components, hooks, and thunk actions to import and use the renamed selectors without changing behavior.