### PR TITLE
fix(Query/Suggestions): store variable may be undefined

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/querySuggestionsModule/createInlineSuggestions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/querySuggestionsModule/createInlineSuggestions.ts
@@ -6,7 +6,6 @@ import {getQuerySuggestionsEnabled} from '../../../store/selectors/settings/sett
 import UIFactory from '../../../UIFactory';
 import debounce_ from 'lodash/debounce';
 
-const store = getWindowStore();
 const getSuggestion = (data: {query: string; line: number; column: number; engine: string}) => {
     return UIFactory.getInlineSuggestionsApi()?.getQuerySuggestions(data);
 };
@@ -21,7 +20,7 @@ export const createInlineSuggestions =
         _context: languages.InlineCompletionContext,
         _token: CancellationToken,
     ): Promise<{items: languages.InlineCompletion[]}> => {
-        const state = store.getState();
+        const state = getWindowStore().getState();
         const enabled = getQuerySuggestionsEnabled(state);
 
         if (!enabled) {


### PR DESCRIPTION
Depending on the order in which modules are executed, initialization of
the local `store` variable may occur before the storage is created, in
which case the local `store` variable will be undefined.

## Summary by Sourcery

Bug Fixes:
- Prevent inline query suggestions from failing when the window store has not yet been initialized by avoiding use of a potentially undefined cached store reference.