### PR TITLE
chore: add RoutedButton and RoutedLink components [YTFRONT-5711] 

### DIFF
--- a/packages/ui/src/ui/components/Link/Link.tsx
+++ b/packages/ui/src/ui/components/Link/Link.tsx
@@ -3,7 +3,7 @@ import {Link as RouterLink} from 'react-router-dom';
 import {Link as CommonLink} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
 import {makeRoutedURL} from '../../store/window-store';
-import {ClickableText, ClickableTextProps} from '../../components/ClickableText/ClickableText';
+import {ClickableText, ClickableTextProps} from '../ClickableText/ClickableText';
 import {ArrowUpRightFromSquare} from '@gravity-ui/icons';
 import './Link.scss';
 
@@ -18,7 +18,7 @@ const THEME_TO_COLOR: Record<
     ghost: 'secondary',
 };
 
-export interface LinkProps {
+export type LinkProps = {
     url?: string;
     onClick?: (e: React.MouseEvent) => void;
     onMouseUp?: (e: React.MouseEvent) => void;
@@ -31,77 +31,62 @@ export interface LinkProps {
     title?: string;
     routedPreserveLocation?: boolean;
     hasExternalIcon?: boolean;
-}
+};
 
-class Link extends React.Component<LinkProps> {
-    static defaultProps = {
-        target: '_blank',
-        routed: false,
-        theme: 'normal',
-    };
+export const Link = ({
+    url,
+    children,
+    className,
+    target = '_blank',
+    onClick,
+    routed = false,
+    theme = 'normal',
+    title,
+    routedPreserveLocation,
+    hasExternalIcon,
+}: LinkProps) => {
+    const content = (
+        <>
+            {children}
+            {hasExternalIcon && (
+                <span style={{paddingLeft: '2px'}}>
+                    <ArrowUpRightFromSquare className={block('external-icon')} />
+                </span>
+            )}
+        </>
+    );
 
-    render() {
-        const {
-            url,
-            children,
-            className,
-            target,
-            onClick,
-            routed,
-            theme,
-            title,
-            routedPreserveLocation,
-            hasExternalIcon,
-        } = this.props;
-
-        const content = (
-            <>
-                {children}
-                {hasExternalIcon && (
-                    <span style={{paddingLeft: '2px'}}>
-                        <ArrowUpRightFromSquare className={block('external-icon')} />
-                    </span>
-                )}
-            </>
-        );
-
-        const to =
-            !routed || !routedPreserveLocation
-                ? url
-                : () => {
-                      return makeRoutedURL(url || '');
-                  };
-
-        if (routed) {
-            return (
-                <RouterLink
-                    className={gBlock({view: theme}, className)}
-                    onClick={onClick}
-                    to={to || ''}
-                >
-                    {content}
-                </RouterLink>
-            );
-        }
-
-        return !url ? (
+    if (!url) {
+        return (
             <ClickableText className={className} onClick={onClick} color={textColor(theme)}>
                 {content}
             </ClickableText>
-        ) : (
-            <CommonLink
-                className={className}
-                onClick={onClick}
-                target={target}
-                view={theme as Exclude<typeof theme, 'ghost'>}
-                title={title}
-                href={url}
-            >
-                {content}
-            </CommonLink>
         );
     }
-}
+
+    if (routed) {
+        const to = routedPreserveLocation ? () => makeRoutedURL(url) : url;
+
+        return (
+            <RouterLink className={gBlock({view: theme}, className)} onClick={onClick} to={to}>
+                {content}
+            </RouterLink>
+        );
+    }
+
+    return (
+        <CommonLink
+            className={className}
+            onClick={onClick}
+            target={target}
+            view={theme as Exclude<typeof theme, 'ghost'>}
+            title={title}
+            href={url}
+        >
+            {content}
+        </CommonLink>
+    );
+};
 
 function textColor(theme: LinkProps['theme']): ClickableTextProps['color'] {
     const converted = THEME_TO_COLOR[theme as keyof typeof THEME_TO_COLOR];

--- a/packages/ui/src/ui/components/Link/Link.tsx
+++ b/packages/ui/src/ui/components/Link/Link.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import {Link as RouterLink} from 'react-router-dom';
 import {Link as CommonLink} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
-import {makeRoutedURL} from '../../store/window-store';
+import {RoutedLink} from '../../containers/RoutedLink/RoutedLink';
 import {ClickableText, ClickableTextProps} from '../ClickableText/ClickableText';
 import {ArrowUpRightFromSquare} from '@gravity-ui/icons';
 import './Link.scss';
 
-const gBlock = cn('g-link');
 const block = cn('yt-link');
 
 const THEME_TO_COLOR: Record<
@@ -65,12 +63,17 @@ export const Link = ({
     }
 
     if (routed) {
-        const to = routedPreserveLocation ? () => makeRoutedURL(url) : url;
-
         return (
-            <RouterLink className={gBlock({view: theme}, className)} onClick={onClick} to={to}>
+            <RoutedLink
+                className={className}
+                onClick={onClick}
+                view={theme as Exclude<typeof theme, 'ghost'>}
+                title={title}
+                href={url}
+                disablePreserveLocation={!routedPreserveLocation}
+            >
                 {content}
-            </RouterLink>
+            </RoutedLink>
         );
     }
 

--- a/packages/ui/src/ui/containers/RoutedButton/RoutedButton.tsx
+++ b/packages/ui/src/ui/containers/RoutedButton/RoutedButton.tsx
@@ -1,0 +1,32 @@
+import {Button, ButtonLinkProps} from '@gravity-ui/uikit';
+import React, {forwardRef} from 'react';
+import {Link as RouterLink} from 'react-router-dom';
+import {makeRoutedURL} from '../../store/window-store';
+import {useRoutedClickHandler} from '../../hooks/useRoutedClickHandler';
+
+type ButtonAdapterProps = ButtonLinkProps & {
+    navigate: () => void;
+};
+
+const ButtonAdapter = forwardRef<HTMLAnchorElement, ButtonAdapterProps>(function ButtonAdapter(
+    {navigate, onClick, ...props},
+    ref,
+) {
+    const handleClick = useRoutedClickHandler({navigate, onClick});
+
+    return <Button {...props} onClick={handleClick} ref={ref} />;
+});
+
+export type RoutedButtonProps = ButtonLinkProps & {
+    disablePreserveLocation?: boolean;
+};
+
+export const RoutedButton = forwardRef<HTMLAnchorElement, RoutedButtonProps>(function RoutedButton(
+    {disablePreserveLocation, ...buttonProps},
+    ref,
+) {
+    const {href} = buttonProps;
+    const to = disablePreserveLocation ? href : () => makeRoutedURL(href);
+
+    return <RouterLink {...buttonProps} component={ButtonAdapter} to={to} ref={ref} />;
+});

--- a/packages/ui/src/ui/containers/RoutedLink/RoutedLink.tsx
+++ b/packages/ui/src/ui/containers/RoutedLink/RoutedLink.tsx
@@ -1,0 +1,32 @@
+import {Link, LinkProps} from '@gravity-ui/uikit';
+import React, {forwardRef} from 'react';
+import {Link as RouterLink} from 'react-router-dom';
+import {makeRoutedURL} from '../../store/window-store';
+import {useRoutedClickHandler} from '../../hooks/useRoutedClickHandler';
+
+type LinkAdapterProps = LinkProps & {
+    navigate: () => void;
+};
+
+const LinkAdapter = forwardRef<HTMLAnchorElement, LinkAdapterProps>(function LinkAdapter(
+    {navigate, onClick, ...props},
+    ref,
+) {
+    const handleClick = useRoutedClickHandler({navigate, onClick});
+
+    return <Link {...props} onClick={handleClick} ref={ref} />;
+});
+
+export type RoutedLinkProps = LinkProps & {
+    disablePreserveLocation?: boolean;
+};
+
+export const RoutedLink = forwardRef<HTMLAnchorElement, RoutedLinkProps>(function RoutedLink(
+    {disablePreserveLocation, ...linkProps},
+    ref,
+) {
+    const {href} = linkProps;
+    const to = disablePreserveLocation ? href : () => makeRoutedURL(href);
+
+    return <RouterLink {...linkProps} component={LinkAdapter} to={to} ref={ref} />;
+});

--- a/packages/ui/src/ui/hooks/useRoutedClickHandler.ts
+++ b/packages/ui/src/ui/hooks/useRoutedClickHandler.ts
@@ -1,0 +1,26 @@
+import {MouseEvent, MouseEventHandler, useCallback} from 'react';
+
+const isModifiedEvent = (event: MouseEvent): boolean => {
+    return event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+};
+
+type Params = {
+    navigate: () => void;
+    onClick: MouseEventHandler | undefined;
+};
+
+export const useRoutedClickHandler = ({navigate, onClick}: Params): MouseEventHandler => {
+    return useCallback(
+        (event) => {
+            onClick?.(event);
+
+            if (event.defaultPrevented || isModifiedEvent(event)) {
+                return;
+            }
+
+            event.preventDefault();
+            navigate();
+        },
+        [navigate, onClick],
+    );
+};


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/tlw1sOCz7Yu6Kq
<!-- nda-end -->## Summary by Sourcery

Introduce shared Link and LinkButton components with optional router integration and external link support.

New Features:
- Add a reusable Link component that supports routed navigation, external targets, and optional external-link icon.
- Add a LinkButton component that renders a button behaving as a navigable link with router-aware navigation handling.

Enhancements:
- Introduce shared routing utilities and props types for link-like components, including routed URL construction and click handling logic.