### PR TITLE
fix(Queries/Graph): wrong cluster in link [YTFRONT-5723]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/DetailBlock/DetailBlockHeader.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/DetailBlock/DetailBlockHeader.tsx
@@ -24,7 +24,7 @@ export const DetailBlockHeader: FC<Props> = ({
 
     return (
         <Flex gap={2} direction="column">
-            <DetailBlockTitle icon={icon} name={name} id={nodeProgress?.remoteId} />
+            <DetailBlockTitle icon={icon} name={name} nodeProgress={nodeProgress} />
             {showContent && (
                 <>
                     {isTable ? (

--- a/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/DetailBlock/DetailBlockTitle.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/DetailBlock/DetailBlockTitle.tsx
@@ -5,22 +5,19 @@ import './DetailBlockTitle.scss';
 import {Button, Icon} from '@gravity-ui/uikit';
 import {ArrowUpRightFromSquare} from '@gravity-ui/icons';
 import {openInNewTab} from '../../../../../utils/utils';
+import type {NodeProgress} from '../../models/plan';
+import {getOperationPageUrlFromNodeProgress} from '../../services/getOperationPageUrlFromNodeProgress';
 
 const block = cn('yt-detailed-block-title');
 
 type Props = {
     icon: QueriesBlockMeta['icon'];
     name: string;
-    id?: string;
+    nodeProgress?: NodeProgress;
 };
 
-export const DetailBlockTitle: FC<Props> = ({icon, name, id}) => {
-    let url = '';
-    if (id) {
-        const [cluster, operationId] = id.split('/');
-        const clusterName = cluster?.split('.')[0] ?? cluster;
-        url = `/${clusterName}/operations/${encodeURIComponent(operationId ?? '')}`;
-    }
+export const DetailBlockTitle: FC<Props> = ({icon, name, nodeProgress}) => {
+    const url = getOperationPageUrlFromNodeProgress(nodeProgress) ?? '';
 
     const handleClick = () => {
         openInNewTab(url);

--- a/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesGraph.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesGraph.tsx
@@ -12,6 +12,7 @@ import {useSelector} from '../../../../store/redux-hooks';
 import {getSettingsQueryTrackerGraphAutoCenter} from '../../../../store/selectors/settings/settings-ts';
 import {checkControlCommandKey} from '../../../../utils/keyboard';
 import {openInNewTab} from '../../../../utils/utils';
+import {getOperationPageUrlFromNodeProgress} from '../services/getOperationPageUrlFromNodeProgress';
 import cn from 'bem-cn-lite';
 import './QueriesGraph.scss';
 
@@ -36,12 +37,8 @@ const Graph: FC<Props> = ({processedGraph}) => {
     const {data, isLoading} = useQueriesGraphLayout(processedGraph, scale);
 
     const handleBlockClick = useCallback((node: QueriesNodeBlock, event: Event) => {
-        const remoteId = node.meta.nodeProgress?.remoteId;
-        if (!remoteId) return;
-
-        const [cluster, operationId] = remoteId.split('/');
-        const clusterName = cluster?.split('.')[0] ?? cluster;
-        const url = `/${clusterName}/operations/${encodeURIComponent(operationId ?? '')}`;
+        const url = getOperationPageUrlFromNodeProgress(node.meta.nodeProgress);
+        if (!url) return;
 
         if (checkControlCommandKey(event as MouseEvent)) {
             openInNewTab(url);

--- a/packages/ui/src/ui/pages/query-tracker/Plan/services/getOperationPageUrlFromNodeProgress.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/services/getOperationPageUrlFromNodeProgress.ts
@@ -1,0 +1,17 @@
+import type {NodeProgress} from '../models/plan';
+import {buildOperationUrl} from '../../QueryResults/helpers/buildOperationUrl';
+
+export function getOperationPageUrlFromNodeProgress(
+    nodeProgress?: NodeProgress,
+): string | undefined {
+    const remoteId = nodeProgress?.remoteId;
+    if (!remoteId) return undefined;
+
+    const operationId = remoteId.split('/').pop();
+    if (!operationId) return undefined;
+
+    const cluster = nodeProgress?.remoteData?.cluster_name ?? remoteId.split('/')[0];
+    if (!cluster) return undefined;
+
+    return buildOperationUrl(cluster, operationId);
+}


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/PqBlN-FY7ZWqgv
<!-- nda-end -->## Summary by Sourcery

Unify and fix operation link generation in the queries graph details and graph nodes using node progress metadata for correct cluster resolution.

Bug Fixes:
- Correct the cluster used in operation links for query plan nodes by basing URLs on node progress metadata instead of parsing remoteId directly.

Enhancements:
- Extract operation URL construction from node progress into a shared helper reused by the graph and detail block components for consistent behavior.