### PR TITLE
fix(Operation/Details): show additional state only for running [YTFRONT-5709]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -106,6 +106,10 @@ function getSpecialWaitingStatuses(
     type: string | undefined,
     isGpuOperation: boolean | undefined,
 ): {isWaitingForJobs?: boolean; isWaitingForResources?: boolean} {
+    if (state !== 'running') {
+        return {};
+    }
+
     const fairShareRatio = runtime?.[0]?.progress?.fair_share_ratio as number | undefined;
     const usageRatio = runtime?.[0]?.progress?.usage_ratio as number | undefined;
     const demandRatio = runtime?.[0]?.progress?.demand_ratio as number | undefined;
@@ -222,7 +226,7 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
             | {state: 'unknown'; iconState: 'running'; text: string} =
             isWaitingForJobs || isWaitingForResources
                 ? {state: 'unknown', iconState: 'running', text: 'Running'}
-                : {label: suspended ? 'suspended' : state};
+                : {label};
 
         return (
             <div className={detailBlock('header', 'elements-section')}>


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/YcyEFfVg7ZW9Yf
<!-- nda-end --> ## Summary by Sourcery

Bug Fixes:
- Ensure additional waiting status indicators are shown only when an operation is in the running state, preventing incorrect status display for other states.