### PR TITLE
chore(histogram/manage-tokens/suggests/chaos_cell_bundles/tablet_cell_bundles): change selector prefix

### DIFF
--- a/packages/ui/src/ui/components/Histogram/Histogram.js
+++ b/packages/ui/src/ui/components/Histogram/Histogram.js
@@ -8,10 +8,10 @@ import keys_ from 'lodash/keys';
 import map_ from 'lodash/map';
 
 import {
-    selectCreateECDF,
-    selectIsDataGood,
-    selectCreatePDF,
-    selectCreateQuartiles,
+    selectGetECDF,
+    selectGetIsDataGood,
+    selectGetPDF,
+    selectGetQuartiles,
 } from '../../store/selectors/histogram';
 import HistogramChart from './HistogramChart';
 
@@ -141,10 +141,10 @@ function Histogram(props) {
 
 // https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances
 const makeMapStateToProps = () => {
-    const getQuartiles = selectCreateQuartiles();
-    const getPDF = selectCreatePDF();
-    const getECDF = selectCreateECDF();
-    const getIsDataGood = selectIsDataGood();
+    const getQuartiles = selectGetQuartiles();
+    const getPDF = selectGetPDF();
+    const getECDF = selectGetECDF();
+    const getIsDataGood = selectGetIsDataGood();
 
     return (state, props) => {
         const quartiles = getQuartiles(state, props);

--- a/packages/ui/src/ui/components/Histogram/Histogram.js
+++ b/packages/ui/src/ui/components/Histogram/Histogram.js
@@ -8,10 +8,10 @@ import keys_ from 'lodash/keys';
 import map_ from 'lodash/map';
 
 import {
-    createGetECDF,
-    createGetIsDataGood,
-    createGetPDF,
-    createGetQuartiles,
+    selectCreateECDF,
+    selectIsDataGood,
+    selectCreatePDF,
+    selectCreateQuartiles,
 } from '../../store/selectors/histogram';
 import HistogramChart from './HistogramChart';
 
@@ -141,10 +141,10 @@ function Histogram(props) {
 
 // https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances
 const makeMapStateToProps = () => {
-    const getQuartiles = createGetQuartiles();
-    const getPDF = createGetPDF();
-    const getECDF = createGetECDF();
-    const getIsDataGood = createGetIsDataGood();
+    const getQuartiles = selectCreateQuartiles();
+    const getPDF = selectCreatePDF();
+    const getECDF = selectCreateECDF();
+    const getIsDataGood = selectIsDataGood();
 
     return (state, props) => {
         const quartiles = getQuartiles(state, props);

--- a/packages/ui/src/ui/containers/AppNavigation/AppNavigationComponent.tsx
+++ b/packages/ui/src/ui/containers/AppNavigation/AppNavigationComponent.tsx
@@ -18,7 +18,7 @@ import {importManageTokens} from '../ManageTokens';
 import {ChatToggleFooterButton} from '../AiChat/ChatToggleButton';
 
 import './AppNavigationComponent.scss';
-import {getAllowManageTokens} from '../../store/selectors/manage-tokens';
+import {selectAllowManageTokens} from '../../store/selectors/manage-tokens';
 
 const block = cn('yt-app-navigation');
 
@@ -58,7 +58,7 @@ function AppNavigationComponent({
 
     const [popupVisible, setPopupVisible] = useState(false);
     const settingsCluster = useSelector(selectSettingsCluster);
-    const isManageTokensMenuVisible = useSelector(getAllowManageTokens);
+    const isManageTokensMenuVisible = useSelector(selectAllowManageTokens);
     const history = useHistory();
 
     let showUserIcon = Boolean(currentUser);

--- a/packages/ui/src/ui/containers/ManageTokens/ManageTokensModal.tsx
+++ b/packages/ui/src/ui/containers/ManageTokens/ManageTokensModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {DialogWrapper as Dialog} from '../../components/DialogWrapper/DialogWrapper';
 import {useDispatch, useSelector} from '../../store/redux-hooks';
-import {isManageTokensModalOpened} from '../../store/selectors/manage-tokens';
+import {selectIsManageTokensModalOpened} from '../../store/selectors/manage-tokens';
 import withLazyLoading from '../../hocs/withLazyLoading';
 import {importManageTokens} from './index';
 
@@ -14,7 +14,7 @@ const ManageTokensModalContentLazy = withLazyLoading(
 );
 
 export const ManageTokensModal = () => {
-    const open = useSelector(isManageTokensModalOpened)!;
+    const open = useSelector(selectIsManageTokensModalOpened)!;
     const dispatch = useDispatch();
 
     const handleCloseModal = () => {

--- a/packages/ui/src/ui/containers/ManageTokens/ManageTokensModalContent/ManageTokensModalContent.tsx
+++ b/packages/ui/src/ui/containers/ManageTokens/ManageTokensModalContent/ManageTokensModalContent.tsx
@@ -14,7 +14,7 @@ import {
     manageTokensRevokeToken,
 } from '../../../store/actions/manage-tokens';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
-import {AuthenticationToken, manageTokensSelector} from '../../../store/selectors/manage-tokens';
+import {AuthenticationToken, selectManageTokens} from '../../../store/selectors/manage-tokens';
 import {selectCurrentUserName} from '../../../store/selectors/global';
 import Icon from '../../../components/Icon/Icon';
 import {YTError} from '../../../../@types/types';
@@ -176,7 +176,7 @@ const AuthenticationTokensSection: FC<{
 }> = ({onSuccessRemove, onClickGenerateTokenButton, passwordSha256 = ''}) => {
     const {getPassword} = useManageTokensPasswordModalContext();
     const dispatch = useDispatch();
-    const tokens = useSelector(manageTokensSelector);
+    const tokens = useSelector(selectManageTokens);
     const user = useSelector(selectCurrentUserName);
 
     const handleClickRemoveToken = React.useCallback(

--- a/packages/ui/src/ui/containers/ManageTokens/ManageTokensPasswordModal/ManageTokensPasswordModal.tsx
+++ b/packages/ui/src/ui/containers/ManageTokens/ManageTokensPasswordModal/ManageTokensPasswordModal.tsx
@@ -7,7 +7,7 @@ import {createPasswordStrategy} from './password-strategies';
 import {YTDFDialog, makeErrorFields} from '../../../components/Dialog';
 import {selectCurrentUserName, selectSettingsCluster} from '../../../store/selectors/global';
 import {YTError} from '../../../../@types/types';
-import {isManageTokensInOAuthMode} from '../../../store/selectors/manage-tokens';
+import {selectIsManageTokensInOAuthMode} from '../../../store/selectors/manage-tokens';
 import {CryptoSubtleAlert} from './CryptoSubtleAlert';
 
 interface ManageTokensPasswordModalContextValue {
@@ -131,7 +131,7 @@ class PromiseWaiter<Data> {
 }
 
 export function ManageTokensPasswordModalContextProvider({children}: {children: React.ReactChild}) {
-    const isOAuth = useSelector(isManageTokensInOAuthMode);
+    const isOAuth = useSelector(selectIsManageTokensInOAuthMode);
     const [visible, setVisible] = React.useState(false);
     const p = React.useRef(new PromiseWaiter<string>());
     const value = React.useMemo(() => {

--- a/packages/ui/src/ui/hooks/settings/use-settings-column-visibility.ts
+++ b/packages/ui/src/ui/hooks/settings/use-settings-column-visibility.ts
@@ -37,10 +37,8 @@ export function useSettingsVisibleColumns<K extends KeysByType<DescribedSettings
                         if (-1 === kIndex) {
                             newVisibleColumns.push(k as any);
                         }
-                    } else {
-                        if (-1 !== kIndex) {
-                            newVisibleColumns.splice(kIndex, 1);
-                        }
+                    } else if (-1 !== kIndex) {
+                        newVisibleColumns.splice(kIndex, 1);
                     }
                 });
 

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/ChaosCellBundlesTopRowContent.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/ChaosCellBundlesTopRowContent.connected.ts
@@ -5,9 +5,9 @@ import TabletCellBundlesTopRowContent from '../../pages/tablet_cell_bundles/Tabl
 import {setChaosActiveBundle} from '../../store/actions/chaos_cell_bundles';
 import type {RootState} from '../../store/reducers';
 import {
-    getChaosActiveBundle,
-    getChaosActiveBundleData,
-    getChaosBreadcrumbItems,
+    selectChaosActiveBundle,
+    selectChaosActiveBundleData,
+    selectChaosBreadcrumbItems,
 } from '../../store/selectors/chaos_cell_bundles';
 import {
     getFavouriteChaosBundles,
@@ -16,9 +16,9 @@ import {
 
 const mapStateToProps = (state: RootState) => {
     return {
-        activeBundle: getChaosActiveBundle(state),
-        activeBundleData: getChaosActiveBundleData(state),
-        bcItems: getChaosBreadcrumbItems(state),
+        activeBundle: selectChaosActiveBundle(state),
+        activeBundleData: selectChaosActiveBundleData(state),
+        bcItems: selectChaosBreadcrumbItems(state),
         page: Page.CHAOS_CELL_BUNDLES,
         favourites: getFavouriteChaosBundles(state),
         isActiveBundleInFavourites: isActiveChaosBundleInFavourites(state),

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/BundlesTable.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/BundlesTable.connected.ts
@@ -10,12 +10,12 @@ import {showChaosCellBundleEditor} from '../../../store/actions/chaos_cell_bundl
 import type {RootState} from '../../../store/reducers';
 import {selectCluster} from '../../../store/selectors/global';
 import {
-    getChaosBundlesSortState,
-    getChaosBundlesSorted,
-    getChaosBundlesTableMode,
-    getChaosBundlesTotal,
-    getChaosIsLoaded,
-    getChaosIsLoading,
+    selectChaosBundlesSortState,
+    selectChaosBundlesSorted,
+    selectChaosBundlesTableMode,
+    selectChaosBundlesTotal,
+    selectChaosIsLoaded,
+    selectChaosIsLoading,
 } from '../../../store/selectors/chaos_cell_bundles';
 import {chaosActiveBundleLink} from '../../../utils/components/tablet-cells';
 
@@ -29,14 +29,14 @@ const columns: ComponentProps<typeof BundlesTable>['columns'] = [
 
 const mapStateToProps = (state: RootState) => {
     return {
-        loading: getChaosIsLoading(state),
-        loaded: getChaosIsLoaded(state),
-        data: getChaosBundlesSorted(state),
-        total: getChaosBundlesTotal(state),
-        sortState: getChaosBundlesSortState(state),
+        loading: selectChaosIsLoading(state),
+        loaded: selectChaosIsLoaded(state),
+        data: selectChaosBundlesSorted(state),
+        total: selectChaosBundlesTotal(state),
+        sortState: selectChaosBundlesSortState(state),
         cluster: selectCluster(state),
         allowPerBundleAccounting: false,
-        mode: getChaosBundlesTableMode(state),
+        mode: selectChaosBundlesTableMode(state),
         pathPrefix: '//sys/chaos_cell_bundles/',
         columns,
         activeBundleLink: chaosActiveBundleLink,

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/BundlesTableInstruments.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/BundlesTableInstruments.connected.ts
@@ -11,20 +11,20 @@ import {
 import type {RootState} from '../../../store/reducers';
 import type {BundlesTableMode} from '../../../store/reducers/chaos_cell_bundles';
 import {
-    getChaosBundlesAccountFilter,
-    getChaosBundlesNameFilter,
-    getChaosBundlesTableMode,
-    getChaosBundlesTagNodeFilter,
+    selectChaosBundlesAccountFilter,
+    selectChaosBundlesNameFilter,
+    selectChaosBundlesTableMode,
+    selectChaosBundlesTagNodeFilter ,
 } from '../../../store/selectors/chaos_cell_bundles';
 
 const modes: Array<BundlesTableMode> = ['default'];
 
 const mapStateToProps = (state: RootState) => {
     return {
-        accountFilter: getChaosBundlesAccountFilter(state),
-        bundlesTableMode: getChaosBundlesTableMode(state),
-        nameFilter: getChaosBundlesNameFilter(state),
-        tagNodeFilter: getChaosBundlesTagNodeFilter(state),
+        accountFilter: selectChaosBundlesAccountFilter(state),
+        bundlesTableMode: selectChaosBundlesTableMode(state),
+        nameFilter: selectChaosBundlesNameFilter(state),
+        tagNodeFilter: selectChaosBundlesTagNodeFilter (state),
         modes,
     };
 };

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/BundlesTableInstruments.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/BundlesTableInstruments.connected.ts
@@ -14,7 +14,7 @@ import {
     selectChaosBundlesAccountFilter,
     selectChaosBundlesNameFilter,
     selectChaosBundlesTableMode,
-    selectChaosBundlesTagNodeFilter ,
+    selectChaosBundlesTagNodeFilter,
 } from '../../../store/selectors/chaos_cell_bundles';
 
 const modes: Array<BundlesTableMode> = ['default'];
@@ -24,7 +24,7 @@ const mapStateToProps = (state: RootState) => {
         accountFilter: selectChaosBundlesAccountFilter(state),
         bundlesTableMode: selectChaosBundlesTableMode(state),
         nameFilter: selectChaosBundlesNameFilter(state),
-        tagNodeFilter: selectChaosBundlesTagNodeFilter (state),
+        tagNodeFilter: selectChaosBundlesTagNodeFilter(state),
         modes,
     };
 };

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/ChaosBundleEditorDialog/ChaosBundleEditorDialog.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/bundles/ChaosBundleEditorDialog/ChaosBundleEditorDialog.connected.ts
@@ -7,11 +7,11 @@ import {
     setBunndleAttributes,
 } from '../../../../store/actions/chaos_cell_bundles/tablet-cell-bundle-editor';
 import type {RootState} from '../../../../store/reducers';
-import {getChaosCellBundleEditorData} from '../../../../store/selectors/chaos_cell_bundles/tablet-cell-bundle-editor';
+import {selectChaosCellBundleEditorData} from '../../../../store/selectors/chaos_cell_bundles/tablet-cell-bundle-editor';
 
 const mapStateToProps = (state: RootState) => {
     return {
-        bundleEditorData: getChaosCellBundleEditorData(state),
+        bundleEditorData: selectChaosCellBundleEditorData(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/cells/CellsInstruments.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/cells/CellsInstruments.connected.ts
@@ -4,26 +4,26 @@ import CellsTableInstruments from '../../../pages/tablet_cell_bundles/cells/Cell
 import {setChaosPartial} from '../../../store/actions/chaos_cell_bundles';
 import type {RootState} from '../../../store/reducers';
 import {
-    getChaosActiveBundle,
-    getChaosCellsBundleFilter,
-    getChaosCellsBundles,
-    getChaosCellsHostFilter,
-    getChaosCellsHosts,
-    getChaosCellsHostsOfActiveBundle,
-    getChaosCellsIdFilter,
+    selectChaosActiveBundle,
+    selectChaosCellsBundleFilter,
+    selectChaosCellsBundles,
+    selectChaosCellsHostFilter,
+    selectChaosCellsHosts,
+    selectChaosCellsHostsOfActiveBundle,
+    selectChaosCellsIdFilter,
 } from '../../../store/selectors/chaos_cell_bundles';
 
 const mapStateToProps = (state: RootState) => {
     return {
-        activeBundle: getChaosActiveBundle(state),
-        activeBundleHosts: getChaosCellsHostsOfActiveBundle(state),
+        activeBundle: selectChaosActiveBundle(state),
+        activeBundleHosts: selectChaosCellsHostsOfActiveBundle(state),
 
-        idFilter: getChaosCellsIdFilter(state),
-        bundleFilter: getChaosCellsBundleFilter(state),
-        hostFilter: getChaosCellsHostFilter(state),
+        idFilter: selectChaosCellsIdFilter(state),
+        bundleFilter: selectChaosCellsBundleFilter(state),
+        hostFilter: selectChaosCellsHostFilter(state),
 
-        bundles: getChaosCellsBundles(state),
-        hosts: getChaosCellsHosts(state),
+        bundles: selectChaosCellsBundles(state),
+        hosts: selectChaosCellsHosts(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/cells/CellsTable.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/cells/CellsTable.connected.ts
@@ -6,10 +6,10 @@ import {setChaosActiveBundle, setChaosPartial} from '../../../store/actions/chao
 import type {RootState} from '../../../store/reducers';
 import {selectCluster} from '../../../store/selectors/global';
 import {
-    getChaosCellsSortState,
-    getChaosCellsSorted,
-    getChaosIsLoaded,
-    getChaosIsLoading,
+    selectChaosCellsSortState,
+    selectChaosCellsSorted,
+    selectChaosIsLoaded,
+    selectChaosIsLoading,
 } from '../../../store/selectors/chaos_cell_bundles';
 import {
     chaosActiveBundleLink,
@@ -29,10 +29,10 @@ const columns: ComponentProps<typeof CellsTable>['columns'] = [
 const mapStateToProps = (state: RootState) => {
     return {
         cluster: selectCluster(state),
-        loading: getChaosIsLoading(state),
-        loaded: getChaosIsLoaded(state),
-        data: getChaosCellsSorted(state),
-        sortState: getChaosCellsSortState(state),
+        loading: selectChaosIsLoading(state),
+        loaded: selectChaosIsLoaded(state),
+        data: selectChaosCellsSorted(state),
+        sortState: selectChaosCellsSortState(state),
         columns,
         activeBundleLink: chaosActiveBundleLink,
         attributesPath: chaosAttributesPath,

--- a/packages/ui/src/ui/pages/components/TabletCellBundlesSuggest/TabletCellBundlesSuggest.tsx
+++ b/packages/ui/src/ui/pages/components/TabletCellBundlesSuggest/TabletCellBundlesSuggest.tsx
@@ -5,7 +5,7 @@ import map_ from 'lodash/map';
 import cn from 'bem-cn-lite';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 
-import {getTabletCellBundlesSuggests} from '../../../store/selectors/suggests';
+import {selectTabletCellBundlesSuggests} from '../../../store/selectors/suggests';
 import {loadUsableTabletCellBundlesSuggests} from '../../../store/actions/suggests';
 import Select from '../../../components/Select/Select';
 
@@ -18,7 +18,7 @@ interface Props
 }
 
 function TabletCellBundlesSuggest(props: Props) {
-    const items = useSelector(getTabletCellBundlesSuggests);
+    const items = useSelector(selectTabletCellBundlesSuggests);
     const dispatch = useDispatch();
     React.useEffect(() => {
         dispatch(loadUsableTabletCellBundlesSuggests());

--- a/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.js
+++ b/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.js
@@ -24,10 +24,10 @@ import {getPath, getType} from '../../../../store/selectors/navigation';
 
 import {
     getActiveHistogram,
-    getHistogram,
     getNavigationTabletsLoadingStatus,
     getTablets,
     hasReplicationData,
+    selectHistogram,
 } from '../../../../store/selectors/navigation/tabs/tablets';
 
 import {NAVIGATION_TABLETS_TABLE_ID} from '../../../../constants/navigation/tabs/tablets';
@@ -656,7 +656,7 @@ const mapStateToProps = (state) => {
         maxByLevel = [getTabletsMax(state)];
     }
 
-    const histogram = getHistogram(state);
+    const histogram = selectHistogram(state);
     const activeHistogram = getActiveHistogram(state);
     const type = getType(state);
     const hasReplication = hasReplicationData(state);

--- a/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundle.tsx
+++ b/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundle.tsx
@@ -13,14 +13,14 @@ import {Column} from '@ytsaurus/components';
 import {DataTableYT} from '../../components/DataTableYT';
 import {YTErrorBlock} from '../../components/Error/Error';
 import {
-    getTabletErrorsByBundleData,
-    getTabletErrorsByBundleError,
-    getTabletErrorsByBundleLoaded,
-    getTabletErrorsByBundleLoading,
-    getTabletErrorsByBundleMethodsFilter,
-    getTabletErrorsByBundlePageCount,
-    getTabletErrorsByBundlePageFilter,
-    getTabletErrorsByBundleTimeRangeFilter,
+    selectTabletErrorsByBundleData,
+    selectTabletErrorsByBundleError,
+    selectTabletErrorsByBundleLoaded,
+    selectTabletErrorsByBundleLoading,
+    selectTabletErrorsByBundleMethodsFilter,
+    selectTabletErrorsByBundlePageCount,
+    selectTabletErrorsByBundlePageFilter,
+    selectTabletErrorsByBundleTimeRangeFilter,
 } from '../../store/selectors/tablet-errors/tablet-errors-by-bundle';
 
 import Link from '../../components/Link/Link';
@@ -33,9 +33,9 @@ import {TabletErrorsByBundleToolbar} from './TabletErrorsByBundleToolbar';
 const block = cn('yt-tablet-errors-by-bunlde');
 
 export function TabletErrorsByBundle({bundle}: {bundle: string}) {
-    const loaded = useSelector(getTabletErrorsByBundleLoaded);
-    const loading = useSelector(getTabletErrorsByBundleLoading);
-    const error = useSelector(getTabletErrorsByBundleError);
+    const loaded = useSelector(selectTabletErrorsByBundleLoaded);
+    const loading = useSelector(selectTabletErrorsByBundleLoading);
+    const error = useSelector(selectTabletErrorsByBundleError);
 
     const {data, columns} = useTabletErrorsColumns(loading);
 
@@ -68,11 +68,11 @@ function useTabletErrorsColumns(loading: boolean) {
         errors: data = [],
         presented_methods = [],
         all_methods = [],
-    } = useSelector(getTabletErrorsByBundleData) ?? {};
-    const pageFilter = useSelector(getTabletErrorsByBundlePageFilter);
-    const teMethods = useSelector(getTabletErrorsByBundleMethodsFilter);
-    const teTime = useSelector(getTabletErrorsByBundleTimeRangeFilter);
-    const pageCount = useSelector(getTabletErrorsByBundlePageCount);
+    } = useSelector(selectTabletErrorsByBundleData) ?? {};
+    const pageFilter = useSelector(selectTabletErrorsByBundlePageFilter);
+    const teMethods = useSelector(selectTabletErrorsByBundleMethodsFilter);
+    const teTime = useSelector(selectTabletErrorsByBundleTimeRangeFilter);
+    const pageCount = useSelector(selectTabletErrorsByBundlePageCount);
 
     const columns = React.useMemo(() => {
         const res: Array<Column<TableMethodErrorsCount>> = [

--- a/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundleToolbar.tsx
+++ b/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundleToolbar.tsx
@@ -12,12 +12,12 @@ import {YTTimeline, calcFromTo} from '../../components/Timeline';
 import TextInputWithDebounce from '../../components/TextInputWithDebounce/TextInputWithDebounce';
 
 import {
-    getTabletErrorsByBundleData,
-    getTabletErrorsByBundleMethodsFilter,
-    getTabletErrorsByBundlePageCount,
-    getTabletErrorsByBundlePageFilter,
-    getTabletErrorsByBundleTablePathFilter,
-    getTabletErrorsByBundleTimeRangeFilter,
+    selectTabletErrorsByBundleData,
+    selectTabletErrorsByBundleMethodsFilter,
+    selectTabletErrorsByBundlePageCount,
+    selectTabletErrorsByBundlePageFilter,
+    selectTabletErrorsByBundleTablePathFilter,
+    selectTabletErrorsByBundleTimeRangeFilter,
 } from '../../store/selectors/tablet-errors/tablet-errors-by-bundle';
 import {
     type TabletErrorsByBundleState,
@@ -39,12 +39,12 @@ export function TabletErrorsByBundleToolbar({
 }) {
     const dispatch = useDispatch();
 
-    const {all_methods = []} = useSelector(getTabletErrorsByBundleData) ?? {};
-    const methodsFilter = useSelector(getTabletErrorsByBundleMethodsFilter);
-    const timeRangeFilter = useSelector(getTabletErrorsByBundleTimeRangeFilter);
-    const pageFilter = useSelector(getTabletErrorsByBundlePageFilter);
-    const tablePathFilter = useSelector(getTabletErrorsByBundleTablePathFilter);
-    const pageCount = useSelector(getTabletErrorsByBundlePageCount);
+    const {all_methods = []} = useSelector(selectTabletErrorsByBundleData) ?? {};
+    const methodsFilter = useSelector(selectTabletErrorsByBundleMethodsFilter);
+    const timeRangeFilter = useSelector(selectTabletErrorsByBundleTimeRangeFilter);
+    const pageFilter = useSelector(selectTabletErrorsByBundlePageFilter);
+    const tablePathFilter = useSelector(selectTabletErrorsByBundleTablePathFilter);
+    const pageCount = useSelector(selectTabletErrorsByBundlePageCount);
 
     const {from, to} = useTabletErrorsLoad(bundle, {
         methodsFilter,

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.js
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.js
@@ -20,7 +20,7 @@ import Label from '../../../components/Label';
 import Yson from '../../../components/Yson/Yson';
 
 import {histogramItems} from '../../../utils/tablet/tablet';
-import {getActiveHistogram, getHistogram} from '../../../store/selectors/tablet/tablet';
+import {getActiveHistogram, selectHistogram} from '../../../store/selectors/tablet/tablet';
 import {changeActiveHistogram} from '../../../store/actions/tablet/tablet';
 import {Tab as NavigationTab} from '../../../constants/navigation';
 import {Page} from '../../../constants/index';
@@ -181,7 +181,7 @@ function Overview({id, block}) {
     }[state];
 
     const activeHistogram = useSelector(getActiveHistogram);
-    const histogram = useSelector(getHistogram);
+    const histogram = useSelector(selectHistogram);
 
     const handleHistogramChange = useCallback(
         (histogram) => dispatch(changeActiveHistogram(histogram)),

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundles.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundles.tsx
@@ -16,7 +16,7 @@ import {
     getTabletBundlesWriteableByName,
     getTabletsActiveBundle,
     getTabletsActiveBundleData,
-    getTabletsError,
+    selectTabletsError,
 } from '../../store/selectors/tablet_cell_bundles/index';
 import {YTErrorBlock} from '../../components/Error/Error';
 import Bundles from './bundles/Bundles';
@@ -75,7 +75,7 @@ export default function TabletCellBundles() {
     const match = useRouteMatch();
     const cluster = useSelector(selectCluster);
 
-    const error = useSelector(getTabletsError);
+    const error = useSelector(selectTabletsError);
     const activeBundle = useSelector(getTabletsActiveBundle);
     const {enable_bundle_controller: enableBundleController = false} =
         useSelector(getTabletsActiveBundleData) || ({} as Partial<TabletBundle>);

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundles.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundles.tsx
@@ -13,9 +13,9 @@ import {useDispatch, useSelector} from '../../store/redux-hooks';
 import {fetchChaosBundles} from '../../store/actions/chaos_cell_bundles';
 import {fetchTabletsBundles} from '../../store/actions/tablet_cell_bundles';
 import {
-    getTabletBundlesWriteableByName,
-    getTabletsActiveBundle,
-    getTabletsActiveBundleData,
+    selectTabletBundlesWriteableByName,
+    selectTabletsActiveBundle,
+    selectTabletsActiveBundleData,
     selectTabletsError,
 } from '../../store/selectors/tablet_cell_bundles/index';
 import {YTErrorBlock} from '../../components/Error/Error';
@@ -76,16 +76,16 @@ export default function TabletCellBundles() {
     const cluster = useSelector(selectCluster);
 
     const error = useSelector(selectTabletsError);
-    const activeBundle = useSelector(getTabletsActiveBundle);
+    const activeBundle = useSelector(selectTabletsActiveBundle);
     const {enable_bundle_controller: enableBundleController = false} =
-        useSelector(getTabletsActiveBundleData) || ({} as Partial<TabletBundle>);
+        useSelector(selectTabletsActiveBundleData) || ({} as Partial<TabletBundle>);
     const dispatch = useDispatch();
     const fetchFn = React.useCallback(() => {
         Promise.all([dispatch(fetchChaosBundles()), dispatch(fetchTabletsBundles())]);
     }, [dispatch]);
     useUpdater(fetchFn);
 
-    const writeableByName = useSelector(getTabletBundlesWriteableByName);
+    const writeableByName = useSelector(selectTabletBundlesWriteableByName);
 
     const bundleWritable = writeableByName.get(activeBundle);
 

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundlesTopRowContent.connected.ts
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundlesTopRowContent.connected.ts
@@ -5,18 +5,18 @@ import TabletCellBundlesTopRowContent from '../../pages/tablet_cell_bundles/Tabl
 import {setTabletsActiveBundle} from '../../store/actions/tablet_cell_bundles';
 import type {RootState} from '../../store/reducers';
 import {
-    getTabletsActiveBundle,
-    getTabletsActiveBundleData,
-    getTabletsBreadcrumbItems,
+    selectTabletsActiveBundle,
+    selectTabletsActiveBundleData,
+    selectTabletsBreadcrumbItems,
 } from '../../store/selectors/tablet_cell_bundles';
 import {bundlesToggleFavourite} from '../../store/actions/favourites';
 import {getFavouriteBundles, isActiveBundleInFavourites} from '../../store/selectors/favourites';
 
 const mapStateToProps = (state: RootState) => {
     return {
-        activeBundle: getTabletsActiveBundle(state),
-        activeBundleData: getTabletsActiveBundleData(state),
-        bcItems: getTabletsBreadcrumbItems(state),
+        activeBundle: selectTabletsActiveBundle(state),
+        activeBundleData: selectTabletsActiveBundleData(state),
+        bcItems: selectTabletsBreadcrumbItems(state),
         page: Page.TABLET_CELL_BUNDLES,
         favourites: getFavouriteBundles(state),
         isActiveBundleInFavourites: isActiveBundleInFavourites(state),

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleAclTab.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleAclTab.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {useSelector} from '../../../store/redux-hooks';
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
-import {getTabletsActiveBundle} from '../../../store/selectors/tablet_cell_bundles';
+import {selectTabletsActiveBundle} from '../../../store/selectors/tablet_cell_bundles';
 import {isPoolAclAllowed} from '../../../store/selectors/scheduling/scheduling';
 import {NoContent} from '../../../components/NoContent';
 import {BundleAcl} from '../../../containers/ACL';
 
 export default function BundleAclTab({className}: {className: string}) {
-    const activeBundle = useSelector(getTabletsActiveBundle);
+    const activeBundle = useSelector(selectTabletsActiveBundle);
     const allowAcl = useSelector(isPoolAclAllowed);
     return (
         <ErrorBoundary>

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleConfigurationMeta.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleConfigurationMeta.tsx
@@ -10,8 +10,8 @@ import reduce_ from 'lodash/reduce';
 import hammer from '../../../common/hammer';
 
 import {
-    getActiveBundleControllerData,
-    getTabletsActiveBundleData,
+    selectActiveBundleControllerData,
+    selectTabletsActiveBundleData,
 } from '../../../store/selectors/tablet_cell_bundles';
 import {fetchTabletCellBundleEditor} from '../../../store/actions/tablet_cell_bundles/tablet-cell-bundle-editor';
 import {OrchidBundlesData} from '../../../store/reducers/tablet_cell_bundles';
@@ -40,7 +40,7 @@ const DETAILS_KEYS = [
 export function ActiveAccountBundleControllerUpdater() {
     const dispatch = useDispatch();
     const {bundle: activeBundle, enable_bundle_controller} =
-        useSelector(getTabletsActiveBundleData) || {};
+        useSelector(selectTabletsActiveBundleData) || {};
     const fetchFn = React.useCallback(() => {
         if (activeBundle) {
             dispatch(fetchTabletCellBundleEditor(activeBundle));
@@ -106,8 +106,8 @@ export function ActiveAccountBundleControllerUpdater() {
 
 export default function BundleConfigurationMeta() {
     const {bundle_controller_target_config: bundleControllerConfig} =
-        useSelector(getTabletsActiveBundleData) || {};
-    const orchidData = useSelector(getActiveBundleControllerData);
+        useSelector(selectTabletsActiveBundleData) || {};
+    const orchidData = useSelector(selectActiveBundleControllerData);
 
     if (!bundleControllerConfig || !orchidData) {
         return null;

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleGeneralMeta.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleGeneralMeta.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import cn from 'bem-cn-lite';
-import {getTabletsActiveBundleData} from '../../../store/selectors/tablet_cell_bundles';
+import {selectTabletsActiveBundleData} from '../../../store/selectors/tablet_cell_bundles';
 import {useSelector} from '../../../store/redux-hooks';
 import {MetaTable, type MetaTableItem} from '@ytsaurus/components';
 import {Progress} from '@gravity-ui/uikit';
@@ -29,7 +29,7 @@ export function BundleBalancerValue(props: {value?: boolean; blocking?: boolean}
 }
 
 export default function BundleGeneralMeta() {
-    const bundleData = useSelector(getTabletsActiveBundleData);
+    const bundleData = useSelector(selectTabletsActiveBundleData);
     const clusterUiConfig = useSelector(selectClusterUiConfig);
     const cluster = useSelector(selectCluster);
     const allowTabletAccounting = useSelector(selectClusterUiConfigEnablePerBundleTabletAccounting);

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleInstancesTab.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleInstancesTab.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {useSelector} from '../../../store/redux-hooks';
-import {getActiveBundleInstances} from '../../../store/selectors/tablet_cell_bundles';
+import {selectActiveBundleInstances} from '../../../store/selectors/tablet_cell_bundles';
 
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
 import {CellsBundleController} from '../cells/CellsBundleController';
 
 export const BundleInstancesTab = () => {
-    const items = useSelector(getActiveBundleInstances);
+    const items = useSelector(selectActiveBundleInstances);
 
     return (
         <ErrorBoundary>

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleMonitorTab.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleMonitorTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useSelector} from '../../../store/redux-hooks';
 import {selectCluster} from '../../../store/selectors/global';
 import ypath from '../../../common/thor/ypath';
-import {getTabletsActiveBundleData} from '../../../store/selectors/tablet_cell_bundles';
+import {selectTabletsActiveBundleData} from '../../../store/selectors/tablet_cell_bundles';
 
 import {NoContent} from '../../../components/NoContent';
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
@@ -13,7 +13,7 @@ function BundleMonitorTab(props: {
     component: React.ComponentType<{cluster: string; tablet_cell_bundle: string; bundleData: any}>;
 }) {
     const {component: BundleMonitor} = props;
-    const bundleData = useSelector(getTabletsActiveBundleData);
+    const bundleData = useSelector(selectTabletsActiveBundleData);
     const cluster = useSelector(selectCluster);
 
     const tablet_cell_bundle: undefined | string = React.useMemo(() => {

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleProxiesTab.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleProxiesTab.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {useSelector} from '../../../store/redux-hooks';
-import {getActiveBundleProxies} from '../../../store/selectors/tablet_cell_bundles';
+import {selectActiveBundleProxies} from '../../../store/selectors/tablet_cell_bundles';
 
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
 import {CellsBundleController} from '../cells/CellsBundleController';
 
 export const BundleProxiesTab = () => {
-    const items = useSelector(getActiveBundleProxies);
+    const items = useSelector(selectActiveBundleProxies);
     return (
         <ErrorBoundary>
             <CellsBundleController items={items} hideColumns={['tablet_static_memory']} />

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleStatisticsTab.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleStatisticsTab.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import {useSelector} from '../../../store/redux-hooks';
 
 import ErrorBoundary from '../../../components/ErrorBoundary/ErrorBoundary';
-import {getTabletsActiveBundle} from '../../../store/selectors/tablet_cell_bundles';
+import {selectTabletsActiveBundle} from '../../../store/selectors/tablet_cell_bundles';
 import {selectCluster, selectTheme} from '../../../store/selectors/global';
 import UIFactory from '../../../UIFactory';
 import {NoContent} from '../../../components/NoContent';
 
 function BundleStatisticsTab() {
     const cluster = useSelector(selectCluster);
-    const bundle = useSelector(getTabletsActiveBundle);
+    const bundle = useSelector(selectTabletsActiveBundle);
     const theme = useSelector(selectTheme);
 
     if (!bundle) {

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundleEditorDialog/BundleEditorDialog.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundleEditorDialog/BundleEditorDialog.tsx
@@ -21,14 +21,14 @@ import {
     setBundleEditorController,
 } from '../../../../store/actions/tablet_cell_bundles/tablet-cell-bundle-editor';
 import {
-    getBundleEditorData,
-    getTabletBundlesWriteableByName,
+    selectBundleEditorData,
+    selectTabletBundlesWriteableByName,
 } from '../../../../store/selectors/tablet_cell_bundles';
 import {
     BundleResourceGuarantee,
     OrchidBundleResource,
 } from '../../../../store/reducers/tablet_cell_bundles';
-import {getTabletCellBundleEditorState} from '../../../../store/selectors/tablet_cell_bundles/tablet-cell-bundle-editor';
+import {selectTabletCellBundleEditorState} from '../../../../store/selectors/tablet_cell_bundles/tablet-cell-bundle-editor';
 
 import {
     bundleEditorDict,
@@ -94,12 +94,12 @@ export function BundleEditorDialog() {
         bundleData,
         data,
         bundleControllerData: orchidData,
-    } = useSelector(getTabletCellBundleEditorState);
+    } = useSelector(selectTabletCellBundleEditorState);
 
     const clusterUiConfig = useSelector(selectClusterUiConfig);
     const queryMemoryLimitIsSupported = useSelector(selectIsQueryMemoryLimitSupported);
 
-    const {defaultConfig: bundleDefaultConfig} = useSelector(getBundleEditorData);
+    const {defaultConfig: bundleDefaultConfig} = useSelector(selectBundleEditorData);
 
     const bundleControllerConfig = bundleData?.bundle_controller_target_config;
     const enableBundleController = bundleData?.enable_bundle_controller || false;
@@ -107,7 +107,7 @@ export function BundleEditorDialog() {
     const {usage: tabletCountUsage} = getResourceData(data, 'tablet_count');
     const {usage: tabletStaticMemoryUsage} = getResourceData(data, 'tablet_static_memory');
 
-    const writeableByName = useSelector(getTabletBundlesWriteableByName);
+    const writeableByName = useSelector(selectTabletBundlesWriteableByName);
     const allowTabletCount = writeableByName.get(bundleName ?? '');
     const allowEdit = useSelector(selectIsAdmin);
 

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTable.connected.ts
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTable.connected.ts
@@ -15,18 +15,18 @@ import {
     selectClusterUiConfigEnablePerBundleTabletAccounting,
 } from '../../../store/selectors/global';
 import {
-    getTabletBundlesTableMode,
-    getTabletBundlesWriteableByName,
-    getTabletsBundlesSortState,
-    getTabletsBundlesSorted,
-    getTabletsBundlesTotal,
-    getTabletsIsLoaded,
-    getTabletsIsLoading,
+    selectTabletBundlesTableMode,
+    selectTabletBundlesWriteableByName,
+    selectTabletsBundlesSortState,
+    selectTabletsBundlesSorted,
+    selectTabletsBundlesTotal,
+    selectTabletsIsLoaded,
+    selectTabletsIsLoading,
 } from '../../../store/selectors/tablet_cell_bundles';
 import {tabletActiveBundleLink} from '../../../utils/components/tablet-cells';
 import {tabletCellBundleDashboardUrl} from '../../../utils/tablet_cell_bundles';
 
-const calcColumns = createSelector([getTabletBundlesTableMode], (mode: BundlesTableMode) => {
+const calcColumns = createSelector([selectTabletBundlesTableMode], (mode: BundlesTableMode) => {
     const columns: ComponentProps<typeof BundlesTable>['columns'] = ['bundle'];
 
     switch (mode) {
@@ -70,18 +70,18 @@ const calcColumns = createSelector([getTabletBundlesTableMode], (mode: BundlesTa
 
 const mapStateToProps = (state: RootState) => {
     return {
-        loading: getTabletsIsLoading(state),
-        loaded: getTabletsIsLoaded(state),
-        data: getTabletsBundlesSorted(state),
-        total: getTabletsBundlesTotal(state),
-        sortState: getTabletsBundlesSortState(state),
+        loading: selectTabletsIsLoading(state),
+        loaded: selectTabletsIsLoaded(state),
+        data: selectTabletsBundlesSorted(state),
+        total: selectTabletsBundlesTotal(state),
+        sortState: selectTabletsBundlesSortState(state),
         cluster: selectCluster(state),
         allowPerBundleAccounting: selectClusterUiConfigEnablePerBundleTabletAccounting(state),
         pathPrefix: '//sys/tablet_cell_bundles/',
         columns: calcColumns(state),
         activeBundleLink: tabletActiveBundleLink,
         bundleDashboardUrl: tabletCellBundleDashboardUrl,
-        writeableByName: getTabletBundlesWriteableByName(state),
+        writeableByName: selectTabletBundlesWriteableByName(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTableInstruments.connected.ts
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTableInstruments.connected.ts
@@ -11,20 +11,20 @@ import {
 import type {RootState} from '../../../store/reducers';
 import type {BundlesTableMode} from '../../../store/reducers/tablet_cell_bundles';
 import {
-    getTabletBundlesTableMode,
-    getTabletsBundlesAccountFilter,
-    getTabletsBundlesNameFilter,
-    getTabletsBundlesTagNodeFilter,
+    selectTabletBundlesTableMode,
+    selectTabletsBundlesAccountFilter,
+    selectTabletsBundlesNameFilter,
+    selectTabletsBundlesTagNodeFilter,
 } from '../../../store/selectors/tablet_cell_bundles';
 
 const modes: Array<BundlesTableMode> = ['default', 'tablets', 'tablets_memory'];
 
 const mapStateToProps = (state: RootState) => {
     return {
-        accountFilter: getTabletsBundlesAccountFilter(state),
-        bundlesTableMode: getTabletBundlesTableMode(state),
-        nameFilter: getTabletsBundlesNameFilter(state),
-        tagNodeFilter: getTabletsBundlesTagNodeFilter(state),
+        accountFilter: selectTabletsBundlesAccountFilter(state),
+        bundlesTableMode: selectTabletBundlesTableMode(state),
+        nameFilter: selectTabletsBundlesNameFilter(state),
+        tagNodeFilter: selectTabletsBundlesTagNodeFilter(state),
         modes,
     };
 };

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsInstruments.connected.ts
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsInstruments.connected.ts
@@ -4,26 +4,26 @@ import CellsTableInstruments from '../../../pages/tablet_cell_bundles/cells/Cell
 import {setTabletsPartial} from '../../../store/actions/tablet_cell_bundles';
 import type {RootState} from '../../../store/reducers';
 import {
-    getTabletsActiveBundle,
-    getTabletsCellsBundleFilter,
-    getTabletsCellsBundles,
-    getTabletsCellsHostFilter,
-    getTabletsCellsHosts,
-    getTabletsCellsHostsOfActiveBundle,
-    getTabletsCellsIdFilter,
+    selectTabletsActiveBundle,
+    selectTabletsCellsBundleFilter,
+    selectTabletsCellsBundles,
+    selectTabletsCellsHostFilter,
+    selectTabletsCellsHosts,
+    selectTabletsCellsHostsOfActiveBundle,
+    selectTabletsCellsIdFilter,
 } from '../../../store/selectors/tablet_cell_bundles';
 
 const mapStateToProps = (state: RootState) => {
     return {
-        activeBundle: getTabletsActiveBundle(state),
-        activeBundleHosts: getTabletsCellsHostsOfActiveBundle(state),
+        activeBundle: selectTabletsActiveBundle(state),
+        activeBundleHosts: selectTabletsCellsHostsOfActiveBundle(state),
 
-        idFilter: getTabletsCellsIdFilter(state),
-        bundleFilter: getTabletsCellsBundleFilter(state),
-        hostFilter: getTabletsCellsHostFilter(state),
+        idFilter: selectTabletsCellsIdFilter(state),
+        bundleFilter: selectTabletsCellsBundleFilter(state),
+        hostFilter: selectTabletsCellsHostFilter(state),
 
-        bundles: getTabletsCellsBundles(state),
-        hosts: getTabletsCellsHosts(state),
+        bundles: selectTabletsCellsBundles(state),
+        hosts: selectTabletsCellsHosts(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.connected.ts
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.connected.ts
@@ -9,10 +9,10 @@ import {
 import type {RootState} from '../../../store/reducers';
 import {selectCluster} from '../../../store/selectors/global';
 import {
-    getTabletsCellsSortState,
-    getTabletsCellsSorted,
-    getTabletsIsLoaded,
-    getTabletsIsLoading,
+    selectTabletsCellsSortState,
+    selectTabletsCellsSorted,
+    selectTabletsIsLoaded,
+    selectTabletsIsLoading,
 } from '../../../store/selectors/tablet_cell_bundles';
 import {
     tabletActiveBundleLink,
@@ -36,10 +36,10 @@ const columns: ComponentProps<typeof CellsTable>['columns'] = [
 const mapStateToProps = (state: RootState) => {
     return {
         cluster: selectCluster(state),
-        loading: getTabletsIsLoading(state),
-        loaded: getTabletsIsLoaded(state),
-        data: getTabletsCellsSorted(state),
-        sortState: getTabletsCellsSortState(state),
+        loading: selectTabletsIsLoading(state),
+        loaded: selectTabletsIsLoaded(state),
+        data: selectTabletsCellsSorted(state),
+        sortState: selectTabletsCellsSortState(state),
         columns,
         activeBundleLink: tabletActiveBundleLink,
         attributesPath: tabletAttributesPath,

--- a/packages/ui/src/ui/store/actions/chaos_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/actions/chaos_cell_bundles/index.ts
@@ -20,9 +20,9 @@ import type {
 } from '../../../store/reducers/chaos_cell_bundles';
 import {
     filterChaosCellsByBundle,
+    prepareHostsFromCells,
     selectChaosBundlesSorted,
     selectChaosCells,
-    prepareHostsFromCells,
 } from '../../../store/selectors/chaos_cell_bundles';
 import {selectCluster} from '../../../store/selectors/global';
 import type {SortState} from '../../../types';

--- a/packages/ui/src/ui/store/actions/chaos_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/actions/chaos_cell_bundles/index.ts
@@ -20,8 +20,8 @@ import type {
 } from '../../../store/reducers/chaos_cell_bundles';
 import {
     filterChaosCellsByBundle,
-    getChaosBundlesSorted,
-    getChaosCells,
+    selectChaosBundlesSorted,
+    selectChaosCells,
     prepareHostsFromCells,
 } from '../../../store/selectors/chaos_cell_bundles';
 import {selectCluster} from '../../../store/selectors/global';
@@ -117,7 +117,7 @@ export function setChaosActiveBundle(activeBundle: string): ChaosBundlesThunkAct
 export function setChaosFirstBundleAsActive(): ChaosBundlesThunkAction {
     return (dispatch, getState) => {
         const state = getState();
-        const bundles = getChaosBundlesSorted(state);
+        const bundles = selectChaosBundlesSorted(state);
         const [first] = bundles;
         if (!first) {
             return;
@@ -131,7 +131,7 @@ export function setChaosFirstBundleAsActive(): ChaosBundlesThunkAction {
 
 export function copyHostListToClipboard(bundle: string): ChaosBundlesThunkAction {
     return (_dispatch, getState) => {
-        const cells = filterChaosCellsByBundle(bundle, getChaosCells(getState()));
+        const cells = filterChaosCellsByBundle(bundle, selectChaosCells(getState()));
         const hosts = prepareHostsFromCells(cells);
         copy(hosts || '');
     };

--- a/packages/ui/src/ui/store/actions/favourites.js
+++ b/packages/ui/src/ui/store/actions/favourites.js
@@ -12,7 +12,7 @@ import {
 import {SettingName} from '../../../shared/constants/settings';
 import {reloadSetting, setSetting} from '../../store/actions/settings';
 import {getActiveAccount} from '../../store/selectors/accounts/accounts';
-import {getTabletsActiveBundle} from '../selectors/tablet_cell_bundles';
+import {selectTabletsActiveBundle} from '../selectors/tablet_cell_bundles';
 
 const LAST_VISITED_BUFFER_SIZE = 15;
 
@@ -38,7 +38,7 @@ export function navigationTrackVisit(path) {
 export function bundlesTrackVisit(bundle) {
     return (dispatch, getState) => {
         const state = getState();
-        const activeBundle = getTabletsActiveBundle(state);
+        const activeBundle = selectTabletsActiveBundle(state);
         if (!bundle || bundle === activeBundle) {
             return;
         }

--- a/packages/ui/src/ui/store/actions/tablet-errors/tablet-errors-by-bundle.ts
+++ b/packages/ui/src/ui/store/actions/tablet-errors/tablet-errors-by-bundle.ts
@@ -4,7 +4,7 @@ import {TabletErrorsApi, fetchFromTabletErrorsApi} from '../../../../shared/tabl
 import {selectCluster} from '../../../store/selectors/global';
 import {tabletErrorsByBundleActions} from '../../../store/reducers/tablet-errors/tablet-errors-by-bundle';
 import CancelHelper from '../../../utils/cancel-helper';
-import {getTabletErrorsByBundleData} from '../../../store/selectors/tablet-errors/tablet-errors-by-bundle';
+import {selectTabletErrorsByBundleData} from '../../../store/selectors/tablet-errors/tablet-errors-by-bundle';
 
 type AsyncAction<T = Promise<void>> = ThunkAction<T, RootState, unknown, any>;
 
@@ -22,7 +22,7 @@ export function loadTabletErrorsByBundle(
 
         const state = getState();
         const cluster = selectCluster(state);
-        const data = getTabletErrorsByBundleData(state);
+        const data = selectTabletErrorsByBundleData(state);
 
         return fetchFromTabletErrorsApi(
             'tablet_errors_by_bundle',

--- a/packages/ui/src/ui/store/actions/tablet_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/actions/tablet_cell_bundles/index.ts
@@ -30,9 +30,9 @@ import {SortState} from '../../../types';
 import {bundlesTrackVisit} from '../favourites';
 import {
     filterTabletCellsByBundle,
+    prepareHostsFromCells,
     selectTabletsBundlesSorted,
     selectTabletsCells,
-    prepareHostsFromCells,
 } from '../../selectors/tablet_cell_bundles';
 
 import copy from 'copy-to-clipboard';

--- a/packages/ui/src/ui/store/actions/tablet_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/actions/tablet_cell_bundles/index.ts
@@ -30,8 +30,8 @@ import {SortState} from '../../../types';
 import {bundlesTrackVisit} from '../favourites';
 import {
     filterTabletCellsByBundle,
-    getTabletsBundlesSorted,
-    getTabletsCells,
+    selectTabletsBundlesSorted,
+    selectTabletsCells,
     prepareHostsFromCells,
 } from '../../selectors/tablet_cell_bundles';
 
@@ -259,7 +259,7 @@ export function setTabletsActiveBundle(activeBundle: string): TabletsBundlesThun
 export function setTabletsFirstBundleAsActive(): TabletsBundlesThunkAction {
     return (dispatch, getState) => {
         const state = getState();
-        const bundles = getTabletsBundlesSorted(state);
+        const bundles = selectTabletsBundlesSorted(state);
         const [first] = bundles;
         if (!first) {
             return;
@@ -273,7 +273,7 @@ export function setTabletsFirstBundleAsActive(): TabletsBundlesThunkAction {
 
 export function copyHostListToClipboard(bundle: string): TabletsBundlesThunkAction {
     return (_dispatch, getState) => {
-        const cells = filterTabletCellsByBundle(bundle, getTabletsCells(getState()));
+        const cells = filterTabletCellsByBundle(bundle, selectTabletsCells(getState()));
         const hosts = prepareHostsFromCells(cells);
         copy(hosts || '');
     };

--- a/packages/ui/src/ui/store/actions/tablet_cell_bundles/tablet-cell-bundle-editor.ts
+++ b/packages/ui/src/ui/store/actions/tablet_cell_bundles/tablet-cell-bundle-editor.ts
@@ -25,8 +25,8 @@ import {makeBatchSubRequest, prepareSetCommandForBatch} from '../../../utils/cyp
 // @ts-ignore
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 import {
-    getTabletsBundles,
-    getTabletsDefaultMemoryConfiguration,
+    selectTabletsBundles,
+    selectTabletsDefaultMemoryConfiguration,
 } from '../../../store/selectors/tablet_cell_bundles';
 import {OrchidBundlesData} from '../../../store/reducers/tablet_cell_bundles';
 import {BatchResults, BatchSubRequest} from '../../../../shared/yt-types';
@@ -43,12 +43,12 @@ export function fetchTabletCellBundleEditor(bundleName: string): TabletCellBundl
         const state = getState();
         dispatch({type: TABLETS_BUNDLES_EDITOR_LOAD_REQUREST, data: {bundleName}});
 
-        const bundles = getTabletsBundles(state);
+        const bundles = selectTabletsBundles(state);
         const toEdit = bundles.find(({bundle}) => bundle === bundleName);
         if (!toEdit) {
             return Promise.resolve();
         }
-        const defaultReservedMemoryLimit = getTabletsDefaultMemoryConfiguration(state);
+        const defaultReservedMemoryLimit = selectTabletsDefaultMemoryConfiguration(state);
 
         const requests: Array<BatchSubRequest> = [
             {

--- a/packages/ui/src/ui/store/location.main.ts
+++ b/packages/ui/src/ui/store/location.main.ts
@@ -69,9 +69,9 @@ import {
 import {getSystemPreparedState, systemParams} from '../store/reducers/system/url-mapping';
 import {
     bundlesPrometheusParams,
-    getTabletsBundlesAclPreparedState,
-    getTabletsBundlesPreparedState,
-    getTabletsCellsPreparedState,
+    selectTabletsBundlesAclPreparedState,
+    selectTabletsBundlesPreparedState,
+    selectTabletsCellsPreparedState,
     tabletsAllBundlesParams,
     tabletsBundlesAclParams,
     tabletsBundlesParams,
@@ -170,17 +170,17 @@ export const getMainLocations = (): Array<[string, PathParameters]> => [
 
     [
         `/*/${Page.TABLET_CELL_BUNDLES}/${TabletsTab.TABLET_CELLS}`,
-        [tabletsTabletCellsParams, getTabletsCellsPreparedState],
+        [tabletsTabletCellsParams, selectTabletsCellsPreparedState],
     ],
 
     [
         `/*/${Page.TABLET_CELL_BUNDLES}/${TabletsTab.ACL}`,
-        [tabletsBundlesAclParams, getTabletsBundlesAclPreparedState],
+        [tabletsBundlesAclParams, selectTabletsBundlesAclPreparedState],
     ],
 
-    [`/*/${Page.TABLET_CELL_BUNDLES}`, [tabletsAllBundlesParams, getTabletsBundlesPreparedState]],
+    [`/*/${Page.TABLET_CELL_BUNDLES}`, [tabletsAllBundlesParams, selectTabletsBundlesPreparedState]],
     [`/*/${Page.TABLET_CELL_BUNDLES}/monitor`, [bundlesPrometheusParams]],
-    [`/*/${Page.TABLET_CELL_BUNDLES}/*`, [tabletsBundlesParams, getTabletsBundlesPreparedState]],
+    [`/*/${Page.TABLET_CELL_BUNDLES}/*`, [tabletsBundlesParams, selectTabletsBundlesPreparedState]],
 
     [
         `/*/${Page.CHAOS_CELL_BUNDLES}/${TabletsTab.CHAOS_CELLS}`,

--- a/packages/ui/src/ui/store/location.main.ts
+++ b/packages/ui/src/ui/store/location.main.ts
@@ -83,8 +83,8 @@ import {
     chaosAllBundlesParams,
     chaosBundlesParams,
     chaosCellsParams,
-    getChaosBundlesPreparedState,
-    getChaosCellsPreparedState,
+    selectChaosBundlesPreparedState,
+    selectChaosCellsPreparedState,
 } from './reducers/chaos_cell_bundles/url-mapping';
 import {draftQueryParameters, getDraftQueryParameters} from './reducers/query-tracker/url_mapping';
 
@@ -184,10 +184,10 @@ export const getMainLocations = (): Array<[string, PathParameters]> => [
 
     [
         `/*/${Page.CHAOS_CELL_BUNDLES}/${TabletsTab.CHAOS_CELLS}`,
-        [chaosCellsParams, getChaosCellsPreparedState],
+        [chaosCellsParams, selectChaosCellsPreparedState],
     ],
-    [`/*/${Page.CHAOS_CELL_BUNDLES}`, [chaosAllBundlesParams, getChaosBundlesPreparedState]],
-    [`/*/${Page.CHAOS_CELL_BUNDLES}/*`, [chaosBundlesParams, getChaosBundlesPreparedState]],
+    [`/*/${Page.CHAOS_CELL_BUNDLES}`, [chaosAllBundlesParams, selectChaosBundlesPreparedState]],
+    [`/*/${Page.CHAOS_CELL_BUNDLES}/*`, [chaosBundlesParams, selectChaosBundlesPreparedState]],
     [`/*/${Page.QUERIES}/*`, [draftQueryParameters, getDraftQueryParameters]],
 
     [`/*/${Page.FLOWS}/${FlowTab.GRAPH}`, [flowGraphParams]],

--- a/packages/ui/src/ui/store/location.main.ts
+++ b/packages/ui/src/ui/store/location.main.ts
@@ -69,9 +69,9 @@ import {
 import {getSystemPreparedState, systemParams} from '../store/reducers/system/url-mapping';
 import {
     bundlesPrometheusParams,
-    selectTabletsBundlesAclPreparedState,
-    selectTabletsBundlesPreparedState,
-    selectTabletsCellsPreparedState,
+    getTabletsBundlesAclPreparedState,
+    getTabletsBundlesPreparedState,
+    getTabletsCellsPreparedState,
     tabletsAllBundlesParams,
     tabletsBundlesAclParams,
     tabletsBundlesParams,
@@ -83,8 +83,8 @@ import {
     chaosAllBundlesParams,
     chaosBundlesParams,
     chaosCellsParams,
-    selectChaosBundlesPreparedState,
-    selectChaosCellsPreparedState,
+    getChaosBundlesPreparedState,
+    getChaosCellsPreparedState,
 } from './reducers/chaos_cell_bundles/url-mapping';
 import {draftQueryParameters, getDraftQueryParameters} from './reducers/query-tracker/url_mapping';
 
@@ -170,24 +170,24 @@ export const getMainLocations = (): Array<[string, PathParameters]> => [
 
     [
         `/*/${Page.TABLET_CELL_BUNDLES}/${TabletsTab.TABLET_CELLS}`,
-        [tabletsTabletCellsParams, selectTabletsCellsPreparedState],
+        [tabletsTabletCellsParams, getTabletsCellsPreparedState],
     ],
 
     [
         `/*/${Page.TABLET_CELL_BUNDLES}/${TabletsTab.ACL}`,
-        [tabletsBundlesAclParams, selectTabletsBundlesAclPreparedState],
+        [tabletsBundlesAclParams, getTabletsBundlesAclPreparedState],
     ],
 
-    [`/*/${Page.TABLET_CELL_BUNDLES}`, [tabletsAllBundlesParams, selectTabletsBundlesPreparedState]],
+    [`/*/${Page.TABLET_CELL_BUNDLES}`, [tabletsAllBundlesParams, getTabletsBundlesPreparedState]],
     [`/*/${Page.TABLET_CELL_BUNDLES}/monitor`, [bundlesPrometheusParams]],
-    [`/*/${Page.TABLET_CELL_BUNDLES}/*`, [tabletsBundlesParams, selectTabletsBundlesPreparedState]],
+    [`/*/${Page.TABLET_CELL_BUNDLES}/*`, [tabletsBundlesParams, getTabletsBundlesPreparedState]],
 
     [
         `/*/${Page.CHAOS_CELL_BUNDLES}/${TabletsTab.CHAOS_CELLS}`,
-        [chaosCellsParams, selectChaosCellsPreparedState],
+        [chaosCellsParams, getChaosCellsPreparedState],
     ],
-    [`/*/${Page.CHAOS_CELL_BUNDLES}`, [chaosAllBundlesParams, selectChaosBundlesPreparedState]],
-    [`/*/${Page.CHAOS_CELL_BUNDLES}/*`, [chaosBundlesParams, selectChaosBundlesPreparedState]],
+    [`/*/${Page.CHAOS_CELL_BUNDLES}`, [chaosAllBundlesParams, getChaosBundlesPreparedState]],
+    [`/*/${Page.CHAOS_CELL_BUNDLES}/*`, [chaosBundlesParams, getChaosBundlesPreparedState]],
     [`/*/${Page.QUERIES}/*`, [draftQueryParameters, getDraftQueryParameters]],
 
     [`/*/${Page.FLOWS}/${FlowTab.GRAPH}`, [flowGraphParams]],

--- a/packages/ui/src/ui/store/reducers/chaos_cell_bundles/url-mapping.ts
+++ b/packages/ui/src/ui/store/reducers/chaos_cell_bundles/url-mapping.ts
@@ -12,7 +12,7 @@ export const chaosBundlesParams: LocationParameters = {
     },
 };
 
-export function getChaosBundlesPreparedState(
+export function selectChaosBundlesPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -82,7 +82,7 @@ export const chaosCellsParams = {
     },
 };
 
-export function getChaosCellsPreparedState(
+export function selectChaosCellsPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {

--- a/packages/ui/src/ui/store/reducers/chaos_cell_bundles/url-mapping.ts
+++ b/packages/ui/src/ui/store/reducers/chaos_cell_bundles/url-mapping.ts
@@ -12,7 +12,7 @@ export const chaosBundlesParams: LocationParameters = {
     },
 };
 
-export function selectChaosBundlesPreparedState(
+export function getChaosBundlesPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -82,7 +82,7 @@ export const chaosCellsParams = {
     },
 };
 
-export function selectChaosCellsPreparedState(
+export function getChaosCellsPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {

--- a/packages/ui/src/ui/store/reducers/tablet_cell_bundles/url-mapping.ts
+++ b/packages/ui/src/ui/store/reducers/tablet_cell_bundles/url-mapping.ts
@@ -18,7 +18,7 @@ export const tabletsBundlesParams = {
     ...tabletErrorsByBundleParams,
 };
 
-export function getTabletsBundlesPreparedState(
+export function selectTabletsBundlesPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -89,7 +89,7 @@ export const tabletsTabletCellsParams = {
     },
 };
 
-export function getTabletsCellsPreparedState(
+export function selectTabletsCellsPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -110,7 +110,7 @@ export const tabletsBundlesAclParams = {
     ...aclFiltersParams,
 };
 
-export function getTabletsBundlesAclPreparedState(
+export function selectTabletsBundlesAclPreparedState(
     prevState: RootState,
     {query}: {query: RootState},
 ): RootState {

--- a/packages/ui/src/ui/store/reducers/tablet_cell_bundles/url-mapping.ts
+++ b/packages/ui/src/ui/store/reducers/tablet_cell_bundles/url-mapping.ts
@@ -18,7 +18,7 @@ export const tabletsBundlesParams = {
     ...tabletErrorsByBundleParams,
 };
 
-export function selectTabletsBundlesPreparedState(
+export function getTabletsBundlesPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -89,7 +89,7 @@ export const tabletsTabletCellsParams = {
     },
 };
 
-export function selectTabletsCellsPreparedState(
+export function getTabletsCellsPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -110,7 +110,7 @@ export const tabletsBundlesAclParams = {
     ...aclFiltersParams,
 };
 
-export function selectTabletsBundlesAclPreparedState(
+export function getTabletsBundlesAclPreparedState(
     prevState: RootState,
     {query}: {query: RootState},
 ): RootState {

--- a/packages/ui/src/ui/store/selectors/chaos_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/selectors/chaos_cell_bundles/index.ts
@@ -18,35 +18,36 @@ import {prepareHost} from '../../../utils';
 import {sortArrayBySortState} from '../../../utils/sort-helpers';
 import {sortTableBundles} from '../../../utils/tablet_cell_bundles';
 
-export const getChaosIsLoaded = (state: RootState) => state.chaos_cell_bundles.loaded;
-export const getChaosIsLoading = (state: RootState) => state.chaos_cell_bundles.loading;
-export const getChaosError = (state: RootState) => state.chaos_cell_bundles.error;
+export const selectChaosIsLoaded = (state: RootState) => state.chaos_cell_bundles.loaded;
+export const selectChaosIsLoading = (state: RootState) => state.chaos_cell_bundles.loading;
+export const selectChaosError = (state: RootState) => state.chaos_cell_bundles.error;
 
-export const getChaosBundlesSortState = (state: RootState) => state.chaos_cell_bundles.bundlesSort;
+export const selectChaosBundlesSortState = (state: RootState) =>
+    state.chaos_cell_bundles.bundlesSort;
 
-export const getChaosBundlesNameFilter = (state: RootState) =>
+export const selectChaosBundlesNameFilter = (state: RootState) =>
     state.chaos_cell_bundles.bundlesNameFilter;
-export const getChaosBundlesAccountFilter = (state: RootState) =>
+export const selectChaosBundlesAccountFilter = (state: RootState) =>
     state.chaos_cell_bundles.bundlesAccountFilter;
-export const getChaosBundlesTagNodeFilter = (state: RootState) =>
+export const selectChaosBundlesTagNodeFilter = (state: RootState) =>
     state.chaos_cell_bundles.bundlesTagNodeFilter;
 
-export const getChaosBundles = (state: RootState) => state.chaos_cell_bundles.bundles;
+export const selectChaosBundles = (state: RootState) => state.chaos_cell_bundles.bundles;
 
-export const getChaosActiveBundle = (state: RootState) => state.chaos_cell_bundles.activeBundle;
+export const selectChaosActiveBundle = (state: RootState) => state.chaos_cell_bundles.activeBundle;
 
-export const getChaosBundlesTableMode = (state: RootState) =>
+export const selectChaosBundlesTableMode = (state: RootState) =>
     state.chaos_cell_bundles.bundlesTableMode;
 
-export const getChaosActiveBundleData = createSelector(
-    [getChaosBundles, getChaosActiveBundle],
+export const selectChaosActiveBundleData = createSelector(
+    [selectChaosBundles, selectChaosActiveBundle],
     (bundles, activeBundle) => {
         return find_(bundles, (item) => item.bundle === activeBundle);
     },
 );
 
-export const getChaosBundlesTotal = createSelector(
-    [getChaosBundles],
+export const selectChaosBundlesTotal = createSelector(
+    [selectChaosBundles],
     (bundles): ChaosBundle => aggregateTotal(bundles),
 );
 
@@ -69,12 +70,12 @@ const COLUMNS_SORTABLE_AS_IS = new Set<keyof ChaosBundle>([
     'tablet_static_memory_percentage',
 ]);
 
-export const getChaosBundlesFiltered = createSelector(
+export const selectChaosBundlesFiltered = createSelector(
     [
-        getChaosBundles,
-        getChaosBundlesNameFilter,
-        getChaosBundlesAccountFilter,
-        getChaosBundlesTagNodeFilter,
+        selectChaosBundles,
+        selectChaosBundlesNameFilter,
+        selectChaosBundlesAccountFilter,
+        selectChaosBundlesTagNodeFilter,
     ],
     (bundles, nameFilter, accountFilter, tagNodeFilter) => {
         const predicates: Array<(item: ChaosBundle) => boolean> = [];
@@ -113,8 +114,8 @@ export const getChaosBundlesFiltered = createSelector(
     },
 );
 
-export const getChaosBundlesSorted = createSelector(
-    [getChaosBundlesFiltered, getChaosBundlesSortState],
+export const selectChaosBundlesSorted = createSelector(
+    [selectChaosBundlesFiltered, selectChaosBundlesSortState],
     (bundles, {column, order}) => {
         if (!column || !order) {
             return bundles;
@@ -124,17 +125,18 @@ export const getChaosBundlesSorted = createSelector(
     },
 );
 
-export const getChaosCells = (state: RootState) => state.chaos_cell_bundles.cells;
-export const getChaosCellsSortState = (state: RootState) => state.chaos_cell_bundles.cellsSort;
+export const selectChaosCells = (state: RootState) => state.chaos_cell_bundles.cells;
+export const selectChaosCellsSortState = (state: RootState) => state.chaos_cell_bundles.cellsSort;
 
-export const getChaosCellsIdFilter = (state: RootState) => state.chaos_cell_bundles.cellsIdFilter;
-export const getChaosCellsBundleFilter = (state: RootState) =>
+export const selectChaosCellsIdFilter = (state: RootState) =>
+    state.chaos_cell_bundles.cellsIdFilter;
+export const selectChaosCellsBundleFilter = (state: RootState) =>
     state.chaos_cell_bundles.cellsBundleFilter;
-export const getChaosCellsHostFilter = (state: RootState) =>
+export const selectChaosCellsHostFilter = (state: RootState) =>
     state.chaos_cell_bundles.cellsHostFilter;
 
-export const getChaosCellsOfActiveAccount = createSelector(
-    [getChaosCells, getChaosActiveBundle],
+export const selectChaosCellsOfActiveAccount = createSelector(
+    [selectChaosCells, selectChaosActiveBundle],
     (cells, activeBundle) => {
         if (!activeBundle) {
             return cells;
@@ -146,13 +148,13 @@ export const getChaosCellsOfActiveAccount = createSelector(
     },
 );
 
-export const getChaosCellsFiltered = createSelector(
+export const selectChaosCellsFiltered = createSelector(
     [
-        getChaosCellsOfActiveAccount,
-        getChaosCellsIdFilter,
-        getChaosCellsBundleFilter,
-        getChaosCellsHostFilter,
-        getChaosActiveBundle,
+        selectChaosCellsOfActiveAccount,
+        selectChaosCellsIdFilter,
+        selectChaosCellsBundleFilter,
+        selectChaosCellsHostFilter,
+        selectChaosActiveBundle,
     ],
     (cells, idFilter, bundleFilter, hostFilter) => {
         const predicates: Array<(item: ChaosCell) => boolean> = [];
@@ -185,23 +187,23 @@ export function filterChaosCellsByBundle(bundle: string, cells: Array<ChaosCell>
     return filter_(cells, (item) => item.bundle === bundle);
 }
 
-export const getChaosCellsSorted = createSelector(
-    [getChaosCellsFiltered, getChaosCellsSortState],
+export const selectChaosCellsSorted = createSelector(
+    [selectChaosCellsFiltered, selectChaosCellsSortState],
     (cells, sortState) => {
         return sortArrayBySortState(cells, sortState);
     },
 );
 
-export const getChaosCellsBundles = createSelector([getChaosCells], (cells) => {
+export const selectChaosCellsBundles = createSelector([selectChaosCells], (cells) => {
     return uniq_(map_(cells, 'bundle')).sort();
 });
 
-export const getChaosCellsHosts = createSelector([getChaosCellsOfActiveAccount], (cells) => {
+export const selectChaosCellsHosts = createSelector([selectChaosCellsOfActiveAccount], (cells) => {
     return uniq_(map_(cells, 'peerAddress')).sort();
 });
 
-export const getChaosCellsHostsOfActiveBundle = createSelector(
-    [getChaosActiveBundle, getChaosCellsFiltered],
+export const selectChaosCellsHostsOfActiveBundle = createSelector(
+    [selectChaosActiveBundle, selectChaosCellsFiltered],
     (activeBundle: string, cells: Array<ChaosCell>) => {
         if (!activeBundle) {
             return '';
@@ -222,8 +224,8 @@ export interface ChaosCellBundlesBreadcrumbsItem {
     title?: string;
 }
 
-export const getChaosBreadcrumbItems = createSelector(
-    [selectCluster, getChaosActiveBundle],
+export const selectChaosBreadcrumbItems = createSelector(
+    [selectCluster, selectChaosActiveBundle],
     (cluster, activeBundle): Array<ChaosCellBundlesBreadcrumbsItem> => {
         const res: Array<ChaosCellBundlesBreadcrumbsItem> = [
             {

--- a/packages/ui/src/ui/store/selectors/chaos_cell_bundles/tablet-cell-bundle-editor.ts
+++ b/packages/ui/src/ui/store/selectors/chaos_cell_bundles/tablet-cell-bundle-editor.ts
@@ -1,3 +1,3 @@
 import type {RootState} from '../../../store/reducers';
 
-export const getChaosCellBundleEditorData = (state: RootState) => state.chaosCellBundleEditor;
+export const selectChaosCellBundleEditorData = (state: RootState) => state.chaosCellBundleEditor;

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -6,7 +6,7 @@ import {createSelector} from 'reselect';
 import {
     getAccountsNS,
     getBundlesNS,
-    getChaosBundlesNS,
+    selectChaosBundlesNS,
     getChytNS,
     getClusterNS,
     getSchedulingNS,
@@ -17,7 +17,7 @@ import {getActiveAccount} from '../../store/selectors/accounts/accounts';
 import {getPath} from '../../store/selectors/navigation';
 import {getPool, getTree} from '../../store/selectors/scheduling/scheduling';
 import {getTabletsActiveBundle} from './tablet_cell_bundles';
-import {getChaosActiveBundle} from './chaos_cell_bundles';
+import {selectChaosActiveBundle} from './chaos_cell_bundles';
 import {selectChytCurrentAlias} from './chyt';
 
 //************* Selectors for Accounts *****************
@@ -93,12 +93,12 @@ export const isActiveBundleInFavourites = createSelector(
 // ************ Selectors for Chaos bundles ***********
 
 export const getFavouriteChaosBundles = createSelector(
-    [makeGetSetting, getChaosBundlesNS],
+    [makeGetSetting, selectChaosBundlesNS],
     prepareFavourites,
 );
 
 export const isActiveChaosBundleInFavourites = createSelector(
-    [getChaosActiveBundle, getFavouriteChaosBundles],
+    [selectChaosActiveBundle, getFavouriteChaosBundles],
     prepareIsInFavourites,
 );
 

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -6,11 +6,11 @@ import {createSelector} from 'reselect';
 import {
     getAccountsNS,
     getBundlesNS,
-    selectChaosBundlesNS,
     getChytNS,
     getClusterNS,
     getSchedulingNS,
     makeGetSetting,
+    selectChaosBundlesNS,
 } from '../../store/selectors/settings';
 import {SettingName} from '../../../shared/constants/settings';
 import {getActiveAccount} from '../../store/selectors/accounts/accounts';

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -16,7 +16,7 @@ import {SettingName} from '../../../shared/constants/settings';
 import {getActiveAccount} from '../../store/selectors/accounts/accounts';
 import {getPath} from '../../store/selectors/navigation';
 import {getPool, getTree} from '../../store/selectors/scheduling/scheduling';
-import {getTabletsActiveBundle} from './tablet_cell_bundles';
+import {selectTabletsActiveBundle} from './tablet_cell_bundles';
 import {selectChaosActiveBundle} from './chaos_cell_bundles';
 import {selectChytCurrentAlias} from './chyt';
 
@@ -86,7 +86,7 @@ export const getFavouriteBundles = createSelector(
 );
 
 export const isActiveBundleInFavourites = createSelector(
-    [getTabletsActiveBundle, getFavouriteBundles],
+    [selectTabletsActiveBundle, getFavouriteBundles],
     prepareIsInFavourites,
 );
 

--- a/packages/ui/src/ui/store/selectors/histogram.js
+++ b/packages/ui/src/ui/store/selectors/histogram.js
@@ -3,14 +3,14 @@ import {createSelector} from 'reselect';
 
 const selectHistogram = (state, props) => props.histogram;
 
-export const selectCreateQuartiles = () =>
+export const selectGetQuartiles = () =>
     createSelector(selectHistogram, (histogram) => hammer.stat.quartiles(histogram.data));
 
-export const selectCreatePDF = () =>
+export const selectGetPDF = () =>
     createSelector(selectHistogram, (histogram) => hammer.stat.pdf(histogram.data));
 
-export const selectCreateECDF = () =>
-    createSelector([selectHistogram, selectCreatePDF()], (histogram, pdf) => {
+export const selectGetECDF = () =>
+    createSelector([selectHistogram, selectGetPDF()], (histogram, pdf) => {
         const ecdf = hammer.stat.ecdf(histogram.data);
 
         // Create fake points
@@ -26,9 +26,9 @@ export const selectCreateECDF = () =>
         return ecdf;
     });
 
-export const selectIsDataGood = () =>
+export const selectGetIsDataGood = () =>
     createSelector(
-        [selectCreatePDF(), selectCreateECDF(), selectCreateQuartiles()],
+        [selectGetPDF(), selectGetECDF(), selectGetQuartiles()],
         (pdfData, ecdfData, quartiles) => {
             if (pdfData.min === pdfData.max) {
                 // All points are the same

--- a/packages/ui/src/ui/store/selectors/histogram.js
+++ b/packages/ui/src/ui/store/selectors/histogram.js
@@ -1,16 +1,16 @@
 import hammer from '../../common/hammer';
 import {createSelector} from 'reselect';
 
-const getHistogram = (state, props) => props.histogram;
+const selectHistogram = (state, props) => props.histogram;
 
-export const createGetQuartiles = () =>
-    createSelector(getHistogram, (histogram) => hammer.stat.quartiles(histogram.data));
+export const selectCreateQuartiles = () =>
+    createSelector(selectHistogram, (histogram) => hammer.stat.quartiles(histogram.data));
 
-export const createGetPDF = () =>
-    createSelector(getHistogram, (histogram) => hammer.stat.pdf(histogram.data));
+export const selectCreatePDF = () =>
+    createSelector(selectHistogram, (histogram) => hammer.stat.pdf(histogram.data));
 
-export const createGetECDF = () =>
-    createSelector([getHistogram, createGetPDF()], (histogram, pdf) => {
+export const selectCreateECDF = () =>
+    createSelector([selectHistogram, selectCreatePDF()], (histogram, pdf) => {
         const ecdf = hammer.stat.ecdf(histogram.data);
 
         // Create fake points
@@ -26,9 +26,9 @@ export const createGetECDF = () =>
         return ecdf;
     });
 
-export const createGetIsDataGood = () =>
+export const selectIsDataGood = () =>
     createSelector(
-        [createGetPDF(), createGetECDF(), createGetQuartiles()],
+        [selectCreatePDF(), selectCreateECDF(), selectCreateQuartiles()],
         (pdfData, ecdfData, quartiles) => {
             if (pdfData.min === pdfData.max) {
                 // All points are the same

--- a/packages/ui/src/ui/store/selectors/manage-tokens/index.ts
+++ b/packages/ui/src/ui/store/selectors/manage-tokens/index.ts
@@ -10,7 +10,7 @@ export type AuthenticationToken = {
     tokenPrefix?: string;
 };
 
-export const manageTokensSelector = createSelector(
+export const selectManageTokens = createSelector(
     [(state: RootState) => state.manageTokens.tokens?.data],
     (tokens) => {
         if (Array.isArray(tokens)) {
@@ -30,21 +30,21 @@ export const manageTokensSelector = createSelector(
     },
 );
 
-export const isManageTokensModalOpened = (state: RootState) => state.manageTokens.modal.open;
+export const selectIsManageTokensModalOpened = (state: RootState) => state.manageTokens.modal.open;
 
-export const isManageTokensInOAuthMode = createSelector(
+export const selectIsManageTokensInOAuthMode = createSelector(
     [selectAuthWay, selectRequirePasswordInAuthenticationCommands],
     (authWay, requirePasswordInAuthenticationCommands) => {
         return authWay === 'oauth' && !requirePasswordInAuthenticationCommands;
     },
 );
 
-export const getAllowManageTokens = (state: RootState) => {
+export const selectAllowManageTokens = (state: RootState) => {
     const authWay = selectAuthWay(state);
 
     if (authWay === 'passwd') {
         return true;
     }
 
-    return isManageTokensInOAuthMode(state);
+    return selectIsManageTokensInOAuthMode(state);
 };

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
@@ -102,7 +102,7 @@ export const getTablets = createSelector(getMergedPreparedTablets, (filteredTabl
     return [aggregation, ...filteredTablets];
 });
 
-const getHistograms = createSelector(getRawTablets, (tablets) => {
+const selectHistograms = createSelector(getRawTablets, (tablets) => {
     return mapValues_(histogramItems, (histogramItem, key) => {
         const get = histogramItem.get || tableItems[key].get;
 
@@ -115,8 +115,8 @@ const getHistograms = createSelector(getRawTablets, (tablets) => {
     });
 });
 
-export const getHistogram = createSelector(
-    [getHistograms, getActiveHistogram],
+export const selectHistogram = createSelector(
+    [selectHistograms, getActiveHistogram],
     (histograms, activeHistogram) => histograms[activeHistogram],
 );
 

--- a/packages/ui/src/ui/store/selectors/settings/index.js
+++ b/packages/ui/src/ui/store/selectors/settings/index.js
@@ -33,7 +33,7 @@ export const getBundlesNS = createSelector(getClusterNS, (clusterNS) =>
     createNestedNS('bundles', clusterNS),
 );
 
-export const getChaosBundlesNS = createSelector(getClusterNS, (clusterNS) =>
+export const selectChaosBundlesNS = createSelector(getClusterNS, (clusterNS) =>
     createNestedNS('chaosBundles', clusterNS),
 );
 

--- a/packages/ui/src/ui/store/selectors/suggests/index.ts
+++ b/packages/ui/src/ui/store/selectors/suggests/index.ts
@@ -1,4 +1,4 @@
 import {RootState} from '../../reducers';
 
-export const getTabletCellBundlesSuggests = (state: RootState) =>
+export const selectTabletCellBundlesSuggests = (state: RootState) =>
     state.suggests.tabletCellBundles.items;

--- a/packages/ui/src/ui/store/selectors/tablet-errors/tablet-errors-by-bundle.ts
+++ b/packages/ui/src/ui/store/selectors/tablet-errors/tablet-errors-by-bundle.ts
@@ -1,31 +1,31 @@
 import {ROWS_PER_PAGE} from '../../../constants/pagination';
 import {RootState} from '../../../store/reducers';
 
-export const getTabletErrorsByBundleData = (state: RootState) =>
+export const selectTabletErrorsByBundleData = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.data;
 
-export const getTabletErrorsByBundleLoading = (state: RootState) =>
+export const selectTabletErrorsByBundleLoading = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.loading;
 
-export const getTabletErrorsByBundleLoaded = (state: RootState) =>
+export const selectTabletErrorsByBundleLoaded = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.loaded;
 
-export const getTabletErrorsByBundleError = (state: RootState) =>
+export const selectTabletErrorsByBundleError = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.error;
 
-export const getTabletErrorsByBundleTimeRangeFilter = (state: RootState) =>
+export const selectTabletErrorsByBundleTimeRangeFilter = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.timeRangeFilter;
 
-export const getTabletErrorsByBundleMethodsFilter = (state: RootState) =>
+export const selectTabletErrorsByBundleMethodsFilter = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.methodsFilter;
 
-export const getTabletErrorsByBundlePageFilter = (state: RootState) =>
+export const selectTabletErrorsByBundlePageFilter = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.pageFilter;
 
-export const getTabletErrorsByBundleTablePathFilter = (state: RootState) =>
+export const selectTabletErrorsByBundleTablePathFilter = (state: RootState) =>
     state.tabletErrors.tabletErrorsByBundle.tablePathFilter;
 
-export const getTabletErrorsByBundlePageCount = (state: RootState) =>
+export const selectTabletErrorsByBundlePageCount = (state: RootState) =>
     Math.max(
         Math.ceil((state.tabletErrors.tabletErrorsByBundle.total_row_count ?? 0) / ROWS_PER_PAGE),
         1,

--- a/packages/ui/src/ui/store/selectors/tablet/tablet.js
+++ b/packages/ui/src/ui/store/selectors/tablet/tablet.js
@@ -31,7 +31,7 @@ export const getPartitions = createSelector(getSortedPartitions, (sortedPartitio
     return [aggregation, ...sortedPartitions];
 });
 
-const getHistograms = createSelector(getRawPartitions, (partitions) =>
+const selectHistograms = createSelector(getRawPartitions, (partitions) =>
     mapValues_(histogramItems, (settings, key) => {
         const partitionsWithoutEden = partitions.slice(1);
 
@@ -46,7 +46,7 @@ const getHistograms = createSelector(getRawPartitions, (partitions) =>
     }),
 );
 
-export const getHistogram = createSelector(
-    [getHistograms, getActiveHistogram],
+export const selectHistogram = createSelector(
+    [selectHistograms, getActiveHistogram],
     (histograms, activeHistogram) => histograms[activeHistogram],
 );

--- a/packages/ui/src/ui/store/selectors/tablet_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/selectors/tablet_cell_bundles/index.ts
@@ -23,48 +23,49 @@ import {sortArrayBySortState} from '../../../utils/sort-helpers';
 import {sortTableBundles} from '../../../utils/tablet_cell_bundles';
 import {makeComponentsNodesUrl, makeProxyUrl} from '../../../utils/app-url';
 import {
-    getTabletCellBundleControllerInstanceDetailsMap,
-    getTabletCellBundleEditorState,
+    selectTabletCellBundleControllerInstanceDetailsMap,
+    selectTabletCellBundleEditorState,
 } from './tablet-cell-bundle-editor';
 import {BundleControllerInstanceDetails} from '../../../store/reducers/tablet_cell_bundles/tablet-cell-bundle-editor';
 import UIFactory from '../../../UIFactory';
 
-export const getTabletsIsLoaded = (state: RootState) => state.tablet_cell_bundles.loaded;
-export const getTabletsIsLoading = (state: RootState) => state.tablet_cell_bundles.loading;
-export const getTabletsError = (state: RootState) => state.tablet_cell_bundles.error;
+export const selectTabletsIsLoaded = (state: RootState) => state.tablet_cell_bundles.loaded;
+export const selectTabletsIsLoading = (state: RootState) => state.tablet_cell_bundles.loading;
+export const selectTabletsError = (state: RootState) => state.tablet_cell_bundles.error;
 
-export const getTabletsBundlesSortState = (state: RootState) =>
+export const selectTabletsBundlesSortState = (state: RootState) =>
     state.tablet_cell_bundles.bundlesSort;
 
-export const getTabletsBundlesNameFilter = (state: RootState) =>
+export const selectTabletsBundlesNameFilter = (state: RootState) =>
     state.tablet_cell_bundles.bundlesNameFilter;
-export const getTabletsBundlesAccountFilter = (state: RootState) =>
+export const selectTabletsBundlesAccountFilter = (state: RootState) =>
     state.tablet_cell_bundles.bundlesAccountFilter;
-export const getTabletsBundlesTagNodeFilter = (state: RootState) =>
+export const selectTabletsBundlesTagNodeFilter = (state: RootState) =>
     state.tablet_cell_bundles.bundlesTagNodeFilter;
 
-export const getTabletsBundles = (state: RootState) => state.tablet_cell_bundles.bundles;
+export const selectTabletsBundles = (state: RootState) => state.tablet_cell_bundles.bundles;
 
-export const getTabletsActiveBundle = (state: RootState) => state.tablet_cell_bundles.activeBundle;
+export const selectTabletsActiveBundle = (state: RootState) =>
+    state.tablet_cell_bundles.activeBundle;
 
-export const getBundleDefaultConfig = (state: RootState) =>
+export const selectBundleDefaultConfig = (state: RootState) =>
     state.tablet_cell_bundles.bundleDefaultConfig;
 
-export const getTabletBundlesTableMode = (state: RootState) =>
+export const selectTabletBundlesTableMode = (state: RootState) =>
     state.tablet_cell_bundles.bundlesTableMode;
 
-export const getTabletBundlesWriteableByName = (state: RootState) =>
+export const selectTabletBundlesWriteableByName = (state: RootState) =>
     state.tablet_cell_bundles.writableByName;
 
-export const getTabletsActiveBundleData = createSelector(
-    [getTabletsBundles, getTabletsActiveBundle],
+export const selectTabletsActiveBundleData = createSelector(
+    [selectTabletsBundles, selectTabletsActiveBundle],
     (bundles, activeBundle) => {
         return find_(bundles, (item) => item.bundle === activeBundle);
     },
 );
 
-export const getTabletsDefaultMemoryConfiguration = createSelector(
-    [getBundleDefaultConfig, getTabletCellBundleEditorState],
+export const selectTabletsDefaultMemoryConfiguration = createSelector(
+    [selectBundleDefaultConfig, selectTabletCellBundleEditorState],
     (config, editorState) => {
         if (!config) return 0;
         const nodeSizes = config.zone_default.tablet_node_sizes;
@@ -114,8 +115,8 @@ function prepareBundleInstances(
     ];
 }
 
-export const getActiveBundleControllerData = createSelector(
-    [getTabletsActiveBundle, getTabletCellBundleEditorState],
+export const selectActiveBundleControllerData = createSelector(
+    [selectTabletsActiveBundle, selectTabletCellBundleEditorState],
     (activeBundle, {bundleData, bundleControllerData}) => {
         if (activeBundle !== bundleData?.bundle) {
             return undefined;
@@ -125,8 +126,12 @@ export const getActiveBundleControllerData = createSelector(
     },
 );
 
-export const getActiveBundleInstances = createSelector(
-    [getActiveBundleControllerData, selectCluster, getTabletCellBundleControllerInstanceDetailsMap],
+export const selectActiveBundleInstances = createSelector(
+    [
+        selectActiveBundleControllerData,
+        selectCluster,
+        selectTabletCellBundleControllerInstanceDetailsMap,
+    ],
     (bundleControllerData, cluster, instanceDetailsMap) => {
         if (!bundleControllerData) {
             return [];
@@ -142,8 +147,12 @@ export const getActiveBundleInstances = createSelector(
     },
 );
 
-export const getActiveBundleProxies = createSelector(
-    [getActiveBundleControllerData, selectCluster, getTabletCellBundleControllerInstanceDetailsMap],
+export const selectActiveBundleProxies = createSelector(
+    [
+        selectActiveBundleControllerData,
+        selectCluster,
+        selectTabletCellBundleControllerInstanceDetailsMap,
+    ],
     (bundleControllerData, cluster, instanceDetailsMap) => {
         if (!bundleControllerData) {
             return [];
@@ -159,8 +168,8 @@ export const getActiveBundleProxies = createSelector(
     },
 );
 
-export const getBundleEditorData = createSelector(
-    [getTabletCellBundleEditorState, getBundleDefaultConfig],
+export const selectBundleEditorData = createSelector(
+    [selectTabletCellBundleEditorState, selectBundleDefaultConfig],
     (editorState, defaultConfig) => {
         const {bundleData, data} = editorState;
         const {zone} = bundleData || {};
@@ -172,8 +181,8 @@ export const getBundleEditorData = createSelector(
     },
 );
 
-export const getTabletsBundlesTotal = createSelector(
-    [getTabletsBundles],
+export const selectTabletsBundlesTotal = createSelector(
+    [selectTabletsBundles],
     (bundles): TabletBundle => aggregateTotal(bundles),
 );
 
@@ -197,12 +206,12 @@ const COLUMNS_SORTABLE_AS_IS = new Set<keyof TabletBundle>([
     'tablet_static_memory_percentage',
 ]);
 
-export const getTabletsBundlesFiltered = createSelector(
+export const selectTabletsBundlesFiltered = createSelector(
     [
-        getTabletsBundles,
-        getTabletsBundlesNameFilter,
-        getTabletsBundlesAccountFilter,
-        getTabletsBundlesTagNodeFilter,
+        selectTabletsBundles,
+        selectTabletsBundlesNameFilter,
+        selectTabletsBundlesAccountFilter,
+        selectTabletsBundlesTagNodeFilter,
     ],
     (bundles, nameFilter, accountFilter, tagNodeFilter) => {
         const predicates: Array<(item: TabletBundle) => boolean> = [];
@@ -241,8 +250,8 @@ export const getTabletsBundlesFiltered = createSelector(
     },
 );
 
-export const getTabletsBundlesSorted = createSelector(
-    [getTabletsBundlesFiltered, getTabletsBundlesSortState],
+export const selectTabletsBundlesSorted = createSelector(
+    [selectTabletsBundlesFiltered, selectTabletsBundlesSortState],
     (bundles, sortState) => {
         const {column, order} = sortState || {};
         if (!column || !order) {
@@ -253,18 +262,19 @@ export const getTabletsBundlesSorted = createSelector(
     },
 );
 
-export const getTabletsCells = (state: RootState) => state.tablet_cell_bundles.cells;
-export const getTabletsCellsSortState = (state: RootState) => state.tablet_cell_bundles.cellsSort;
+export const selectTabletsCells = (state: RootState) => state.tablet_cell_bundles.cells;
+export const selectTabletsCellsSortState = (state: RootState) =>
+    state.tablet_cell_bundles.cellsSort;
 
-export const getTabletsCellsIdFilter = (state: RootState) =>
+export const selectTabletsCellsIdFilter = (state: RootState) =>
     state.tablet_cell_bundles.cellsIdFilter;
-export const getTabletsCellsBundleFilter = (state: RootState) =>
+export const selectTabletsCellsBundleFilter = (state: RootState) =>
     state.tablet_cell_bundles.cellsBundleFilter;
-export const getTabletsCellsHostFilter = (state: RootState) =>
+export const selectTabletsCellsHostFilter = (state: RootState) =>
     state.tablet_cell_bundles.cellsHostFilter;
 
-export const getTabletCellsOfActiveAccount = createSelector(
-    [getTabletsCells, getTabletsActiveBundle],
+export const selectTabletCellsOfActiveAccount = createSelector(
+    [selectTabletsCells, selectTabletsActiveBundle],
     (cells, activeBundle) => {
         if (!activeBundle) {
             return cells;
@@ -276,13 +286,13 @@ export const getTabletCellsOfActiveAccount = createSelector(
     },
 );
 
-export const getTabletsCellsFiltered = createSelector(
+export const selectTabletsCellsFiltered = createSelector(
     [
-        getTabletCellsOfActiveAccount,
-        getTabletsCellsIdFilter,
-        getTabletsCellsBundleFilter,
-        getTabletsCellsHostFilter,
-        getTabletsActiveBundle,
+        selectTabletCellsOfActiveAccount,
+        selectTabletsCellsIdFilter,
+        selectTabletsCellsBundleFilter,
+        selectTabletsCellsHostFilter,
+        selectTabletsActiveBundle,
     ],
     (cells, idFilter, bundleFilter, hostFilter) => {
         const predicates: Array<(item: TabletCell) => boolean> = [];
@@ -315,23 +325,26 @@ export function filterTabletCellsByBundle(bundle: string, cells: Array<TabletCel
     return filter_(cells, (item) => item.bundle === bundle);
 }
 
-export const getTabletsCellsSorted = createSelector(
-    [getTabletsCellsFiltered, getTabletsCellsSortState],
+export const selectTabletsCellsSorted = createSelector(
+    [selectTabletsCellsFiltered, selectTabletsCellsSortState],
     (cells, sortState) => {
         return sortArrayBySortState(cells, sortState);
     },
 );
 
-export const getTabletsCellsBundles = createSelector([getTabletsCells], (cells) => {
+export const selectTabletsCellsBundles = createSelector([selectTabletsCells], (cells) => {
     return uniq_(map_(cells, 'bundle')).sort();
 });
 
-export const getTabletsCellsHosts = createSelector([getTabletCellsOfActiveAccount], (cells) => {
-    return uniq_(map_(cells, 'peerAddress')).sort();
-});
+export const selectTabletsCellsHosts = createSelector(
+    [selectTabletCellsOfActiveAccount],
+    (cells) => {
+        return uniq_(map_(cells, 'peerAddress')).sort();
+    },
+);
 
-export const getTabletsCellsHostsOfActiveBundle = createSelector(
-    [getTabletsActiveBundle, getTabletsCellsFiltered],
+export const selectTabletsCellsHostsOfActiveBundle = createSelector(
+    [selectTabletsActiveBundle, selectTabletsCellsFiltered],
     (activeBundle: string, cells: Array<TabletCell>) => {
         if (!activeBundle) {
             return '';
@@ -352,8 +365,8 @@ export interface TabletsCellBundlesBreadcrumbsItem {
     title?: string;
 }
 
-export const getTabletsBreadcrumbItems = createSelector(
-    [selectCluster, getTabletsActiveBundleData],
+export const selectTabletsBreadcrumbItems = createSelector(
+    [selectCluster, selectTabletsActiveBundleData],
     (cluster, activeBundleData): Array<TabletsCellBundlesBreadcrumbsItem> => {
         const res: Array<TabletsCellBundlesBreadcrumbsItem> = [
             {

--- a/packages/ui/src/ui/store/selectors/tablet_cell_bundles/tablet-cell-bundle-editor.ts
+++ b/packages/ui/src/ui/store/selectors/tablet_cell_bundles/tablet-cell-bundle-editor.ts
@@ -1,5 +1,5 @@
 import type {RootState} from '../../../store/reducers';
 
-export const getTabletCellBundleEditorState = (state: RootState) => state.tabletCellBundleEditor;
-export const getTabletCellBundleControllerInstanceDetailsMap = (state: RootState) =>
+export const selectTabletCellBundleEditorState = (state: RootState) => state.tabletCellBundleEditor;
+export const selectTabletCellBundleControllerInstanceDetailsMap = (state: RootState) =>
     state.tabletCellBundleEditor.instanceDetailsMap;

--- a/packages/ui/src/ui/utils/app-url/utils.ts
+++ b/packages/ui/src/ui/utils/app-url/utils.ts
@@ -8,10 +8,10 @@ export function makeURLSearchParams<T extends object>(params: T, info: LocationP
             if (info[k].options?.serialize) {
                 const tmp = info[k].options?.serialize?.(value);
                 if (tmp !== undefined) {
-                    res.append(k, tmp + '');
+                    res.append(k, String(tmp));
                 }
             } else {
-                res.append(k, value + '');
+                res.append(k, String(value));
             }
         }
         return acc;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/dXM6Z9lE7ZQGY2
<!-- nda-end -->## Summary by Sourcery

Standardize selector naming across tablet, chaos bundles, histogram, manage tokens, and related modules, and apply minor code cleanups.

Enhancements:
- Rename selector functions to use a `select*` prefix for tablet cell bundles, chaos cell bundles, histogram, tablet errors, manage tokens, favourites, and navigation/tablet modules for consistency.
- Update URL-mapping and location configuration helpers to use the new selector names when preparing state from query parameters.
- Simplify column-visibility toggle logic in the settings hook and replace string concatenation with `String(...)` when building URL search params.
- Align connected components, hooks, and thunks to consume the renamed selectors and editor state selectors for bundle editors in both tablet and chaos bundles.

Chores:
- Refactor manage tokens modal and password modal containers to use the new selector naming scheme.
- Adjust bundle-related pages (statistics, ACL, monitor, instances, proxies, general meta) to rely on the standardized `select*` selectors.