### PR TITLE
chore(Operations): incarnations next tab (part 2) [YTFRONT-5266]

### DIFF
--- a/packages/ui/src/shared/constants/settings-types.ts
+++ b/packages/ui/src/shared/constants/settings-types.ts
@@ -51,7 +51,6 @@ interface DevelopmentSettings {
     'global::development::yqlTypes': boolean;
     'global::development::regularUserUI': boolean;
     'global::development::showAiChat': boolean;
-    'global::development::feature::incarnationNext': boolean;
 }
 
 interface MenuSettings {
@@ -106,6 +105,7 @@ interface A11YSettings {
 type OperationsSettings = OperationPresetsSettings & {
     'global::operations::statisticsAggregationType': 'avg' | 'min' | 'max' | 'sum' | 'count';
     'global::operations::statisticsActiveJobTypes': Record<string, string>;
+    'global::operations::showIncarnationsNext': boolean;
 };
 
 export type OperationPresetsSettings = {

--- a/packages/ui/src/shared/utils/toolkit/index.ts
+++ b/packages/ui/src/shared/utils/toolkit/index.ts
@@ -1,2 +1,3 @@
 export * from './assert';
 export * from './string';
+export * from './type';

--- a/packages/ui/src/shared/utils/toolkit/type/index.ts
+++ b/packages/ui/src/shared/utils/toolkit/type/index.ts
@@ -1,0 +1,1 @@
+export * from './isTruthy';

--- a/packages/ui/src/shared/utils/toolkit/type/isTruthy.ts
+++ b/packages/ui/src/shared/utils/toolkit/type/isTruthy.ts
@@ -1,5 +1,5 @@
 type Falsy = false | '' | 0 | null | undefined;
 
-export const isTruthy = <T>(value: T | Falsy): value is T => {
+export const isTruthy = <T>(value: T): value is Exclude<T, Falsy> => {
     return Boolean(value);
 };

--- a/packages/ui/src/shared/utils/toolkit/type/isTruthy.ts
+++ b/packages/ui/src/shared/utils/toolkit/type/isTruthy.ts
@@ -1,0 +1,5 @@
+type Falsy = false | '' | 0 | null | undefined;
+
+export const isTruthy = <T>(value: T | Falsy): value is T => {
+    return Boolean(value);
+};

--- a/packages/ui/src/ui/UIFactory/default-ui-factory.tsx
+++ b/packages/ui/src/ui/UIFactory/default-ui-factory.tsx
@@ -389,9 +389,6 @@ export const defaultUIFactory: UIFactory = {
     renderIncarnationsTab() {
         return <IncarnationsLazy />;
     },
-    renderIncarnationsNextTab() {
-        return undefined;
-    },
     renderOperationLogsTab() {
         return undefined;
     },

--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -531,9 +531,11 @@ export interface UIFactory {
 
     getAnalyticsService(): AnalyticsService[];
 
-    renderIncarnationsTab(): React.ReactNode;
-
-    renderIncarnationsNextTab(params: {cluster: string; operationId: string}): React.ReactNode;
+    renderIncarnationsTab(params: {
+        cluster: string;
+        operationId: string;
+        showIncarnationsNext: boolean;
+    }): React.ReactNode;
 
     getAiChatMessageComponent(
         message: ChatMessage,

--- a/packages/ui/src/ui/components/Link/Link.tsx
+++ b/packages/ui/src/ui/components/Link/Link.tsx
@@ -31,6 +31,9 @@ export type LinkProps = {
     hasExternalIcon?: boolean;
 };
 
+/**
+ * @deprecated Use RoutedLink or RoutedButton container instead.
+ */
 export const Link = ({
     url,
     children,

--- a/packages/ui/src/ui/components/Yson/Yson.tsx
+++ b/packages/ui/src/ui/components/Yson/Yson.tsx
@@ -12,8 +12,10 @@ import {UnipikaSettings, UnipikaValue} from './StructuredYson/StructuredYsonType
 import StructuredYsonVirtualized from './StructuredYsonVirtualized/StructuredYsonVirtualized';
 import type {Settings} from '@gravity-ui/react-data-table';
 
+export type YsonSettings = UnipikaSettings;
+
 export interface YsonProps {
-    settings?: UnipikaSettings;
+    settings?: YsonSettings;
     value: any;
     inline?: boolean;
     folding?: boolean;

--- a/packages/ui/src/ui/constants/job.ts
+++ b/packages/ui/src/ui/constants/job.ts
@@ -22,6 +22,6 @@ export const Tab = {
     STATISTICS: 'statistics',
     SPECIFICATION: 'specification',
     LOGS: 'logs',
-};
+} as const;
 
 export const DEFAULT_TAB = Tab.DETAILS;

--- a/packages/ui/src/ui/constants/operations/detail.ts
+++ b/packages/ui/src/ui/constants/operations/detail.ts
@@ -20,7 +20,6 @@ export const Tab = {
     MONITOR: 'monitor',
     PERFORMANCE: 'performance',
     INCARNATIONS: 'incarnations',
-    INCARNATIONS_NEXT: 'incarnations_next',
     LOGS: 'logs',
 } as const;
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -70,7 +70,7 @@ import {
     selectTotalCpuTimeSpent,
     selectTotalJobWallTime,
 } from '../../../store/selectors/operations/statistics-v2';
-import {selectIsIncarnationNextFeatureEnabled} from '../../../store/selectors/settings/settings-development';
+import {selectShowIncarnationsNext} from '../../../store/selectors/settings/operations';
 import {getCurrentCluster} from '../../../store/selectors/thor';
 import {getYsonSettingsDisableDecode} from '../../../store/selectors/thor/unipika';
 import {OperationPool, OperationStates} from '../selectors';
@@ -339,7 +339,6 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
             timelineTabVisible,
             operationPerformanceUrlTemplate,
             operationEvents,
-            isIncarnationNextFeatureEnabled,
         } = this.props;
         const path = `/${cluster}/${Page.OPERATIONS}/${operationId}`;
 
@@ -350,11 +349,6 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
             [Tab.MONITOR]: {show: monitorTabVisible},
             [Tab.JOBS_TIMELINE]: {show: timelineTabVisible},
             [Tab.INCARNATIONS]: {show: Boolean(operationEvents?.length)},
-            [Tab.INCARNATIONS_NEXT]: {
-                show:
-                    isIncarnationNextFeatureEnabled &&
-                    Boolean(UIFactory.renderIncarnationsNextTab({cluster, operationId})),
-            },
             [Tab.LOGS]: {show: Boolean(UIFactory.renderOperationLogsTab())},
             [Tab.PERFORMANCE]: {
                 show: Boolean(operationPerformanceUrlTemplate),
@@ -404,6 +398,7 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
             jobsMonitorIsSupported,
             monitoringComponent,
             timelineTabVisible,
+            showIncarnationsNext,
         } = this.props;
         const {url, params} = match;
         const {operationId} = params;
@@ -455,11 +450,13 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
                     )}
                     <Route
                         path={`${path}/${Tab.INCARNATIONS}`}
-                        render={UIFactory.renderIncarnationsTab}
-                    />
-                    <Route
-                        path={`${path}/${Tab.INCARNATIONS_NEXT}`}
-                        render={() => UIFactory.renderIncarnationsNextTab({cluster, operationId})}
+                        render={() =>
+                            UIFactory.renderIncarnationsTab({
+                                cluster,
+                                operationId,
+                                showIncarnationsNext,
+                            })
+                        }
                     />
                     <Route path={`${path}/${Tab.LOGS}`} render={UIFactory.renderOperationLogsTab} />
                     <Route path={`${path}/:tab`} component={Placeholder} />
@@ -575,7 +572,7 @@ const mapStateToProps = (state: RootState, routerProps: RouteProps) => {
         operationPerformanceUrlTemplate: selectOperationPerformanceUrlTemplate(state),
         operationEvents,
         ysonSettings: getYsonSettingsDisableDecode(state),
-        isIncarnationNextFeatureEnabled: selectIsIncarnationNextFeatureEnabled(state),
+        showIncarnationsNext: selectShowIncarnationsNext(state),
     };
 };
 

--- a/packages/ui/src/ui/store/selectors/settings/operations.ts
+++ b/packages/ui/src/ui/store/selectors/settings/operations.ts
@@ -1,0 +1,6 @@
+import {createSelector} from 'reselect';
+import {getSettingsData} from './settings-base';
+
+export const selectShowIncarnationsNext = createSelector([getSettingsData], (data) => {
+    return data['global::operations::showIncarnationsNext'] === true;
+});

--- a/packages/ui/src/ui/store/selectors/settings/settings-development.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-development.ts
@@ -8,7 +8,3 @@ export const selectShowAiChat = createSelector([getSettingsData], (data) => {
 export const shouldUseYqlTypes = createSelector([getSettingsData], (data) => {
     return data['global::development::yqlTypes'];
 });
-
-export const selectIsIncarnationNextFeatureEnabled = createSelector([getSettingsData], (data) => {
-    return data['global::development::feature::incarnationNext'] === true;
-});

--- a/packages/ui/src/ui/utils/app-url/index.ts
+++ b/packages/ui/src/ui/utils/app-url/index.ts
@@ -66,6 +66,16 @@ export function makeOperationJobsUrl(params: {
     return searchParams.size > 0 ? `${pathname}?${searchParams}` : pathname;
 }
 
+export function makeOperationJobUrl(params: {
+    cluster?: string;
+    operationId: string;
+    jobId: string;
+}): string {
+    const {cluster, operationId, jobId} = params;
+
+    return `/${cluster || YT.cluster}/${Page.JOB}/${operationId}/${jobId}`;
+}
+
 export function makeOperationLogsUrl(params: {cluster?: string; operationId: string}): string {
     const {cluster, operationId} = params;
 

--- a/packages/ui/src/ui/utils/app-url/index.ts
+++ b/packages/ui/src/ui/utils/app-url/index.ts
@@ -42,11 +42,12 @@ export function makeOperationJobsUrl(params: {
     cluster?: string;
     operationId: string;
     incarnationId?: string;
+    jobId?: string;
     state?: 'all' | 'running' | 'completed' | 'failed' | 'aborted';
 }): string {
-    const {cluster, operationId, incarnationId, state} = params;
+    const {cluster, operationId, incarnationId, jobId, state} = params;
 
-    const baseUrl = `/${cluster || YT.cluster}/${Page.OPERATIONS}/${operationId}/jobs`;
+    const pathname = `/${cluster || YT.cluster}/${Page.OPERATIONS}/${operationId}/jobs`;
 
     const searchParams = new URLSearchParams();
 
@@ -54,11 +55,15 @@ export function makeOperationJobsUrl(params: {
         searchParams.set('incarnation', incarnationId);
     }
 
+    if (jobId) {
+        searchParams.set('jobId', jobId);
+    }
+
     if (state) {
         searchParams.set('state', state);
     }
 
-    return searchParams.size > 0 ? `${baseUrl}?${searchParams}` : baseUrl;
+    return searchParams.size > 0 ? `${pathname}?${searchParams}` : pathname;
 }
 
 export function makeOperationLogsUrl(params: {cluster?: string; operationId: string}): string {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/W8G6lQ7h7YsA8u
<!-- nda-end -->                                          ## Summary by Sourcery

Route operation incarnations handling through a unified tab and extend URL utilities and settings to support Incarnations Next and job-specific navigation.

New Features:
- Add support for an operations setting to control visibility of the Incarnations Next functionality.
- Expose a URL helper to navigate directly to a specific job page for an operation and extend the jobs URL helper to accept a jobId parameter.

Enhancements:
- Unify incarnations routing by passing Incarnations Next visibility into the existing incarnations tab instead of using a separate tab and feature flag.
- Introduce a reusable isTruthy type guard utility for filtering truthy values in a type-safe way.
- Tighten job tab constants typing with an as-const assertion for safer usage across the app.

Documentation:
- Mark the generic Link component as deprecated in favor of RoutedLink or RoutedButton containers.