### PR TITLE
feat(InterfaceHelpers): add ui format helpers [YTFRONT-5601]

### DIFF
--- a/packages/interface-helpers/jest.config.js
+++ b/packages/interface-helpers/jest.config.js
@@ -1,9 +1,9 @@
+/* eslint-env node */
+process.env.TZ = 'UTC';
+
 module.exports = {
-  moduleDirectories: [
-    "node_modules",
-    "lib",
-  ],
-  moduleFileExtensions: ['js'],
-  testMatch: ['<rootDir>/lib/**/*.spec.js'],
-  transform: {},
+    moduleDirectories: ['node_modules', 'lib'],
+    moduleFileExtensions: ['js'],
+    testMatch: ['<rootDir>/lib/**/*.spec.js'],
+    transform: {},
 };

--- a/packages/interface-helpers/lib/hammer/format.js
+++ b/packages/interface-helpers/lib/hammer/format.js
@@ -1,6 +1,7 @@
 const BigNumber = require('bignumber.js');
 const _map = require('lodash/map');
-const {dateTime} = require('@gravity-ui/date-utils');
+const forEach = require('lodash/forEach');
+const {dateTime, duration} = require('@gravity-ui/date-utils');
 
 const type = require('./type');
 const utils = require('./utils');
@@ -248,8 +249,8 @@ format['Percent'] = function (value, settings) {
 /**
  * Allows to strip port from fqdn
  * @param {String} value
- * @param {Object} settings
- * @param {String} settings.format 'port' or omitted
+ * @param {Object} [settings]
+ * @param {String} [settings.format] 'port' or omitted
  * @returns {*}
  */
 format['Address'] = function (value, settings) {
@@ -306,9 +307,9 @@ format['Hex'] = function (value, settings) {
 /**
  * Show readable values. Value is expected to have format 'foo_bar' and turns into 'Foo bar' or 'Foo Bar'
  * @param {String} value
- * @param {Object} settings
- * @param {String} settings.delimiter - any string, by default '_'
- * @param {String} settings.caps - 'all', 'none', by default 'first'
+ * @param {Object} [settings]
+ * @param {String} [settings.delimiter] - any string, by default '_'
+ * @param {String} [settings.caps] - 'all', 'none', by default 'first'
  * @returns {String}
  */
 format['Readable'] = function (value, settings) {
@@ -364,5 +365,292 @@ format['Command'] = function (value) {
     return shellescape(value);
 };
 /* jshint ignore:end */
+
+function preformat(value) {
+    const replacements = [
+        ['dynamic_row_read_rate', 'dynamic_read'],
+        ['dynamic_row_lookup_rate', 'dynamic_lookup'],
+        ['dynamic_row_delete_rate', 'dynamic_delete'],
+        ['dynamic_row_write_rate', 'dynamic_write'],
+        ['static_chunk_row_read_rate', 'static_chunk_read'],
+        ['static_chunk_row_lookup_rate', 'static_chunk_lookup'],
+        ['unmerged_row_read_rate', 'unmerged_read'],
+        ['merged_row_read_rate', 'merged_read'],
+        [/_count$/, 's'],
+        [/_data_size$/, '_size'],
+    ];
+
+    forEach(replacements, (replacementSettings) => {
+        value = value.replace(...replacementSettings);
+    });
+
+    return value;
+}
+
+function postformat(value) {
+    const replacements = [
+        ['acl', 'ACL'],
+        ['id', 'Id'],
+        ['cpu', 'CPU'],
+        ['ram', 'RAM'],
+        ['gpu', 'GPU'],
+        ['In memory', 'In-memory'],
+        ['Yt', 'YT'],
+        ['Yamr', 'YaMR'],
+        ['Io', 'IO'],
+        ['Ssd', 'SSD'],
+        ['hdd', 'HDD'],
+        ['Rpc', 'RPC'],
+        ['VCPU', 'vCPU'],
+        ['vcpu', 'vCPU'],
+        ['tablet-cell-bundle', 'TABLET CELL BUNDLE'],
+        ['Fifo', 'FIFO'],
+        ['Http', 'HTTP'],
+        ['lastVisited', 'Visited'],
+    ];
+
+    forEach(replacements, (replacementSettings) => {
+        const regex = new RegExp('(^|\\s)(' + replacementSettings[0] + ')($|\\s)', 'i');
+        const replacement = '$1' + replacementSettings[1] + '$3';
+        value = value.replace(regex, replacement);
+    });
+
+    return value;
+}
+
+/**
+ * Formats API fields. E.g uncompressed_data_size -> Uncompressed size, partition_count -> Partitions
+ * @param {String} value
+ * @param {Object} [settings]
+ * @returns {String}
+ */
+format['ReadableField'] = function (value, settings) {
+    settings = settings || {};
+
+    let formatted = value;
+
+    if (formatted) {
+        formatted = preformat(formatted);
+        formatted = format['Readable'](formatted, {
+            delimiter: '_',
+            caps: parseSetting(settings, 'caps', 'first'),
+        });
+        formatted = postformat(formatted);
+    }
+
+    return formatted;
+};
+
+/**
+ * @param {*} v
+ * @param {Object} [settings]
+ * @param {String} [settings.format]
+ * @param {String} [settings.pattern]
+ */
+format['DateTime'] = function (v, settings) {
+    const dateFormat = parseSetting(settings, 'format', 'full');
+    const datePattern = parseSetting(settings, 'pattern');
+
+    if (v === undefined || v === null) {
+        return format.NO_VALUE;
+    }
+
+    const value = format.toMoment(v);
+
+    if (datePattern) {
+        return value.format(datePattern);
+    }
+
+    switch (dateFormat) {
+        case 'human':
+            return value.fromNow();
+        case 'full':
+            return value.format('DD MMM YYYY HH:mm:ss');
+        case 'short':
+            return value.format('DD MMM HH:mm');
+        case 'day':
+            return value.format('DD MMM YYYY');
+        case 'month':
+            return value.format('MMMM YYYY');
+        case 'time':
+            return value.format('HH:mm:ss');
+        default:
+            throw new Error(
+                'hammer.format.DateTime: Unknown `format` option. Please specify one of [human, full, short, day, month] or use `pattern` option.',
+            );
+    }
+};
+
+/**
+ * Show a readable time duration string
+ * @param {Number} value - number of milliseconds
+ * @param {Object} [settings]
+ * @param {String} [settings.format] - 'milliseconds' or omitted
+ */
+format['TimeDuration'] = function (value, settings) {
+    const TIME_MEASURES = [
+        'years',
+        'months',
+        'days',
+        'hours',
+        'minutes',
+        'seconds',
+        'milliseconds',
+    ];
+    const OUTPUT_FORMATTER = {
+        years: 'y ',
+        months: 'm ',
+        days: 'd ',
+        hours: ':',
+        minutes: ':',
+        seconds: '',
+        milliseconds: '.',
+    };
+    let durationOutput;
+    let durationHash;
+
+    const showMilliseconds = parseSetting(settings, 'format') === 'milliseconds';
+
+    if (format.validNumber(value)) {
+        durationOutput = '';
+        durationHash = duration(value);
+
+        TIME_MEASURES.forEach(function (measure) {
+            const measureValue = durationHash[measure]();
+
+            if (measure === 'years' || measure === 'months' || measure === 'days') {
+                if (measureValue > 0) {
+                    durationOutput += measureValue + OUTPUT_FORMATTER[measure];
+                }
+            } else if (measure === 'hours' || measure === 'minutes' || measure === 'seconds') {
+                durationOutput += format['StrPad'](measureValue, '0') + OUTPUT_FORMATTER[measure];
+            } else if (measure === 'milliseconds' && showMilliseconds) {
+                durationOutput +=
+                    OUTPUT_FORMATTER[measure] + format['StrPad'](measureValue, '0', 3);
+            }
+        });
+
+        return durationOutput;
+    } else {
+        return format.NO_VALUE;
+    }
+};
+
+format['UnderscoreToHyphen'] = format['CssTemplateField'] = function (value) {
+    let formatted = value;
+    if (formatted) {
+        formatted = preformat(formatted).replace(/_/g, format.HYPHEN);
+    }
+    return formatted;
+};
+
+/**
+ * Parses words and number in rack name and returns a vector that can be used for sorting
+ * @param value {String}
+ * @returns {Array}
+ * @constructor
+ */
+format['RackToVector'] = function (value) {
+    const rackPartRegex = /([a-z]+)|(\d+)|([-.])/i;
+    const vector = [];
+    let currentMatch;
+
+    if (typeof value !== 'undefined') {
+        do {
+            currentMatch = rackPartRegex.exec(value);
+
+            if (currentMatch !== null) {
+                if (currentMatch[2]) {
+                    vector.push(parseInt(currentMatch[2], 10));
+                } else if (currentMatch[1]) {
+                    vector.push(currentMatch[1].toLowerCase());
+                } else {
+                    vector.push(currentMatch[3]);
+                }
+
+                value = value.substring(currentMatch.index + currentMatch[0].length);
+            }
+        } while (currentMatch !== null);
+    } else {
+        vector.push(value);
+    }
+
+    return vector;
+};
+
+format['vCores'] = function (value) {
+    const tmp = Number.isNaN(value) ? undefined : Math.floor(value / 1000);
+    return `${format.Number(tmp)} cores`;
+};
+
+format['RowsPerSecond'] = function (value, settings = {digits: 2}) {
+    if (!value) {
+        return format.Number(value, settings);
+    }
+    return `${format.Number(value, settings)} rows/s`;
+};
+
+format['NumberSmart'] = function NumberSmart(value, settings) {
+    let significantDigits = parseSetting(settings, 'significantDigits', 3);
+    const MAX_PRECISION = 20;
+    const DECIMAL_DELIMETER = '.';
+    const ZERO = '0';
+
+    if (format.validNumber(value)) {
+        if (value === 0) {
+            return '0';
+        }
+
+        const [integerPart, decimalPart] = value.toFixed(MAX_PRECISION).split(DECIMAL_DELIMETER);
+        let siginificantDigitEncountered = false;
+
+        if (integerPart !== ZERO && integerPart !== `-${ZERO}`) {
+            if (integerPart.length >= significantDigits) {
+                return format.Number(value, {digits: 0});
+            }
+
+            siginificantDigitEncountered = true;
+            significantDigits -= value > 0 ? integerPart.length : integerPart.length - 1;
+        }
+
+        let decimalResult = '';
+        let hasSignificantDecimalPart = false;
+
+        for (let i = 0; i < decimalPart.length && significantDigits > 0; i++) {
+            const digit = decimalPart[i];
+
+            if (digit !== ZERO) {
+                siginificantDigitEncountered = true;
+                hasSignificantDecimalPart = true;
+            }
+
+            if (siginificantDigitEncountered) {
+                significantDigits--;
+            }
+
+            decimalResult += digit;
+        }
+
+        if (!hasSignificantDecimalPart) {
+            return format.Number(value, {digits: 0});
+        }
+
+        const res = format.Number(value, {digits: decimalResult.length});
+        const dotIndex = -1 !== res.indexOf(DECIMAL_DELIMETER);
+        if (dotIndex === -1) {
+            return res;
+        }
+
+        for (let i = res.length - 1; i >= 0; --i) {
+            if (res[i] !== ZERO) {
+                return res.substring(0, i + 1);
+            }
+        }
+
+        return res;
+    } else {
+        return format.NO_VALUE;
+    }
+};
 
 module.exports = format;

--- a/packages/interface-helpers/lib/hammer/format.js
+++ b/packages/interface-helpers/lib/hammer/format.js
@@ -1,6 +1,6 @@
 const BigNumber = require('bignumber.js');
 const _map = require('lodash/map');
-const moment = require('moment');
+const {dateTime} = require('@gravity-ui/date-utils');
 
 const type = require('./type');
 const utils = require('./utils');
@@ -30,10 +30,10 @@ format.validNumber = function (value) {
 
 format.toMoment = function (value) {
     if (format.validNumber(value)) {
-        // Assume unix timestamp
-        return moment.unix(value);
-    } else if (format.validString(value)) {
-        return moment(value);
+        return dateTime({input: value * 1000});
+    }
+    if (format.validString(value)) {
+        return dateTime({input: value});
     }
 };
 

--- a/packages/interface-helpers/lib/hammer/format.spec.js
+++ b/packages/interface-helpers/lib/hammer/format.spec.js
@@ -1,6 +1,18 @@
 const format = require('./format');
 
 describe('format', () => {
+    describe('toMoment', () => {
+        it('parses unix seconds as number', () => {
+            const dt = format.toMoment(1000000000);
+            expect(dt.unix()).toBe(1000000000);
+        });
+
+        it('parses ISO date string', () => {
+            const dt = format.toMoment('2019-06-01T12:00:00.000Z');
+            expect(dt.isValid()).toBe(true);
+        });
+    });
+
     describe('NumberWithSuffix', () => {
         function checkNumberWithSuffix(value, expected) {
             expect(format.NumberWithSuffix(value)).toEqual(expected);

--- a/packages/interface-helpers/lib/hammer/format.spec.js
+++ b/packages/interface-helpers/lib/hammer/format.spec.js
@@ -1,3 +1,4 @@
+const {settings} = require('@gravity-ui/date-utils');
 const format = require('./format');
 
 describe('format', () => {
@@ -212,5 +213,452 @@ describe('format', () => {
         expect(format.Hex('')).toBe(format.NO_VALUE);
         expect(format.Hex('0abc')).toBe(format.NO_VALUE);
         expect(format.Hex('abc')).toBe(format.NO_VALUE);
+    });
+
+    describe('DateTime', () => {
+        beforeEach(() => {
+            settings.setDefaultTimeZone('UTC');
+        });
+
+        describe('when value is undefined', () => {
+            it('should return NO_VALUE', () => {
+                const result = format.DateTime(undefined);
+                expect(result).toBe(format.NO_VALUE);
+            });
+        });
+
+        describe('when value is null', () => {
+            it('should handle null value', () => {
+                const result = format.DateTime(null);
+                expect(result).toBe(format.NO_VALUE);
+            });
+        });
+
+        describe('with custom pattern', () => {
+            const testDate = '2023-09-15T10:30:45Z';
+
+            it('should use custom pattern when provided', () => {
+                const result = format.DateTime(testDate, {pattern: 'YYYY-MM-DD'});
+                expect(result).toBe('2023-09-15');
+            });
+
+            it('should use custom pattern with time', () => {
+                const result = format.DateTime(testDate, {pattern: 'HH:mm:ss'});
+                expect(result).toBe('10:30:45');
+            });
+
+            it('should use custom pattern with full format', () => {
+                const result = format.DateTime(testDate, {pattern: 'YYYY-MM-DD HH:mm:ss'});
+                expect(result).toBe('2023-09-15 10:30:45');
+            });
+
+            it('should prioritize pattern over format setting', () => {
+                const result = format.DateTime(testDate, {
+                    pattern: 'MM/DD/YYYY',
+                    format: 'full',
+                });
+                expect(result).toBe('09/15/2023');
+            });
+        });
+
+        describe('with format setting', () => {
+            const testDate = '2023-09-15T10:30:45Z';
+
+            it('should format as full date when format is "full"', () => {
+                const result = format.DateTime(testDate, {format: 'full'});
+                expect(result).toBe('15 Sep 2023 10:30:45');
+            });
+
+            it('should format as short date when format is "short"', () => {
+                const result = format.DateTime(testDate, {format: 'short'});
+                expect(result).toBe('15 Sep 10:30');
+            });
+
+            it('should format as day when format is "day"', () => {
+                const result = format.DateTime(testDate, {format: 'day'});
+                expect(result).toBe('15 Sep 2023');
+            });
+
+            it('should format as month when format is "month"', () => {
+                const result = format.DateTime(testDate, {format: 'month'});
+                expect(result).toBe('September 2023');
+            });
+
+            it('should format as time when format is "time"', () => {
+                const result = format.DateTime(testDate, {format: 'time'});
+                expect(result).toBe('10:30:45');
+            });
+
+            it('should throw error for unknown format', () => {
+                expect(() => {
+                    format.DateTime(testDate, {format: 'unknown'});
+                }).toThrow(
+                    'hammer.format.DateTime: Unknown `format` option. Please specify one of [human, full, short, day, month] or use `pattern` option.',
+                );
+            });
+        });
+
+        describe('with default format', () => {
+            const testDate = '2023-09-15T10:30:45Z';
+
+            it('should use "full" format by default', () => {
+                const result = format.DateTime(testDate);
+                expect(result).toBe('15 Sep 2023 10:30:45');
+            });
+
+            it('should use "full" format with empty settings', () => {
+                const result = format.DateTime(testDate, {});
+                expect(result).toBe('15 Sep 2023 10:30:45');
+            });
+
+            it('should use "full" format with null settings', () => {
+                const result = format.DateTime(testDate, null);
+                expect(result).toBe('15 Sep 2023 10:30:45');
+            });
+        });
+
+        describe('with different input types', () => {
+            it('should handle ISO string', () => {
+                const result = format.DateTime('2023-09-15T10:30:45.123Z');
+                expect(result).toBe('15 Sep 2023 10:30:45');
+            });
+
+            it('should handle timestamp in milliseconds', () => {
+                const timestamp = 1694772645000;
+                const result = format.DateTime(timestamp);
+                expect(typeof result).toBe('string');
+                expect(result).not.toBe(format.NO_VALUE);
+            });
+
+            it('should handle string date in different format', () => {
+                const result = format.DateTime('2023-09-15 10:30:45');
+                expect(result).toBe('15 Sep 2023 10:30:45');
+            });
+        });
+
+        describe('edge cases', () => {
+            it('should handle zero timestamp', () => {
+                const result = format.DateTime(0);
+                expect(result).toBe('01 Jan 1970 00:00:00');
+            });
+        });
+
+        describe('different date scenarios', () => {
+            it('should handle leap year date', () => {
+                const result = format.DateTime('2024-02-29T12:00:00Z');
+                expect(result).toBe('29 Feb 2024 12:00:00');
+            });
+
+            it('should handle end of year date', () => {
+                const result = format.DateTime('2023-12-31T23:59:59Z');
+                expect(result).toBe('31 Dec 2023 23:59:59');
+            });
+
+            it('should handle beginning of year date', () => {
+                const result = format.DateTime('2023-01-01T00:00:00Z');
+                expect(result).toBe('01 Jan 2023 00:00:00');
+            });
+
+            it('should handle different months correctly', () => {
+                const testCases = [
+                    {input: '2023-01-15T12:00:00Z', expected: '15 Jan 2023 12:00:00'},
+                    {input: '2023-02-15T12:00:00Z', expected: '15 Feb 2023 12:00:00'},
+                    {input: '2023-03-15T12:00:00Z', expected: '15 Mar 2023 12:00:00'},
+                    {input: '2023-04-15T12:00:00Z', expected: '15 Apr 2023 12:00:00'},
+                    {input: '2023-05-15T12:00:00Z', expected: '15 May 2023 12:00:00'},
+                    {input: '2023-06-15T12:00:00Z', expected: '15 Jun 2023 12:00:00'},
+                    {input: '2023-07-15T12:00:00Z', expected: '15 Jul 2023 12:00:00'},
+                    {input: '2023-08-15T12:00:00Z', expected: '15 Aug 2023 12:00:00'},
+                    {input: '2023-09-15T12:00:00Z', expected: '15 Sep 2023 12:00:00'},
+                    {input: '2023-10-15T12:00:00Z', expected: '15 Oct 2023 12:00:00'},
+                    {input: '2023-11-15T12:00:00Z', expected: '15 Nov 2023 12:00:00'},
+                    {input: '2023-12-15T12:00:00Z', expected: '15 Dec 2023 12:00:00'},
+                ];
+
+                testCases.forEach(({input, expected}) => {
+                    const result = format.DateTime(input);
+                    expect(result).toBe(expected);
+                });
+            });
+        });
+
+        describe('custom patterns', () => {
+            const testDate = '2023-09-15T10:30:45Z';
+
+            it('should format with YYYY pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'YYYY'});
+                expect(result).toBe('2023');
+            });
+
+            it('should format with MM pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'MM'});
+                expect(result).toBe('09');
+            });
+
+            it('should format with DD pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'DD'});
+                expect(result).toBe('15');
+            });
+
+            it('should format with HH pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'HH'});
+                expect(result).toBe('10');
+            });
+
+            it('should format with mm pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'mm'});
+                expect(result).toBe('30');
+            });
+
+            it('should format with ss pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'ss'});
+                expect(result).toBe('45');
+            });
+
+            it('should format with YYYY-MM pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'YYYY-MM'});
+                expect(result).toBe('2023-09');
+            });
+
+            it('should format with MM-DD pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'MM-DD'});
+                expect(result).toBe('09-15');
+            });
+
+            it('should format with DD/MM/YYYY pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'DD/MM/YYYY'});
+                expect(result).toBe('15/09/2023');
+            });
+
+            it('should format with HH:mm pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'HH:mm'});
+                expect(result).toBe('10:30');
+            });
+
+            it('should format with mm:ss pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'mm:ss'});
+                expect(result).toBe('30:45');
+            });
+
+            it('should format with YYYY-MM-DD HH:mm pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'YYYY-MM-DD HH:mm'});
+                expect(result).toBe('2023-09-15 10:30');
+            });
+
+            it('should format with DD MMM YYYY pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'DD MMM YYYY'});
+                expect(result).toBe('15 Sep 2023');
+            });
+
+            it('should format with MMM DD, YYYY pattern', () => {
+                const result = format.DateTime(testDate, {pattern: 'MMM DD, YYYY'});
+                expect(result).toBe('Sep 15, 2023');
+            });
+        });
+
+        describe('all format types', () => {
+            const testDate = '2023-09-15T10:30:45Z';
+
+            it('should format with "full" format', () => {
+                const result = format.DateTime(testDate, {format: 'full'});
+                expect(result).toBe('15 Sep 2023 10:30:45');
+            });
+
+            it('should format with "short" format', () => {
+                const result = format.DateTime(testDate, {format: 'short'});
+                expect(result).toBe('15 Sep 10:30');
+            });
+
+            it('should format with "day" format', () => {
+                const result = format.DateTime(testDate, {format: 'day'});
+                expect(result).toBe('15 Sep 2023');
+            });
+
+            it('should format with "month" format', () => {
+                const result = format.DateTime(testDate, {format: 'month'});
+                expect(result).toBe('September 2023');
+            });
+
+            it('should format with "time" format', () => {
+                const result = format.DateTime(testDate, {format: 'time'});
+                expect(result).toBe('10:30:45');
+            });
+        });
+    });
+
+    describe('NumberSmart', () => {
+        describe('when value is not a valid number', () => {
+            it('should return NO_VALUE for undefined', () => {
+                const result = format.NumberSmart(undefined);
+                expect(result).toBe(format.NO_VALUE);
+            });
+
+            it('should return NO_VALUE for null', () => {
+                const result = format.NumberSmart(null);
+                expect(result).toBe(format.NO_VALUE);
+            });
+
+            it('should return NO_VALUE for NaN', () => {
+                const result = format.NumberSmart(NaN);
+                expect(result).toBe(format.NO_VALUE);
+            });
+
+            it('should return NO_VALUE for non-numeric string', () => {
+                const result = format.NumberSmart('abc');
+                expect(result).toBe(format.NO_VALUE);
+            });
+        });
+
+        describe('when value is zero', () => {
+            it('should return "0" for zero', () => {
+                const result = format.NumberSmart(0);
+                expect(result).toBe('0');
+            });
+
+            it('should return "0" for zero with custom significantDigits', () => {
+                const result = format.NumberSmart(0, {significantDigits: 5});
+                expect(result).toBe('0');
+            });
+        });
+
+        describe('with default significantDigits (3)', () => {
+            describe('integer values', () => {
+                it('should format small integers without decimals', () => {
+                    expect(format.NumberSmart(1)).toBe('1');
+                    expect(format.NumberSmart(12)).toBe('12');
+                    expect(format.NumberSmart(123)).toBe('123');
+                });
+
+                it('should format large integers without decimals when they have enough significant digits', () => {
+                    expect(format.NumberSmart(1234)).toBe('1 234');
+                    expect(format.NumberSmart(12345)).toBe('12 345');
+                    expect(format.NumberSmart(123456)).toBe('123 456');
+                });
+            });
+
+            describe('decimal values', () => {
+                it('should format decimals with leading zeros correctly', () => {
+                    expect(format.NumberSmart(0.1)).toBe('0.1');
+                    expect(format.NumberSmart(0.01)).toBe('0.01');
+                    expect(format.NumberSmart(0.001)).toBe('0.001');
+                    expect(format.NumberSmart(0.0001)).toBe('0.0001');
+                });
+
+                it('should format decimals with multiple significant digits', () => {
+                    expect(format.NumberSmart(0.123)).toBe('0.123');
+                    expect(format.NumberSmart(0.0123)).toBe('0.0123');
+                    expect(format.NumberSmart(0.00123)).toBe('0.00123');
+                });
+
+                it('should limit to 3 significant digits for decimals', () => {
+                    expect(format.NumberSmart(0.12345)).toBe('0.123');
+                    expect(format.NumberSmart(0.012345)).toBe('0.0123');
+                    expect(format.NumberSmart(0.0012345)).toBe('0.00123');
+                });
+
+                it('should format mixed integer and decimal parts', () => {
+                    expect(format.NumberSmart(1.23)).toBe('1.23');
+                    expect(format.NumberSmart(12.3)).toBe('12.3');
+                    expect(format.NumberSmart(1.234)).toBe('1.23');
+                    expect(format.NumberSmart(12.34)).toBe('12.3');
+                });
+
+                it('should handle very small numbers', () => {
+                    expect(format.NumberSmart(0.000123)).toBe('0.000123');
+                    expect(format.NumberSmart(0.0000123)).toBe('0.0000123');
+                });
+            });
+
+            describe('edge cases', () => {
+                it('should handle numbers with trailing zeros', () => {
+                    expect(format.NumberSmart(1.0)).toBe('1');
+                    expect(format.NumberSmart(1.2)).toBe('1.2');
+                    expect(format.NumberSmart(1.23)).toBe('1.23');
+                });
+
+                it('should handle negative numbers', () => {
+                    expect(format.NumberSmart(-1.23)).toBe('-1.23');
+                    expect(format.NumberSmart(-123)).toBe('-123');
+                    expect(format.NumberSmart(-0.123)).toBe('-0.123');
+                });
+
+                it('should handle very large numbers', () => {
+                    expect(format.NumberSmart(1234567)).toBe('1 234 567');
+                    expect(format.NumberSmart(1234567.89)).toBe('1 234 568');
+                });
+            });
+        });
+
+        describe('with custom significantDigits', () => {
+            it('should respect custom significantDigits = 1', () => {
+                expect(format.NumberSmart(1.23456, {significantDigits: 1})).toBe('1');
+                expect(format.NumberSmart(0.123456, {significantDigits: 1})).toBe('0.1');
+                expect(format.NumberSmart(0.0123456, {significantDigits: 1})).toBe('0.01');
+            });
+
+            it('should respect custom significantDigits = 2', () => {
+                expect(format.NumberSmart(1.23456, {significantDigits: 2})).toBe('1.2');
+                expect(format.NumberSmart(0.123456, {significantDigits: 2})).toBe('0.12');
+                expect(format.NumberSmart(0.0123456, {significantDigits: 2})).toBe('0.012');
+            });
+
+            it('should respect custom significantDigits = 5', () => {
+                expect(format.NumberSmart(1.23456789, {significantDigits: 5})).toBe('1.2346');
+                expect(format.NumberSmart(0.123456789, {significantDigits: 5})).toBe('0.12346');
+                expect(format.NumberSmart(0.0123456789, {significantDigits: 5})).toBe('0.012346');
+            });
+
+            it('should handle significantDigits larger than available digits', () => {
+                expect(format.NumberSmart(1.2, {significantDigits: 5})).toBe('1.2');
+                expect(format.NumberSmart(123, {significantDigits: 5})).toBe('123');
+            });
+
+            it('should handle significantDigits = 0', () => {
+                expect(format.NumberSmart(1.23456, {significantDigits: 0})).toBe('1');
+                expect(format.NumberSmart(0.123456, {significantDigits: 0})).toBe('0');
+            });
+        });
+
+        describe('integer part handling', () => {
+            it('should return only integer part when it has enough significant digits', () => {
+                expect(format.NumberSmart(123.456, {significantDigits: 3})).toBe('123');
+                expect(format.NumberSmart(1234.567, {significantDigits: 3})).toBe('1 235');
+                expect(format.NumberSmart(12345.678, {significantDigits: 4})).toBe('12 346');
+            });
+
+            it('should include decimal part when integer part has fewer significant digits', () => {
+                expect(format.NumberSmart(1.23456, {significantDigits: 3})).toBe('1.23');
+                expect(format.NumberSmart(12.3456, {significantDigits: 3})).toBe('12.3');
+                expect(format.NumberSmart(12.3456, {significantDigits: 4})).toBe('12.35');
+            });
+        });
+
+        describe('decimal part handling', () => {
+            it('should handle numbers with only decimal part', () => {
+                expect(format.NumberSmart(0.123456, {significantDigits: 3})).toBe('0.123');
+                expect(format.NumberSmart(0.0123456, {significantDigits: 3})).toBe('0.0123');
+                expect(format.NumberSmart(0.00123456, {significantDigits: 3})).toBe('0.00123');
+            });
+
+            it('should not include decimal part if it has no significant digits', () => {
+                expect(format.NumberSmart(1.0, {significantDigits: 3})).toBe('1');
+                expect(format.NumberSmart(123.0, {significantDigits: 3})).toBe('123');
+            });
+        });
+
+        describe('number formatting integration', () => {
+            it('should use format.Number for integer part formatting', () => {
+                expect(format.NumberSmart(1234567.89, {significantDigits: 7})).toBe('1 234 568');
+                expect(format.NumberSmart(1000000, {significantDigits: 7})).toBe('1 000 000');
+            });
+        });
+
+        describe('precision edge cases', () => {
+            it('should handle maximum precision correctly', () => {
+                const veryPreciseNumber = 1.123456789012345;
+                const result = format.NumberSmart(veryPreciseNumber, {significantDigits: 10});
+                expect(result).toBe('1.123456789');
+            });
+        });
     });
 });

--- a/packages/interface-helpers/lib/ypath/ypath.js
+++ b/packages/interface-helpers/lib/ypath/ypath.js
@@ -146,6 +146,10 @@ ypath._next = function (path) {
  * @param {Function} [nodeParser] - node parser can do some action to a node and return new node.
  */
 ypath.get = function (node, path, nodeParser) {
+    if (typeof path === 'undefined') {
+        return node;
+    }
+
     if (typeof path !== 'string') {
         throw new YPathError('invalid relative ypath type - expected string');
     }
@@ -188,10 +192,69 @@ ypath.getValue = function (node, path) {
     return yson.value(ypath.get(node, path));
 };
 
+ypath.getAttributes = function (node, path) {
+    return yson.attributes(ypath.get(node, path));
+};
+
 ypath.getValues = function (node, paths) {
     return _map(paths, function (path) {
         return ypath.getValue(node, path);
     });
+};
+
+function convertToBoolean(value) {
+    const unwrapped = yson.value(value);
+    if (unwrapped === undefined) {
+        return undefined;
+    }
+    const t = typeof unwrapped;
+    if (t === 'string' && (unwrapped === 'true' || unwrapped === 'false')) {
+        return unwrapped === 'true';
+    }
+    if (t === 'boolean') {
+        return unwrapped;
+    }
+    throw new Error('convertToBoolean: value cannot be converted to boolean.');
+}
+
+function convertToNumber(value, defaultValue) {
+    if (value === null || value === undefined) {
+        return defaultValue;
+    }
+    const res = Number(value);
+    if (isNaN(res) && defaultValue === undefined) {
+        throw new Error('convertToNumber: value "' + value + '" cannot be converted to number.');
+    }
+    return isNaN(res) ? defaultValue : res;
+}
+
+ypath.getNumberBase = function (node, path, defaultValue) {
+    let value;
+    if (typeof path === 'undefined') {
+        value = node;
+    } else {
+        value = ypath.getValue(node, path);
+    }
+    return convertToNumber(value, defaultValue);
+};
+
+ypath.getNumber = function (node, path, defaultValue) {
+    try {
+        return ypath.getNumberBase(node, path, defaultValue);
+    } catch (e) {
+        const wrapped = new Error(
+            'getNumber: failed to convert field with path: "' + path + '". ' + e.message,
+        );
+        if (e.stack) {
+            wrapped.stack = e.stack;
+        }
+        throw wrapped;
+    }
+};
+
+ypath.getBoolean = function (node, path) {
+    const value = ypath.get(node, path);
+    return convertToBoolean(value);
 };
 
 /**

--- a/packages/interface-helpers/lib/ypath/ypath.spec.js
+++ b/packages/interface-helpers/lib/ypath/ypath.spec.js
@@ -91,6 +91,33 @@ describe('YPath', () => {
 
             expect(_get(node, '/path/@')).toEqual({});
         });
+
+        it('returns node when path is undefined', () => {
+            const node = {a: 1};
+            expect(_get(node, undefined)).toBe(node);
+        });
+    });
+
+    describe('getAttributes', () => {
+        const _getAttributes = ypath.getAttributes;
+
+        it('Exports', () => {
+            expect(_getAttributes).toBeDefined();
+        });
+
+        it('returns attributes of the node at path', () => {
+            const node = {
+                item: {
+                    $attributes: {type: 'x'},
+                    $value: 'y',
+                },
+            };
+            expect(_getAttributes(node, '/item')).toEqual({type: 'x'});
+        });
+
+        it('returns empty object for missing attributes when path is undefined', () => {
+            expect(_getAttributes({foo: 1}, undefined)).toEqual({});
+        });
     });
 
     describe('contructor', () => {
@@ -342,6 +369,149 @@ describe('YPath', () => {
                         '\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe',
                 );
             });
+        });
+    });
+
+    describe('getValue', () => {
+        it('null is treated as an error if encountered in the middle', () => {
+            const node = {
+                $value: null,
+                $attributes: {
+                    recursive_resource_usage: null,
+                },
+            };
+
+            expect(() => {
+                ypath.getValue(node, '/some_property');
+            }).toThrow(Error);
+
+            expect(() => {
+                ypath.getValue(node, '/@recursive_resource_usage');
+            }).not.toThrow();
+        });
+    });
+
+    describe('getBoolean', () => {
+        it('gets boolean from boolean', () => {
+            const node = {
+                $value: '//home/user/table',
+                $attributes: {
+                    append: true,
+                    teleport: false,
+                },
+            };
+
+            expect(ypath.getBoolean(node, '/@append')).toBe(true);
+            expect(ypath.getBoolean(node, '/@teleport')).toBe(false);
+        });
+
+        it('gets boolean from string', () => {
+            const node = {
+                $value: '//home/user/table',
+                $attributes: {
+                    append: 'true',
+                    teleport: 'false',
+                },
+            };
+
+            expect(ypath.getBoolean(node, '/@append')).toBe(true);
+            expect(ypath.getBoolean(node, '/@teleport')).toBe(false);
+        });
+
+        it('plays well with undefined', () => {
+            const node = {
+                $value: '//home/user/table',
+                $attributes: {
+                    append: undefined,
+                    teleport: undefined,
+                },
+            };
+
+            expect(ypath.getBoolean(node, '/@append')).toBeUndefined();
+            expect(ypath.getBoolean(node, '/@teleport')).toBeUndefined();
+        });
+
+        it('everything else is treated as an error', () => {
+            const node = {
+                $value: '//home/user/table',
+                $attributes: {
+                    append: 'foo',
+                    teleport: 'foo',
+                },
+            };
+
+            expect(() => {
+                ypath.getBoolean(node, '/@append');
+            }).toThrow(Error);
+            expect(() => {
+                ypath.getBoolean(node, '/@teleport');
+            }).toThrow(Error);
+        });
+    });
+
+    describe('convertToNumber', () => {
+        it('converts valid values', () => {
+            expect(ypath.getNumberBase(2, undefined)).toBe(2);
+            expect(ypath.getNumberBase('2', undefined)).toBe(2);
+        });
+
+        it('returns default for null and undefined', () => {
+            expect(ypath.getNumberBase(null, undefined, 5)).toBe(5);
+            expect(ypath.getNumberBase(undefined, undefined, 5)).toBe(5);
+        });
+
+        it('throws when not convertible without default', () => {
+            expect(() => ypath.getNumberBase('asdasd', undefined)).toThrow(
+                'convertToNumber: value "asdasd" cannot be converted to number.',
+            );
+        });
+    });
+
+    describe('getNumberBase', () => {
+        const node = {
+            $value: '/some/value',
+            $attributes: {
+                test_number: 2,
+                test_valid_string: '2',
+                test_invalid_string: 'asdasd',
+                test_undefined: undefined,
+                test_null: null,
+            },
+        };
+
+        it('reads attributes like ypath-base', () => {
+            expect(ypath.getNumberBase(node, '/@test_number')).toBe(2);
+            expect(ypath.getNumberBase(node, '/@test_valid_string')).toBe(2);
+            expect(() => ypath.getNumberBase(node, '/@test_invalid_string')).toThrow(
+                'convertToNumber: value "asdasd" cannot be converted to number.',
+            );
+            expect(ypath.getNumberBase(node, '/@test_undefined')).toBeUndefined();
+            expect(ypath.getNumberBase(node, '/@test_null')).toBeUndefined();
+        });
+
+        it('uses default when provided', () => {
+            expect(ypath.getNumberBase(node, '/@test_invalid_string', 4)).toBe(4);
+            expect(ypath.getNumberBase(node, '/@test_undefined', 4)).toBe(4);
+            expect(ypath.getNumberBase(node, '/@test_null', 4)).toBe(4);
+        });
+
+        it('uses whole node when path is undefined', () => {
+            expect(ypath.getNumberBase(42, undefined)).toBe(42);
+        });
+    });
+
+    describe('getNumber', () => {
+        it('wraps convert errors with path in message', () => {
+            const node = {
+                $attributes: {x: 'nope'},
+            };
+            expect(() => ypath.getNumber(node, '/@x')).toThrow(
+                'getNumber: failed to convert field with path: "/@x". convertToNumber: value "nope" cannot be converted to number.',
+            );
+        });
+
+        it('returns number when valid', () => {
+            expect(ypath.getNumber({$attributes: {n: 7}}, '/@n')).toBe(7);
         });
     });
 });

--- a/packages/interface-helpers/package-lock.json
+++ b/packages/interface-helpers/package-lock.json
@@ -8,19 +8,19 @@
       "name": "@ytsaurus/interface-helpers",
       "version": "1.1.1",
       "devDependencies": {
+        "@gravity-ui/date-utils": "^2.6.0",
         "@gravity-ui/eslint-config": "^3.2.0",
         "@gravity-ui/prettier-config": "^1.1.0",
         "bignumber.js": "^9.0.1",
         "eslint": "^8.57.1",
         "jest": "^26.6.3",
         "lodash": "^4.17.15",
-        "moment": "^2.24.0",
         "prettier": "^3.7.4"
       },
       "peerDependencies": {
+        "@gravity-ui/date-utils": "^2.6.0",
         "bignumber.js": "^9.0.1",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0"
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -738,6 +738,16 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@gravity-ui/date-utils": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/date-utils/-/date-utils-2.7.0.tgz",
+      "integrity": "sha512-XzsLH8F03n3HUZPBRNtWb6C5Vj7/2rZDH4RjYRSWJiyPDV1qt+v9p9lXLVb40ifQAIkiWgE03lM/KzIcCYdAjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "1.11.10"
       }
     },
     "node_modules/@gravity-ui/eslint-config": {
@@ -3199,6 +3209,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7099,15 +7116,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/packages/interface-helpers/package.json
+++ b/packages/interface-helpers/package.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/ytsaurus/ytsaurus-ui/tree/main/packages/interface-helpers"
   },
   "peerDependencies": {
+    "@gravity-ui/date-utils": "^2.6.0",
     "bignumber.js": "^9.0.1",
-    "lodash": "^4.17.15",
-    "moment": "^2.24.0"
+    "lodash": "^4.17.15"
   },
   "private": false,
   "devDependencies": {
+    "@gravity-ui/date-utils": "^2.6.0",
     "@gravity-ui/eslint-config": "^3.2.0",
     "@gravity-ui/prettier-config": "^1.1.0",
     "bignumber.js": "^9.0.1",
     "eslint": "^8.57.1",
     "jest": "^26.6.3",
     "lodash": "^4.17.15",
-    "moment": "^2.24.0",
     "prettier": "^3.7.4"
   },
   "scripts": {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/dhBAYm6P7ZWVFE
<!-- nda-end --> ## Summary by Sourcery

Replace moment-based date handling with @gravity-ui/date-utils and add new UI-oriented formatting helpers and YPath utilities.

New Features:
- Add ReadableField formatter for transforming API field names into user-friendly labels.
- Add DateTime formatter supporting multiple preset formats and custom patterns using the shared date utilities.
- Add TimeDuration formatter to render millisecond durations as human-readable strings with optional millisecond precision.
- Add UnderscoreToHyphen/CssTemplateField formatter for converting underscored values into hyphenated strings.
- Add RackToVector helper for parsing rack identifiers into sortable vectors.
- Add vCores formatter to display virtual core counts in cores units.
- Add RowsPerSecond formatter to render row throughput values with rows/s suffix.
- Add NumberSmart formatter to display numbers using a configurable count of significant digits.

Bug Fixes:
- Make ypath.get return the original node when path is undefined instead of throwing.
- Make ypath.getAttributes return an empty attribute object when called with an undefined path.

Enhancements:
- Refine toMoment implementation to use @gravity-ui/date-utils for consistent date parsing.
- Document optional settings parameters for Address and Readable formatters and improve null-safety in various helpers.

Build:
- Update interface-helpers package dependencies to add @gravity-ui/date-utils and drop moment.

Tests:
- Add tests for the new toMoment behavior with numeric timestamps and ISO strings.
- Extend YPath tests to cover undefined-path behavior and getAttributes extraction.