### PR TITLE
feat(server/config): add authCookieDomain setting [YTFRONT-5702]

### DIFF
--- a/packages/ui-helm-chart/templates/config-map.yaml
+++ b/packages/ui-helm-chart/templates/config-map.yaml
@@ -10,6 +10,7 @@ data:
     {{ .Values.ui.clusterConfig | toJson }}
   common.js: |
     module.exports = { 
+      authCookieDomain: {{ .Values.settings.authCookieDomain | quote }},
       odinBaseUrl: {{ .Values.settings.odinBaseUrl | quote }}, 
       uiSettings: { 
         directDownload: {{ .Values.settings.directDownload | toJson }},

--- a/packages/ui-helm-chart/values.yaml
+++ b/packages/ui-helm-chart/values.yaml
@@ -44,7 +44,7 @@ readinessProbe:
 
 nginx:
   useCustomConfig: false
-  # name of config map where custom config for nginx is located 
+  # name of config map where custom config for nginx is located
   configMapName: "custom-nginx-configmap"
   configMapkey: "nginx.conf"
 
@@ -69,15 +69,15 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-
 settings:
+  authCookieDomain: ""
   odinBaseUrl: ""
   directDownload: true
   uploadTableExcelBaseUrl: ""
   exportTableBaseUrl: ""
 
   # see https://github.com/ytsaurus/ytsaurus-ui/blob/main/packages/ui/docs/configuration.md#oauth
-  oauth: 
+  oauth:
     enabled: false
     baseURL: ""
     authPath: ""
@@ -87,7 +87,7 @@ settings:
     clientSecretEnvName: ""
     scope: ""
     buttonLabel: ""
-  
+
 securityContext: {}
 
 resources: {}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -74,6 +74,7 @@ All application files in a resulting docker-image will be placed in /opt/app, so
 
 - `YT_AUTH_ALLOW_INSECURE` - if defined allows insecure (over http) authentication, do not use it for production
 - `ALLOW_PASSWORD_AUTH` - If defined, the app requires a password for cluster access
+- `AUTH_COOKIE_DOMAIN` - specifies `Domain` attribute for `Set-Cookie` auth headers for password and oauth authentication (the value is forwarded to `YTCoreConfig.authCookieDomain`)
 - `PROMETHEUS_BASE_URL` - If defined enables monitoring dashboards with prometheus data, see `Prometheus dashboards` below (the value is forwarded to `YTCoreConfig.prometheusBaseUrl`). To use authorized requests to your prometheus instance provide `prometheusAuthHeaders` field in `secrets/yt-interface-secret.json`, like:
 
 ```json

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -74,6 +74,7 @@ All application files in a resulting docker-image will be placed in /opt/app, so
 
 - `YT_AUTH_ALLOW_INSECURE` - if defined allows insecure (over http) authentication, do not use it for production
 - `ALLOW_PASSWORD_AUTH` - If defined, the app requires a password for cluster access
+- `AUTH_COOKIE_DOMAIN` - specifies `Domain` attribute for `Set-Cookie` auth headers for password and OAuth authentication (the value is forwarded to `YTCoreConfig.authCookieDomain`)
 - `PROMETHEUS_BASE_URL` - If defined enables monitoring dashboards with prometheus data, see `Prometheus dashboards` below (the value is forwarded to `YTCoreConfig.prometheusBaseUrl`). To use authorized requests to your prometheus instance provide `prometheusAuthHeaders` field in `secrets/yt-interface-secret.json`, like:
 
 ```json

--- a/packages/ui/docs/configuration.md
+++ b/packages/ui/docs/configuration.md
@@ -23,7 +23,39 @@ exports.default = {
 }
 ```
 
-#### UISettings
+### Authentication & Authorization
+
+#### `authCookieDomain`
+
+The option `authCookieDomain` is necessary to use upload files and tables. Example: `authCookieDomain=".ytsaurus.my.domain"`.
+Make sure `ClusterConfig.externalProxy` value is a subdomain for the value.
+
+#### Password
+
+To enable password authentication/authorization you have to provde `YTCoreConfig.allowPasswordAuth = true` value.
+
+#### OAuth
+
+To use oauth authentication, it is necessary to define configurations `ytOAuthSettings`.
+
+`ytOAuthSettings` - OAuth config
+
+An example of configuration:
+
+```js
+ytOAuthSettings: {
+    baseURL: 'http://keycloak.some-domain.com',
+    authPath: 'realms/test-realm/protocol/openid-connect/auth',
+    tokenPath: 'realms/test-realm/protocol/openid-connect/token',
+    logoutPath: 'realms/test-realm/protocol/openid-connect/logout',
+    clientId: 'test-client',
+    clientSecret: process.env.KEYCLOAK_CLIENT_SECRET,
+    scope: 'openid profile',
+    buttonLabel: 'Login via Keycloak', // OPTIONAL. By default equal `Login via SSO`
+}
+```
+
+### UISettings
 
 `uiSettings` object from config is passed to user's browser "as is" and might it be accessed as `window.__DATA__.uiSettings`.
 
@@ -147,27 +179,4 @@ Example of usage:
     },
   },
 };
-```
-
-#### Authentication
-
-### OAuth
-
-To use authentication, it is necessary to define configurations `ytOAuthSettings`.
-
-`ytOAuthSettings` - OAuth config
-
-An example of configuration:
-
-```js
-ytOAuthSettings: {
-    baseURL: 'http://keycloak.some-domain.com',
-    authPath: 'realms/test-realm/protocol/openid-connect/auth',
-    tokenPath: 'realms/test-realm/protocol/openid-connect/token',
-    logoutPath: 'realms/test-realm/protocol/openid-connect/logout',
-    clientId: 'test-client',
-    clientSecret: process.env.KEYCLOAK_CLIENT_SECRET,
-    scope: 'openid profile',
-    buttonLabel: 'Login via Keycloak', // OPTIONAL. By default equal `Login via SSO`
-}
 ```

--- a/packages/ui/docs/configuration.md
+++ b/packages/ui/docs/configuration.md
@@ -23,7 +23,39 @@ exports.default = {
 }
 ```
 
-#### UISettings
+### Authentication & Authorization
+
+#### `authCookieDomain`
+
+The `authCookieDomain` option is required for uploading files and tables. Example: `authCookieDomain=".ytsaurus.my.domain"`.
+Make sure `ClusterConfig.externalProxy` value is a subdomain for the value.
+
+#### Password
+
+To enable password authentication/authorization you have to set `YTCoreConfig.allowPasswordAuth = true`.
+
+#### OAuth
+
+To use oauth authentication, it is necessary to define configurations `ytOAuthSettings`.
+
+`ytOAuthSettings` - OAuth config
+
+An example of configuration:
+
+```js
+ytOAuthSettings: {
+    baseURL: 'http://keycloak.some-domain.com',
+    authPath: 'realms/test-realm/protocol/openid-connect/auth',
+    tokenPath: 'realms/test-realm/protocol/openid-connect/token',
+    logoutPath: 'realms/test-realm/protocol/openid-connect/logout',
+    clientId: 'test-client',
+    clientSecret: process.env.KEYCLOAK_CLIENT_SECRET,
+    scope: 'openid profile',
+    buttonLabel: 'Login via Keycloak', // OPTIONAL. By default equal `Login via SSO`
+}
+```
+
+### UISettings
 
 `uiSettings` object from config is passed to user's browser "as is" and might it be accessed as `window.__DATA__.uiSettings`.
 
@@ -147,27 +179,4 @@ Example of usage:
     },
   },
 };
-```
-
-#### Authentication
-
-### OAuth
-
-To use authentication, it is necessary to define configurations `ytOAuthSettings`.
-
-`ytOAuthSettings` - OAuth config
-
-An example of configuration:
-
-```js
-ytOAuthSettings: {
-    baseURL: 'http://keycloak.some-domain.com',
-    authPath: 'realms/test-realm/protocol/openid-connect/auth',
-    tokenPath: 'realms/test-realm/protocol/openid-connect/token',
-    logoutPath: 'realms/test-realm/protocol/openid-connect/logout',
-    clientId: 'test-client',
-    clientSecret: process.env.KEYCLOAK_CLIENT_SECRET,
-    scope: 'openid profile',
-    buttonLabel: 'Login via Keycloak', // OPTIONAL. By default equal `Login via SSO`
-}
 ```

--- a/packages/ui/src/@types/core.d.ts
+++ b/packages/ui/src/@types/core.d.ts
@@ -82,6 +82,12 @@ export interface YTCoreConfig {
     };
 
     /**
+     * The setting allows to explicitly set the "Domain" attribute for "Set-Cookie" auth headers.
+     * The option affects auth cookies for oauth and password authorization.
+     */
+    authCookieDomain?: string;
+
+    /**
      * OpenID Connect configuration
      */
     ytOAuthSettings?: {

--- a/packages/ui/src/@types/core.d.ts
+++ b/packages/ui/src/@types/core.d.ts
@@ -6,7 +6,7 @@ import type {NodeKit} from '@gravity-ui/nodekit';
 
 import {ClusterConfig} from '../shared/yt-types';
 
-import {UISettings} from '../../shared/ui-settings';
+import {UISettings} from '../shared/ui-settings';
 import {DescribedSettings} from '../shared/constants/settings-types';
 
 export interface YTCoreConfig {

--- a/packages/ui/src/@types/core.d.ts
+++ b/packages/ui/src/@types/core.d.ts
@@ -1,12 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export {type AppConfig, type Request, type Response} from '@gravity-ui/expresskit';
 import {type AppContext, type NodeKit} from '@gravity-ui/nodekit';
 import {type MetrikaCounter} from '@gravity-ui/app-layout';
-
 import {type UISettings} from '../../shared/ui-settings';
 import {type ClusterConfig} from '../shared/yt-types';
 import {type AppLang, type DescribedSettings} from '../shared/constants/settings-types';
-
-export {type AppConfig} from '@gravity-ui/nodekit';
-export {type Request, type Response} from '@gravity-ui/expresskit';
 
 export interface YTCoreConfig {
     /**

--- a/packages/ui/src/@types/core.d.ts
+++ b/packages/ui/src/@types/core.d.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export {type AppConfig, type Request, type Response} from '@gravity-ui/expresskit';
 import {type AppContext, type NodeKit} from '@gravity-ui/nodekit';
 import {type MetrikaCounter} from '@gravity-ui/app-layout';
@@ -77,6 +76,12 @@ export interface YTCoreConfig {
         cluster?: string;
         dynamicTablePath: string;
     };
+
+    /**
+     * The setting allows to explicitly set the "Domain" attribute for "Set-Cookie" auth headers.
+     * The option affects auth cookies for oauth and password authorization.
+     */
+    authCookieDomain?: string;
 
     /**
      * OpenID Connect configuration

--- a/packages/ui/src/server/components/oauth.spec.ts
+++ b/packages/ui/src/server/components/oauth.spec.ts
@@ -1,0 +1,79 @@
+import express, {type Request, type Response} from 'express';
+
+import {removeOAuthCookies, saveOAuthTokensInCookies} from './oauth';
+
+const NOW = new Date('2026-08-14T12:00:00.000Z');
+
+function makeRequest(authCookieDomain?: string) {
+    return {ctx: {config: {authCookieDomain}}} as unknown as Request;
+}
+
+function makeResponse(req: Request) {
+    const headers = new Map<string, string | string[]>();
+    const res = Object.create(express.response) as Response;
+
+    res.req = req;
+    res.getHeader = (name) => headers.get(name.toLowerCase());
+    res.setHeader = (name, value) => {
+        headers.set(name.toLowerCase(), value as string | string[]);
+        return res;
+    };
+
+    return res;
+}
+
+describe('OAuth auth Set-Cookie headers', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should set access and refresh cookies with the configured domain', () => {
+        const req = makeRequest('.example.com');
+        const res = makeResponse(req);
+
+        saveOAuthTokensInCookies(req, res, {
+            access_token: 'access-token',
+            expires_in: 60,
+            refresh_token: 'refresh-token',
+            refresh_expires_in: 120,
+        });
+
+        expect(res.getHeader('set-cookie')).toEqual([
+            'yt_oauth_access_token=access-token; Max-Age=60; Domain=.example.com; Path=/; Expires=Fri, 14 Aug 2026 12:01:00 GMT; HttpOnly; Secure',
+            'yt_oauth_refresh_token=refresh-token; Max-Age=120; Domain=.example.com; Path=/; Expires=Fri, 14 Aug 2026 12:02:00 GMT; HttpOnly; Secure',
+        ]);
+    });
+
+    it('should preserve a host-only access cookie when the domain is not configured', () => {
+        const req = makeRequest();
+        const res = makeResponse(req);
+
+        saveOAuthTokensInCookies(req, res, {
+            access_token: 'access-token',
+            expires_in: 60,
+            refresh_token: '',
+            refresh_expires_in: 0,
+        });
+
+        expect(res.getHeader('set-cookie')).toBe(
+            'yt_oauth_access_token=access-token; Max-Age=60; Path=/; Expires=Fri, 14 Aug 2026 12:01:00 GMT; HttpOnly; Secure',
+        );
+    });
+
+    it('should expire both cookies with the configured domain', () => {
+        const req = makeRequest('.example.com');
+        const res = makeResponse(req);
+
+        removeOAuthCookies(req, res);
+
+        expect(res.getHeader('set-cookie')).toEqual([
+            'yt_oauth_access_token=; Domain=.example.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+            'yt_oauth_refresh_token=; Domain=.example.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+        ]);
+    });
+});

--- a/packages/ui/src/server/components/oauth.ts
+++ b/packages/ui/src/server/components/oauth.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import type {Request, Response} from 'express';
 import crypto from 'node:crypto';
 import {YT_OAUTH_ACCESS_TOKEN_NAME, YT_OAUTH_REFRESH_TOKEN_NAME} from '../../shared/constants';
+import {makeAuthCookieOptions} from '../utils/cookie';
 
 function getRedirectURL(req: Request) {
     const config = getOAuthSettings(req);
@@ -52,19 +53,27 @@ export async function getOAuthAccessToken(req: Request, res: Response) {
             req,
             req.cookies[YT_OAUTH_REFRESH_TOKEN_NAME] as string,
         );
-        saveOAuthTokensInCookies(res, tokens);
+        saveOAuthTokensInCookies(req, res, tokens);
         return tokens.access_token;
     }
     return undefined;
 }
 
-export function removeOAuthCookies(res: Response) {
-    res.clearCookie(YT_OAUTH_ACCESS_TOKEN_NAME);
-    res.clearCookie(YT_OAUTH_REFRESH_TOKEN_NAME);
+export function removeOAuthCookies(req: Request, res: Response) {
+    const options = makeAuthCookieOptions(req);
+    res.clearCookie(YT_OAUTH_ACCESS_TOKEN_NAME, options);
+    res.clearCookie(YT_OAUTH_REFRESH_TOKEN_NAME, options);
 }
 
-export function saveOAuthTokensInCookies(res: Response, tokens: OAuthAuthorizationTokens) {
+export function saveOAuthTokensInCookies(
+    req: Request,
+    res: Response,
+    tokens: OAuthAuthorizationTokens,
+) {
+    const options = makeAuthCookieOptions(req);
+
     res.cookie(YT_OAUTH_ACCESS_TOKEN_NAME, tokens.access_token, {
+        ...options,
         maxAge: tokens.expires_in * 1000,
         httpOnly: true,
         secure: true,
@@ -72,6 +81,7 @@ export function saveOAuthTokensInCookies(res: Response, tokens: OAuthAuthorizati
 
     if (tokens.refresh_token) {
         res.cookie(YT_OAUTH_REFRESH_TOKEN_NAME, tokens.refresh_token, {
+            ...options,
             maxAge: tokens.refresh_expires_in * 1000,
             httpOnly: true,
             secure: true,

--- a/packages/ui/src/server/components/oauth.ts
+++ b/packages/ui/src/server/components/oauth.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import {type Request, type Response} from 'express';
 import crypto from 'node:crypto';
 import {YT_OAUTH_ACCESS_TOKEN_NAME, YT_OAUTH_REFRESH_TOKEN_NAME} from '../../shared/constants';
+import {makeAuthCookieOptions} from '../utils/cookie';
 
 function getRedirectURL(req: Request) {
     const config = getOAuthSettings(req);
@@ -52,19 +53,27 @@ export async function getOAuthAccessToken(req: Request, res: Response) {
             req,
             req.cookies[YT_OAUTH_REFRESH_TOKEN_NAME] as string,
         );
-        saveOAuthTokensInCookies(res, tokens);
+        saveOAuthTokensInCookies(req, res, tokens);
         return tokens.access_token;
     }
     return undefined;
 }
 
-export function removeOAuthCookies(res: Response) {
-    res.clearCookie(YT_OAUTH_ACCESS_TOKEN_NAME);
-    res.clearCookie(YT_OAUTH_REFRESH_TOKEN_NAME);
+export function removeOAuthCookies(req: Request, res: Response) {
+    const options = makeAuthCookieOptions(req);
+    res.clearCookie(YT_OAUTH_ACCESS_TOKEN_NAME, options);
+    res.clearCookie(YT_OAUTH_REFRESH_TOKEN_NAME, options);
 }
 
-export function saveOAuthTokensInCookies(res: Response, tokens: OAuthAuthorizationTokens) {
+export function saveOAuthTokensInCookies(
+    req: Request,
+    res: Response,
+    tokens: OAuthAuthorizationTokens,
+) {
+    const options = makeAuthCookieOptions(req);
+
     res.cookie(YT_OAUTH_ACCESS_TOKEN_NAME, tokens.access_token, {
+        ...options,
         maxAge: tokens.expires_in * 1000,
         httpOnly: true,
         secure: true,
@@ -72,6 +81,7 @@ export function saveOAuthTokensInCookies(res: Response, tokens: OAuthAuthorizati
 
     if (tokens.refresh_token) {
         res.cookie(YT_OAUTH_REFRESH_TOKEN_NAME, tokens.refresh_token, {
+            ...options,
             maxAge: tokens.refresh_expires_in * 1000,
             httpOnly: true,
             secure: true,

--- a/packages/ui/src/server/components/vcs/index.ts
+++ b/packages/ui/src/server/components/vcs/index.ts
@@ -34,7 +34,7 @@ export class VcsFactory {
         if (!('vcsSettings' in uiSettings))
             throw new ErrorWithCode(404, 'vcsSettings is not found in UISettings');
 
-        return uiSettings.vcsSettings;
+        return uiSettings.vcsSettings ?? [];
     }
 
     static getVcsSettingById(req: Request, vcsId?: string): VCSSettings {

--- a/packages/ui/src/server/components/yt-auth.ts
+++ b/packages/ui/src/server/components/yt-auth.ts
@@ -1,22 +1,34 @@
 import {AppConfig} from '@gravity-ui/nodekit';
-import type {Response} from 'express';
+import type {Request, Response} from 'express';
 import {YT_CYPRESS_COOKIE_NAME} from '../../shared/constants';
 import {getClustersFromConfig} from './utils';
 import {makeAuthClusterCookieName} from '../utils';
+import {makeAuthCookieOptions, replaceDomainForSetCookie} from '../utils/cookie';
 
 export function isYtAuthEnabled(config: AppConfig) {
     return Boolean(config.allowPasswordAuth);
 }
 
-export function YTAuthLogout(res: Response) {
+export function YTAuthLogout(req: Request, res: Response) {
     const clusters = getClustersFromConfig();
 
-    res.setHeader(
-        'set-cookie',
-        [`${YT_CYPRESS_COOKIE_NAME}=deleted; Path=/; Max-Age=0;`].concat(
-            Object.keys(clusters).map(
-                (cluster) => `${makeAuthClusterCookieName(cluster)}=deleted; Path=/; Max-Age=0;`,
+    const {domain} = makeAuthCookieOptions(req);
+
+    res.setHeader('set-cookie', [
+        replaceDomainIfDefined(`${YT_CYPRESS_COOKIE_NAME}=deleted; Path=/; Max-Age=0;`, domain),
+        ...Object.keys(clusters).map((cluster) =>
+            replaceDomainIfDefined(
+                `${makeAuthClusterCookieName(cluster)}=deleted; Path=/; Max-Age=0;`,
+                domain,
             ),
         ),
-    );
+    ]);
+}
+
+function replaceDomainIfDefined(item: string, domain?: string) {
+    if (domain) {
+        return replaceDomainForSetCookie(item, domain);
+    }
+
+    return item;
 }

--- a/packages/ui/src/server/components/yt-auth.ts
+++ b/packages/ui/src/server/components/yt-auth.ts
@@ -1,22 +1,35 @@
 import {type AppConfig} from '@gravity-ui/nodekit';
-import {type Response} from 'express';
+import type {Request, Response} from 'express';
+
 import {YT_CYPRESS_COOKIE_NAME} from '../../shared/constants';
 import {getClustersFromConfig} from './utils';
 import {makeAuthClusterCookieName} from '../utils';
+import {makeAuthCookieOptions, replaceDomainForSetCookie} from '../utils/cookie';
 
 export function isYtAuthEnabled(config: AppConfig) {
     return Boolean(config.allowPasswordAuth);
 }
 
-export function YTAuthLogout(res: Response) {
+export function YTAuthLogout(req: Request, res: Response) {
     const clusters = getClustersFromConfig();
 
-    res.setHeader(
-        'set-cookie',
-        [`${YT_CYPRESS_COOKIE_NAME}=deleted; Path=/; Max-Age=0;`].concat(
-            Object.keys(clusters).map(
-                (cluster) => `${makeAuthClusterCookieName(cluster)}=deleted; Path=/; Max-Age=0;`,
+    const {domain} = makeAuthCookieOptions(req);
+
+    res.setHeader('set-cookie', [
+        replaceDomainIfDefined(`${YT_CYPRESS_COOKIE_NAME}=deleted; Path=/; Max-Age=0;`, domain),
+        ...Object.keys(clusters).map((cluster) =>
+            replaceDomainIfDefined(
+                `${makeAuthClusterCookieName(cluster)}=deleted; Path=/; Max-Age=0;`,
+                domain,
             ),
         ),
-    );
+    ]);
+}
+
+function replaceDomainIfDefined(item: string, domain?: string) {
+    if (domain) {
+        return replaceDomainForSetCookie(item, domain);
+    }
+
+    return item;
 }

--- a/packages/ui/src/server/configs/e2e/local.ts
+++ b/packages/ui/src/server/configs/e2e/local.ts
@@ -1,12 +1,14 @@
 import {AppConfig} from '@gravity-ui/nodekit';
 import common from '../common';
 
+const {LOCALMODE_EXTERNAL_PROXY} = process.env;
+
 const e2eConfig: Partial<AppConfig> = {
     uiSettings: {
         defaultFontType: 'internal',
         newTableReplicasCount: 1,
         uploadTableMaxSize: 50 * 1024 * 1024,
-        uploadTableUseLocalmode: true,
+        uploadTableUseLocalmode: !LOCALMODE_EXTERNAL_PROXY,
         queryTrackerStage: 'testing',
         directDownload: false,
         docsBaseUrl: 'https://ytsaurus.tech/docs/en',
@@ -66,7 +68,7 @@ const e2eConfig: Partial<AppConfig> = {
             iconbig:
                 'https://yastatic.net/s3/cloud/yt/static/freeze/assets/images/ui-big.44e3fa56.jpg',
         },
-        externalProxy: 'external.proxy.my',
+        externalProxy: LOCALMODE_EXTERNAL_PROXY ?? 'external.proxy.my',
     },
 };
 

--- a/packages/ui/src/server/controllers/login.spec.ts
+++ b/packages/ui/src/server/controllers/login.spec.ts
@@ -1,0 +1,95 @@
+import axios from 'axios';
+import {type Request, type Response} from 'express';
+import {Readable, Writable} from 'node:stream';
+
+import {getYTApiClusterSetup} from '../components/requestsSetup';
+import {handleLogin} from './login';
+
+jest.mock('axios');
+jest.mock('@ytsaurus/javascript-wrapper', () => jest.fn(() => ({})));
+jest.mock('../components/requestsSetup', () => ({
+    getYTApiClusterSetup: jest.fn(),
+}));
+
+const axiosRequestMock = jest.mocked(axios.request);
+const getYTApiClusterSetupMock = jest.mocked(getYTApiClusterSetup);
+
+function makeRequest(authCookieDomain?: string) {
+    return {
+        body: JSON.stringify({username: 'user', password: 'password'}),
+        method: 'POST',
+        params: {ytAuthCluster: 'alpha'},
+        headers: {},
+        ctx: {
+            config: {authCookieDomain},
+            getMetadata: jest.fn(() => ({})),
+            log: jest.fn(),
+            logError: jest.fn(),
+        },
+    } as unknown as Request;
+}
+
+function makeResponse() {
+    const headers = new Map<string, string | string[]>();
+    const res = new Writable({
+        write(_chunk, _encoding, callback) {
+            callback();
+        },
+    }) as unknown as Response;
+
+    res.status = jest.fn(() => res);
+    res.setHeader = (name, value) => {
+        headers.set(name.toLowerCase(), value as string | string[]);
+        return res;
+    };
+    res.getHeader = (name) => headers.get(name.toLowerCase());
+
+    return res;
+}
+
+describe('handleLogin', () => {
+    beforeEach(() => {
+        getYTApiClusterSetupMock.mockReturnValue({
+            proxyBaseUrl: 'https://alpha.example.com',
+            setup: {} as ReturnType<typeof getYTApiClusterSetup>['setup'],
+        });
+    });
+
+    it('should return the main and cluster auth cookies with the configured domain', async () => {
+        axiosRequestMock.mockResolvedValue({
+            data: Readable.from(['ok']),
+            headers: {
+                'set-cookie': [
+                    'YTCypressCookie=secret; Path=/; Secure; HttpOnly',
+                    'unrelated=value; Path=/',
+                ],
+            },
+            status: 200,
+        });
+        const res = makeResponse();
+
+        await handleLogin(makeRequest('.example.com'), res);
+
+        expect(res.getHeader('set-cookie')).toEqual([
+            'YTCypressCookie=secret; Path=/; Secure; HttpOnly; Domain=.example.com',
+            'alpha_YTCypressCookie=secret; Path=/; Secure; HttpOnly; Domain=.example.com',
+            'unrelated=value; Path=/',
+        ]);
+    });
+
+    it('should preserve host-only auth cookies when the domain is not configured', async () => {
+        axiosRequestMock.mockResolvedValue({
+            data: Readable.from(['ok']),
+            headers: {'set-cookie': ['YTCypressCookie=secret; Path=/; Secure; HttpOnly']},
+            status: 200,
+        });
+        const res = makeResponse();
+
+        await handleLogin(makeRequest(), res);
+
+        expect(res.getHeader('set-cookie')).toEqual([
+            'YTCypressCookie=secret; Path=/; Secure; HttpOnly',
+            'alpha_YTCypressCookie=secret; Path=/; Secure; HttpOnly',
+        ]);
+    });
+});

--- a/packages/ui/src/server/controllers/login.ts
+++ b/packages/ui/src/server/controllers/login.ts
@@ -17,6 +17,7 @@ import crypto from 'crypto';
 // @ts-ignore
 import ytLib from '@ytsaurus/javascript-wrapper';
 import {getXSRFToken} from '../components/cluster-queries';
+import {makeAuthCookieOptions, replaceDomainForSetCookie} from '../utils/cookie';
 
 const yt = ytLib();
 
@@ -43,6 +44,8 @@ export async function handleLogin(req: Request, res: Response) {
                 responseType: 'stream',
             })
             .then(async (response) => {
+                const {domain} = makeAuthCookieOptions(req);
+
                 const pipedSize = await pipeAxiosResponse(
                     req.ctx,
                     res,
@@ -51,19 +54,24 @@ export async function handleLogin(req: Request, res: Response) {
                     (headers: Record<string, string[]>) => {
                         if (headers['set-cookie']) {
                             headers['set-cookie'] = headers['set-cookie'].reduce<string[]>(
-                                (ret, item) => {
-                                    ret.push(item);
-
+                                (acc, item) => {
                                     if (item.startsWith(YT_CYPRESS_COOKIE_NAME)) {
-                                        ret.push(
-                                            item.replace(
+                                        const newItem = domain
+                                            ? replaceDomainForSetCookie(item, domain)
+                                            : item;
+
+                                        acc.push(newItem);
+                                        acc.push(
+                                            newItem.replace(
                                                 YT_CYPRESS_COOKIE_NAME,
                                                 makeAuthClusterCookieName(ytAuthCluster),
                                             ),
                                         );
+                                    } else {
+                                        acc.push(item);
                                     }
 
-                                    return ret;
+                                    return acc;
                                 },
                                 [],
                             );

--- a/packages/ui/src/server/controllers/logout.spec.ts
+++ b/packages/ui/src/server/controllers/logout.spec.ts
@@ -1,0 +1,68 @@
+import {type Request, type Response} from 'express';
+
+import {getClustersFromConfig} from '../components/utils';
+import {handleLogout} from './logout';
+
+jest.mock('../components/utils', () => ({
+    getClustersFromConfig: jest.fn(),
+}));
+
+const getClustersFromConfigMock = jest.mocked(getClustersFromConfig);
+
+function makeRequest(authCookieDomain?: string) {
+    return {
+        cookies: {},
+        ctx: {config: {allowPasswordAuth: true, authCookieDomain}},
+    } as unknown as Request;
+}
+
+function makeResponse() {
+    const headers = new Map<string, string | string[]>();
+    const res = {
+        getHeader: (name: string) => headers.get(name.toLowerCase()),
+        setHeader: (name: string, value: string | string[]) => {
+            headers.set(name.toLowerCase(), value);
+        },
+        redirect: jest.fn(),
+    } as unknown as Response;
+
+    return res;
+}
+
+describe('handleLogout', () => {
+    beforeEach(() => {
+        getClustersFromConfigMock.mockReturnValue({
+            alpha: {
+                id: 'alpha',
+                name: 'Alpha',
+                theme: 'bluejeans',
+                environment: 'production',
+                proxy: 'alpha.example.com',
+            },
+        });
+    });
+
+    it('should expire password auth cookies with the configured domain', () => {
+        const res = makeResponse();
+
+        handleLogout(makeRequest('.example.com'), res);
+
+        expect(res.getHeader('set-cookie')).toEqual([
+            'YTCypressCookie=deleted; Path=/; Max-Age=0; ; Domain=.example.com',
+            'alpha_YTCypressCookie=deleted; Path=/; Max-Age=0; ; Domain=.example.com',
+        ]);
+        expect(res.redirect).toHaveBeenCalledWith('/');
+    });
+
+    it('should preserve host-only password auth cookies when the domain is not configured', () => {
+        const res = makeResponse();
+
+        handleLogout(makeRequest(), res);
+
+        expect(res.getHeader('set-cookie')).toEqual([
+            'YTCypressCookie=deleted; Path=/; Max-Age=0;',
+            'alpha_YTCypressCookie=deleted; Path=/; Max-Age=0;',
+        ]);
+        expect(res.redirect).toHaveBeenCalledWith('/');
+    });
+});

--- a/packages/ui/src/server/controllers/logout.ts
+++ b/packages/ui/src/server/controllers/logout.ts
@@ -6,7 +6,7 @@ export function handleLogout(req: Request, res: Response) {
     if (isOAuthAllowed(req) && isUserOAuthLogged(req)) {
         res.redirect(getOAuthLogoutPath(req));
     } else if (isYtAuthEnabled(req.ctx.config)) {
-        YTAuthLogout(res);
+        YTAuthLogout(req, res);
     }
     res.redirect('/');
 }

--- a/packages/ui/src/server/controllers/oauth-login.ts
+++ b/packages/ui/src/server/controllers/oauth-login.ts
@@ -10,8 +10,8 @@ export function oauthLogin(req: Request, res: Response) {
     res.redirect(getOAuthLoginPath(req, res));
 }
 
-export function oauthLogout(_: Request, res: Response) {
-    removeOAuthCookies(res);
+export function oauthLogout(req: Request, res: Response) {
+    removeOAuthCookies(req, res);
     res.redirect('/');
 }
 
@@ -30,7 +30,7 @@ export async function oauthCallback(req: Request, res: Response) {
     try {
         const tokens = await exchangeOAuthToken(req, code as string);
 
-        saveOAuthTokensInCookies(res, tokens);
+        saveOAuthTokensInCookies(req, res, tokens);
 
         res.redirect(redirectURL);
     } catch (e) {

--- a/packages/ui/src/server/utils/configs/apply-app-env-to-config.ts
+++ b/packages/ui/src/server/utils/configs/apply-app-env-to-config.ts
@@ -36,6 +36,7 @@ function applyAppAuthEnvToConfig(config: Partial<YTCoreConfig>) {
         allowPasswordAuth,
         ytAuthAllowInsecure: Boolean(YT_AUTH_ALLOW_INSECURE),
         ...{appAuthPolicy: allowPasswordAuth ? AuthPolicy.required : AuthPolicy.disabled},
+        authCookieDomain: process.env.AUTH_COOKIE_DOMAIN,
     };
 
     applyMissingFields(config, tmp);

--- a/packages/ui/src/server/utils/configs/apply-app-env-to-config.ts
+++ b/packages/ui/src/server/utils/configs/apply-app-env-to-config.ts
@@ -3,8 +3,9 @@ import {AppConfig, YTCoreConfig} from '../../../@types/core';
 import {applyMissingFields} from './apply-missing-fields';
 
 function applyEnvToUISettings(config: Partial<YTCoreConfig>) {
+    const {uiSettings = {}} = config;
     if (!config.uiSettings) {
-        Object.assign(config, {uiSettings: {}});
+        Object.assign(config, {uiSettings});
     }
 
     const tmp: Partial<(typeof config)['uiSettings']> = {
@@ -15,7 +16,7 @@ function applyEnvToUISettings(config: Partial<YTCoreConfig>) {
         docsBaseUrl: process.env.YT_DOCS_BASE_URL || 'https://ytsaurus.tech/docs/en',
     };
 
-    applyMissingFields(config.uiSettings, tmp);
+    applyMissingFields(uiSettings, tmp);
 }
 
 function applyEnvToConfig(config: Partial<YTCoreConfig>) {

--- a/packages/ui/src/server/utils/configs/apply-app-env-to-config.ts
+++ b/packages/ui/src/server/utils/configs/apply-app-env-to-config.ts
@@ -3,8 +3,9 @@ import {type AppConfig, type YTCoreConfig} from '../../../@types/core';
 import {applyMissingFields} from './apply-missing-fields';
 
 function applyEnvToUISettings(config: Partial<YTCoreConfig>) {
+    const {uiSettings = {}} = config;
     if (!config.uiSettings) {
-        Object.assign(config, {uiSettings: {}});
+        Object.assign(config, {uiSettings});
     }
 
     const tmp: Partial<(typeof config)['uiSettings']> = {
@@ -15,7 +16,7 @@ function applyEnvToUISettings(config: Partial<YTCoreConfig>) {
         docsBaseUrl: process.env.YT_DOCS_BASE_URL || 'https://ytsaurus.tech/docs/en',
     };
 
-    applyMissingFields(config.uiSettings, tmp);
+    applyMissingFields(uiSettings, tmp);
 }
 
 function applyEnvToConfig(config: Partial<YTCoreConfig>) {

--- a/packages/ui/src/server/utils/cookie.spec.ts
+++ b/packages/ui/src/server/utils/cookie.spec.ts
@@ -1,0 +1,73 @@
+import {replaceDomainForSetCookie} from './cookie';
+
+describe('replaceSetCookieDomain', () => {
+    it('should replace an existing Domain attribute (exact case)', () => {
+        const result = replaceDomainForSetCookie(
+            'foo=bar; Domain=old.example.com; Path=/',
+            'new.example.com',
+        );
+        expect(result).toBe('foo=bar; Domain=new.example.com; Path=/');
+    });
+
+    it('should replace an existing Domain attribute (lowercase)', () => {
+        const result = replaceDomainForSetCookie(
+            'foo=bar; domain=old.example.com; Path=/',
+            'new.example.com',
+        );
+        expect(result).toBe('foo=bar; Domain=new.example.com; Path=/');
+    });
+
+    it('should replace an existing Domain attribute (mixed case)', () => {
+        const result = replaceDomainForSetCookie(
+            'foo=bar; DoMaIn=old.example.com; Path=/',
+            'new.example.com',
+        );
+        expect(result).toBe('foo=bar; Domain=new.example.com; Path=/');
+    });
+
+    it('should append Domain attribute when it is absent', () => {
+        const result = replaceDomainForSetCookie('foo=bar; Path=/; HttpOnly', 'new.example.com');
+        expect(result).toBe('foo=bar; Path=/; HttpOnly; Domain=new.example.com');
+    });
+
+    it('should append Domain attribute to a cookie string with no other attributes', () => {
+        const result = replaceDomainForSetCookie('foo=bar', 'example.com');
+        expect(result).toBe('foo=bar; Domain=example.com');
+    });
+
+    it('should handle a cookie string that already has only a Domain attribute', () => {
+        const result = replaceDomainForSetCookie(
+            'foo=bar; Domain=old.example.com',
+            'new.example.com',
+        );
+        expect(result).toBe('foo=bar; Domain=new.example.com');
+    });
+
+    it('should handle semicolons with varying whitespace between parts', () => {
+        const result = replaceDomainForSetCookie(
+            'foo=bar;Domain=old.example.com;Path=/',
+            'new.example.com',
+        );
+        expect(result).toBe('foo=bar; Domain=new.example.com; Path=/');
+    });
+
+    it('should not modify other attributes when replacing Domain', () => {
+        const result = replaceDomainForSetCookie(
+            'session=abc123Domain=old.example.com; Domain=old.example.com; Path=/; Secure; HttpOnly; SameSite=Strict',
+            'new.example.com',
+        );
+        expect(result).toBe(
+            'session=abc123Domain=old.example.com; Domain=new.example.com; Path=/; Secure; HttpOnly; SameSite=Strict',
+        );
+    });
+
+    it('should not modify other attributes when appending Domain', () => {
+        const result = replaceDomainForSetCookie(
+            'session=abc123; Path=/; Secure; HttpOnly; SameSite=Strict',
+            'new.example.com',
+        );
+        expect(result).toBe(
+            'session=abc123; Path=/; Secure; HttpOnly; SameSite=Strict; Domain=new.example.com',
+        );
+    });
+});

--- a/packages/ui/src/server/utils/cookie.ts
+++ b/packages/ui/src/server/utils/cookie.ts
@@ -1,0 +1,19 @@
+import type {Request} from 'express';
+
+export function replaceDomainForSetCookie(setCookieItem: string, domain: string) {
+    const parts = setCookieItem.split(/;\s*/);
+
+    const index = parts.findIndex((x) => x.toLowerCase().startsWith('domain'));
+    if (index !== -1) {
+        parts[index] = `Domain=${domain}`;
+    } else {
+        parts.push(`Domain=${domain}`);
+    }
+
+    return parts.join('; ');
+}
+
+export function makeAuthCookieOptions(req: Request) {
+    const {authCookieDomain: domain} = req.ctx.config;
+    return domain ? {domain} : {};
+}

--- a/packages/ui/src/shared/ui-settings.ts
+++ b/packages/ui/src/shared/ui-settings.ts
@@ -13,9 +13,9 @@ export interface UISettings {
     docsBaseUrl?: string;
     jupyterBasePath?: string;
 
-    newTableReplicasCount: number;
+    newTableReplicasCount?: number;
 
-    uploadTableMaxSize: number;
+    uploadTableMaxSize?: number;
     uploadTableUseLocalmode?: boolean;
 
     uploadTableExcelBaseUrl?: string;
@@ -163,7 +163,7 @@ export interface UISettings {
      *   "https:\\/\\/image\\.bank\\.my\\/vegetables\\/"
      * ]
      */
-    reUnipikaAllowTaggedSources: Array<string>;
+    reUnipikaAllowTaggedSources?: Array<string>;
 
     /**
      * Allows to define service for removing 'Referer' header for url-s on a page.

--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -116,6 +116,7 @@ export interface ClusterConfig {
      * if defined it will be used instead of `proxy`-field for some direct
      * heavy url/commands like: read_table, write_table, get-job-stderr, ...
      * the field should be used only from browser.
+     * It might be useful to provide `YTCoreConfig.authCookieDomain`.
      */
     externalProxy?: string;
 

--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -120,6 +120,7 @@ export interface ClusterConfig {
      * if defined it will be used instead of `proxy`-field for some direct
      * heavy url/commands like: read_table, write_table, get-job-stderr, ...
      * the field should be used only from browser.
+     * It might be useful to provide `YTCoreConfig.authCookieDomain`.
      */
     externalProxy?: string;
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/3JTOKQyR7ZLGNo
<!-- nda-end -->    ## Summary by Sourcery

Introduce configurable auth cookie domain for password and OAuth authentication and propagate it through server, Helm chart, and documentation.

New Features:
- Add YTCoreConfig.authCookieDomain setting, configurable via AUTH_COOKIE_DOMAIN env var and Helm chart values, to control the Domain attribute of auth cookies.

Enhancements:
- Apply the configured auth cookie domain when setting and clearing password and OAuth auth cookies, preserving host-only cookies when unset.
- Relax several UISettings fields and vcsSettings to be optional to avoid required config values.
- Clarify and expand authentication documentation, including authCookieDomain usage and password/OAuth setup, and reorganize the auth section.

Documentation:
- Document the AUTH_COOKIE_DOMAIN environment variable and authCookieDomain usage in configuration and README.

Tests:
- Add unit tests covering auth cookie domain behavior for login, logout, OAuth flows, and cookie Domain replacement helper.