### PR TITLE
fix(Queries): wrong jobs count [YTFRONT-5708]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesNodeBlock.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesNodeBlock.ts
@@ -228,7 +228,7 @@ export class QueriesCanvasBlock extends YTGraphCanvasBlock<QueriesNodeBlock> {
         const nodeProgress = this.state.meta.nodeProgress;
         if (!nodeProgress || !nodeProgress.total) return undefined;
 
-        return nodeProgress.total + (nodeProgress.aborted || 0);
+        return nodeProgress.total;
     }
 
     private drawJobCounter(mode: ZoomMode) {

--- a/packages/ui/src/ui/pages/query-tracker/Plan/NodeJobs/NodeJobs.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/NodeJobs/NodeJobs.tsx
@@ -13,6 +13,7 @@ interface NodeJobsProps {
     running?: number;
     failed?: number;
     aborted?: number;
+    pending?: number;
     total?: number;
 }
 
@@ -27,11 +28,7 @@ const getJobsColumns = (): Column<JobRow>[] => [
             return (
                 <div className={block('item')}>
                     <div className={block('item-color', {status: row.status.toLowerCase()})} />
-                    <Text
-                        className={block('item-title')}
-                        color={footer ? 'primary' : 'secondary'}
-                        // weight={footer ? 'medium' : 'regular'}
-                    >
+                    <Text className={block('item-title')} color={footer ? 'primary' : 'secondary'}>
                         {row.status}
                     </Text>
                 </div>
@@ -47,11 +44,12 @@ export default function NodeJobs({
     failed = 0,
     aborted = 0,
     total = 0,
+    pending = 0,
 }: NodeJobsProps) {
     const statuses: JobRow[] = [];
     statuses.push({
         status: i18n('value_pending'),
-        count: total - running - completed - failed - aborted,
+        count: pending,
     });
     statuses.push({status: i18n('value_running'), count: running});
     statuses.push({status: i18n('value_completed'), count: completed});


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/qvLiwWVq7Yro4W
<!-- nda-end -->## Summary by Sourcery

Correct job status counts in query tracker node jobs and align displayed totals with backend progress data.

Bug Fixes:
- Use the provided pending jobs count instead of deriving it from total and other statuses in the node jobs view.
- Stop double-counting aborted jobs in the total jobs counter for query tracker nodes.