### PR TITLE
chore(Favourites): change prefix to select [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/components/Dialog/controls/AccountsMultiple/AccountsMultiple.tsx
+++ b/packages/ui/src/ui/components/Dialog/controls/AccountsMultiple/AccountsMultiple.tsx
@@ -7,7 +7,7 @@ import filter_ from 'lodash/filter';
 
 import {useFetchBatchQuery} from '../../../../store/api/yt';
 import {useUsableAccountsQuery} from '../../../../store/api/accounts';
-import {getFavouriteAccounts} from '../../../../store/selectors/favourites';
+import {selectFavouriteAccounts} from '../../../../store/selectors/favourites';
 import {selectCluster} from '../../../../store/selectors/global';
 
 import {DialogControlProps} from '../../../../components/Dialog/Dialog.types';
@@ -26,7 +26,7 @@ type Props = DialogControlProps<string[]> & {
 export function AccountsMultiple(props: Props) {
     const {value, onChange} = props;
 
-    const favourites = useSelector(getFavouriteAccounts);
+    const favourites = useSelector(selectFavouriteAccounts);
     const cluster = useSelector(selectCluster);
 
     const {data: accounts, isLoading} = useFetchBatchQuery<string>({

--- a/packages/ui/src/ui/pages/accounts/Accounts/AccountsTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/AccountsTopRowContent.tsx
@@ -6,8 +6,8 @@ import {Breadcrumbs} from '@gravity-ui/uikit';
 import {RowWithName} from '../../../containers/AppNavigation/TopRowContent/SectionName';
 import Favourites, {FavouritesItem} from '../../../components/Favourites/Favourites';
 import {
-    getFavouriteAccounts,
-    isActiveAcountInFavourites,
+    selectFavouriteAccounts,
+    selectIsActiveAccountInFavourites,
 } from '../../../store/selectors/favourites';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {
@@ -54,8 +54,8 @@ function AccountsTopRowContent() {
 }
 
 function AccountsFavourites() {
-    const isActiveInFavourites = useSelector(isActiveAcountInFavourites);
-    const favourites = useSelector(getFavouriteAccounts);
+    const isActiveInFavourites = useSelector(selectIsActiveAccountInFavourites);
+    const favourites = useSelector(selectFavouriteAccounts);
     const dispatch = useDispatch();
     const activeAccount = useSelector(getActiveAccount);
 

--- a/packages/ui/src/ui/pages/chaos_cell_bundles/ChaosCellBundlesTopRowContent.connected.ts
+++ b/packages/ui/src/ui/pages/chaos_cell_bundles/ChaosCellBundlesTopRowContent.connected.ts
@@ -10,8 +10,8 @@ import {
     selectChaosBreadcrumbItems,
 } from '../../store/selectors/chaos_cell_bundles';
 import {
-    getFavouriteChaosBundles,
-    isActiveChaosBundleInFavourites,
+    selectFavouriteChaosBundles,
+    selectIsActiveChaosBundleInFavourites,
 } from '../../store/selectors/favourites';
 
 const mapStateToProps = (state: RootState) => {
@@ -20,8 +20,8 @@ const mapStateToProps = (state: RootState) => {
         activeBundleData: selectChaosActiveBundleData(state),
         bcItems: selectChaosBreadcrumbItems(state),
         page: Page.CHAOS_CELL_BUNDLES,
-        favourites: getFavouriteChaosBundles(state),
-        isActiveBundleInFavourites: isActiveChaosBundleInFavourites(state),
+        favourites: selectFavouriteChaosBundles(state),
+        isActiveBundleInFavourites: selectIsActiveChaosBundleInFavourites(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/chyt/ChytPageTopRow.tsx
+++ b/packages/ui/src/ui/pages/chyt/ChytPageTopRow.tsx
@@ -15,7 +15,10 @@ import Suggest from '../../components/Suggest/Suggest';
 import {Page} from '../../constants';
 import {RowWithName} from '../../containers/AppNavigation/TopRowContent/SectionName';
 import {WaitForDefaultPoolTree} from '../../hooks/global-pool-trees';
-import {getFavouriteChyt, isActiveCliqueInFavourites} from '../../store/selectors/favourites';
+import {
+    selectFavouriteChyt,
+    selectIsActiveCliqueInFavourites,
+} from '../../store/selectors/favourites';
 import {selectChytCurrentAlias} from '../../store/selectors/chyt';
 import {selectCluster} from '../../store/selectors/global';
 import {selectIsAdmin} from '../../store/selectors/global/is-developer';
@@ -44,8 +47,8 @@ export default function ChytPageTopRow() {
 function ChytFavourites() {
     const history = useHistory();
     const cluster = useSelector(selectCluster);
-    const isActiveInFavourites = useSelector(isActiveCliqueInFavourites);
-    const favourites = useSelector(getFavouriteChyt);
+    const isActiveInFavourites = useSelector(selectIsActiveCliqueInFavourites);
+    const favourites = useSelector(selectFavouriteChyt);
     const dispatch = useDispatch();
     const currentClique = useSelector(selectChytCurrentAlias);
 

--- a/packages/ui/src/ui/pages/dashboard/Links/Links.js
+++ b/packages/ui/src/ui/pages/dashboard/Links/Links.js
@@ -13,12 +13,12 @@ import {LinksTab} from '../../../constants/dashboard';
 import {Page} from '../../../constants/index';
 import hammer from '../../../common/hammer';
 import {
-    getFavouriteAccounts,
-    getFavouritePaths,
-    getLastVisitedAccounts,
-    getLastVisitedPaths,
-    getPopularAccounts,
-    getPopularPaths,
+    selectFavouriteAccounts,
+    selectFavouritePaths,
+    selectLastVisitedAccounts,
+    selectLastVisitedPaths,
+    selectPopularAccounts,
+    selectPopularPaths,
 } from '../../../store/selectors/favourites';
 
 import './Links.scss';
@@ -167,12 +167,12 @@ const mapStateToProps = (state) => {
 
     return {
         activeTab,
-        lastVisited: getLastVisitedPaths(state),
-        popular: getPopularPaths(state),
-        favourites: getFavouritePaths(state),
-        lastVisitedAccounts: getLastVisitedAccounts(state),
-        popularAccounts: getPopularAccounts(state),
-        favouriteAccounts: getFavouriteAccounts(state),
+        lastVisited: selectLastVisitedPaths(state),
+        popular: selectPopularPaths(state),
+        favourites: selectFavouritePaths(state),
+        lastVisitedAccounts: selectLastVisitedAccounts(state),
+        popularAccounts: selectPopularAccounts(state),
+        favouriteAccounts: selectFavouriteAccounts(state),
         tabSize: UI_TAB_SIZE,
         cluster: selectCluster(state),
     };

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/hooks/use-navigation-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/hooks/use-navigation-widget.ts
@@ -5,7 +5,7 @@ import {usePathsQuery} from '../../../../../../store/api/dashboard2/navigation';
 import {selectCluster} from '../../../../../../store/selectors/global';
 import {getNavigationTypeFilter} from '../../../../../../store/selectors/dashboard2/navigation';
 import {getLastVisited} from '../../../../../../store/selectors/settings';
-import {getFavouritePaths} from '../../../../../../store/selectors/favourites';
+import {selectFavouritePaths} from '../../../../../../store/selectors/favourites';
 
 import {NavigationWidgetProps} from '../types';
 
@@ -14,7 +14,7 @@ export function useNavigationWidget(props: NavigationWidgetProps) {
     const cluster = useSelector(selectCluster);
 
     const lastVisitedPaths = useSelector(getLastVisited);
-    const favouritePaths = useSelector(getFavouritePaths);
+    const favouritePaths = useSelector(selectFavouritePaths);
 
     const {
         data: items,

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/hooks/use-pools-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/hooks/use-pools-widget.ts
@@ -8,7 +8,7 @@ import includes_ from 'lodash/includes';
 import {RootState} from '../../../../../../store/reducers';
 import {PoolQueryParams} from '../../../../../../store/api/dashboard2/pools/pools';
 import {usePoolsQuery} from '../../../../../../store/api/dashboard2/pools';
-import {getFavouritePools} from '../../../../../../store/selectors/favourites';
+import {selectFavouritePools} from '../../../../../../store/selectors/favourites';
 import {getPoolsTypeFilter} from '../../../../../../store/selectors/dashboard2/pools';
 import {selectCluster} from '../../../../../../store/selectors/global';
 
@@ -20,7 +20,7 @@ export function usePoolsWidget(props: PoolsWidgetProps) {
     const userPools = props.data?.pools as PoolQueryParams[];
     const resourcesColumns = props.data?.columns as string[];
 
-    const favouritePools = useSelector(getFavouritePools);
+    const favouritePools = useSelector(selectFavouritePools);
     const cluster = useSelector(selectCluster);
     const type = useSelector((state: RootState) => getPoolsTypeFilter(state, props.id));
 

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/hooks/use-services-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/hooks/use-services-widget.ts
@@ -5,7 +5,10 @@ import {useServicesQuery} from '../../../../../../store/api/dashboard2/services'
 import {RootState} from '../../../../../../store/reducers';
 import {selectCluster} from '../../../../../../store/selectors/global';
 import {getServicesTypeFilter} from '../../../../../../store/selectors/dashboard2/services';
-import {getFavouriteBundles, getFavouriteChyt} from '../../../../../../store/selectors/favourites';
+import {
+    selectFavouriteBundles,
+    selectFavouriteChyt,
+} from '../../../../../../store/selectors/favourites';
 
 import type {ServicesWidgetProps} from '../types';
 
@@ -16,8 +19,8 @@ export function useServicesWidget(props: ServicesWidgetProps) {
 
     const type = useSelector((state: RootState) => getServicesTypeFilter(state, props.id));
 
-    const favouriteBundles = useSelector(getFavouriteBundles);
-    const favouriteCliques = useSelector(getFavouriteChyt);
+    const favouriteBundles = useSelector(selectFavouriteBundles);
+    const favouriteCliques = useSelector(selectFavouriteChyt);
 
     const {data, isLoading, isFetching, error} = useServicesQuery({
         type,

--- a/packages/ui/src/ui/pages/navigation/Navigation/NavigationTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/navigation/Navigation/NavigationTopRowContent.tsx
@@ -17,7 +17,10 @@ import {selectCluster} from '../../../store/selectors/global';
 import {makeRoutedURL} from '../../../store/location';
 import {restoreObject} from '../../../store/actions/navigation/modals/restore-object';
 import {getNavigationDefaultPath} from '../../../store/selectors/settings';
-import {getFavouritePaths, isCurrentPathInFavourites} from '../../../store/selectors/favourites';
+import {
+    selectFavouritePaths,
+    selectIsCurrentPathInFavourites,
+} from '../../../store/selectors/favourites';
 import {
     getActualPath,
     getPath,
@@ -83,9 +86,9 @@ function NavigationTopRowContent() {
 function NavigationFavourites() {
     const dispatch = useDispatch();
 
-    const favourites = useSelector(getFavouritePaths);
+    const favourites = useSelector(selectFavouritePaths);
 
-    const isInFavourites = useSelector(isCurrentPathInFavourites);
+    const isInFavourites = useSelector(selectIsCurrentPathInFavourites);
     const path = useSelector(getPath);
 
     const handleToggle = React.useCallback(() => {

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
@@ -16,7 +16,10 @@ import {
     getTree,
     getTreesSelectItems,
 } from '../../../store/selectors/scheduling/scheduling';
-import {getFavouritePools, isActivePoolInFavourites} from '../../../store/selectors/favourites';
+import {
+    selectFavouritePools,
+    selectIsActivePoolInFavourites,
+} from '../../../store/selectors/favourites';
 import {
     changePool,
     changeTree,
@@ -75,8 +78,8 @@ function SchedulingFavourites() {
     const tree = useSelector(getTree);
     const dispatch = useDispatch();
     const pool = useSelector(getPool);
-    const favouritesPools = useSelector(getFavouritePools);
-    const isActivePool = useSelector(isActivePoolInFavourites);
+    const favouritesPools = useSelector(selectFavouritePools);
+    const isActivePool = useSelector(selectIsActivePoolInFavourites);
 
     const onFavouriteClick = React.useCallback(
         ({path}: {path: string}) => {

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundlesTopRowContent.connected.ts
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/TabletCellBundlesTopRowContent.connected.ts
@@ -10,7 +10,10 @@ import {
     selectTabletsBreadcrumbItems,
 } from '../../store/selectors/tablet_cell_bundles';
 import {bundlesToggleFavourite} from '../../store/actions/favourites';
-import {getFavouriteBundles, isActiveBundleInFavourites} from '../../store/selectors/favourites';
+import {
+    selectFavouriteBundles,
+    selectIsActiveBundleInFavourites,
+} from '../../store/selectors/favourites';
 
 const mapStateToProps = (state: RootState) => {
     return {
@@ -18,8 +21,8 @@ const mapStateToProps = (state: RootState) => {
         activeBundleData: selectTabletsActiveBundleData(state),
         bcItems: selectTabletsBreadcrumbItems(state),
         page: Page.TABLET_CELL_BUNDLES,
-        favourites: getFavouriteBundles(state),
-        isActiveBundleInFavourites: isActiveBundleInFavourites(state),
+        favourites: selectFavouriteBundles(state),
+        isActiveBundleInFavourites: selectIsActiveBundleInFavourites(state),
     };
 };
 

--- a/packages/ui/src/ui/store/selectors/accounts/dashboard.js
+++ b/packages/ui/src/ui/store/selectors/accounts/dashboard.js
@@ -4,7 +4,7 @@ import {
     getUsableAccounts,
     prepareAccountsFlattenTree,
 } from '../../../store/selectors/accounts/accounts';
-import {getFavouriteAccounts} from '../../../store/selectors/favourites';
+import {selectFavouriteAccounts} from '../../../store/selectors/favourites';
 import {
     getAccountsVisibilityMode,
     getAccountsVisibilityModeOfDashboard,
@@ -20,7 +20,7 @@ export const getUsableAccountsSet = createSelector([getUsableAccounts], (items) 
  * This selector cannot be moved to 'store/selectors/accounts/accounts'
  * because of cyclic dependencies.
  */
-export const getFavouriteAccountsSet = createSelector([getFavouriteAccounts], (items) => {
+export const getFavouriteAccountsSet = createSelector([selectFavouriteAccounts], (items) => {
     return new Set(map_(items, 'path'));
 });
 

--- a/packages/ui/src/ui/store/selectors/dashboard2/accounts.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/accounts.ts
@@ -2,7 +2,7 @@ import {createSelector} from '@reduxjs/toolkit';
 
 import {RootState} from '../../../store/reducers';
 import {accountsApi} from '../../../store/api/accounts';
-import {getFavouriteAccounts} from '../../../store/selectors/favourites';
+import {selectFavouriteAccounts} from '../../../store/selectors/favourites';
 import {selectCluster} from '../../../store/selectors/global/cluster';
 
 import {createWidgetDataFieldSelector} from './utils';
@@ -22,7 +22,7 @@ const getUsableAccounts = (state: RootState) => {
 };
 
 export const getAccountsList = createSelector(
-    [getFavouriteAccounts, getUsableAccounts, getCustomAccountsList, getAccountsTypeFilter],
+    [selectFavouriteAccounts, getUsableAccounts, getCustomAccountsList, getAccountsTypeFilter],
     (favourite, usable, custom, type) => {
         if (type === 'favourite') {
             return favourite?.length ? favourite.map((item) => item?.path) : [];

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -22,83 +22,89 @@ import {selectChytCurrentAlias} from './chyt';
 
 //************* Selectors for Accounts *****************
 
-export const getFavouriteAccounts = createSelector(
+export const selectFavouriteAccounts = createSelector(
     [makeGetSetting, getAccountsNS],
     prepareFavourites,
 );
 
-export const getLastVisitedAccounts = createSelector(
+export const selectLastVisitedAccounts = createSelector(
     [makeGetSetting, getAccountsNS],
     prepareLastVisited,
 );
 
-export const getPopularAccounts = createSelector([getLastVisitedAccounts], preparePopulars);
+export const selectPopularAccounts = createSelector([selectLastVisitedAccounts], preparePopulars);
 
-export const isActiveAcountInFavourites = createSelector(
-    [getActiveAccount, getFavouriteAccounts],
+export const selectIsActiveAccountInFavourites = createSelector(
+    [getActiveAccount, selectFavouriteAccounts],
     prepareIsInFavourites,
 );
 
-export const getFavouriteChyt = createSelector([makeGetSetting, getChytNS], prepareFavourites);
+export const selectFavouriteChyt = createSelector([makeGetSetting, getChytNS], prepareFavourites);
 
-export const getLastVisitedChyt = createSelector([makeGetSetting, getChytNS], prepareLastVisited);
+export const selectLastVisitedChyt = createSelector(
+    [makeGetSetting, getChytNS],
+    prepareLastVisited,
+);
 
-export const getPopularChyt = createSelector([getLastVisitedChyt], preparePopulars);
+export const selectPopularChyt = createSelector([selectLastVisitedChyt], preparePopulars);
 
-export const isActiveCliqueInFavourites = createSelector(
-    [selectChytCurrentAlias, getFavouriteChyt],
+export const selectIsActiveCliqueInFavourites = createSelector(
+    [selectChytCurrentAlias, selectFavouriteChyt],
     prepareIsInFavourites,
 );
 
 //************* Selectors for Navigation *****************
 
-export const getFavouritePaths = createSelector([makeGetSetting, getClusterNS], prepareFavourites);
+export const selectFavouritePaths = createSelector(
+    [makeGetSetting, getClusterNS],
+    prepareFavourites,
+);
 
-export const getLastVisitedPaths = createSelector(
+export const selectLastVisitedPaths = createSelector(
     [makeGetSetting, getClusterNS],
     prepareLastVisited,
 );
 
-export const getPopularPaths = createSelector([getLastVisitedPaths], preparePopulars);
+export const selectPopularPaths = createSelector([selectLastVisitedPaths], preparePopulars);
 
-export const isCurrentPathInFavourites = createSelector(
-    [getPath, getFavouritePaths],
+export const selectIsCurrentPathInFavourites = createSelector(
+    [getPath, selectFavouritePaths],
     prepareIsInFavourites,
 );
 
 //************* Selectors for Scheduling *****************
 
-export const getFavouritePools = createSelector(
+export const selectFavouritePools = createSelector(
     [makeGetSetting, getSchedulingNS],
     prepareFavourites,
 );
 
-export const isActivePoolInFavourites = createSelector(
-    [getPool, getTree, getFavouritePools],
+export const selectIsActivePoolInFavourites = createSelector(
+    [getPool, getTree, selectFavouritePools],
     prepareIsPoolInFavourites,
 );
 
 //************* Selectors for Bundles *****************
 
-export const getFavouriteBundles = createSelector(
+export const selectFavouriteBundles = createSelector(
     [makeGetSetting, getBundlesNS],
     prepareFavourites,
 );
 
-export const isActiveBundleInFavourites = createSelector(
-    [selectTabletsActiveBundle, getFavouriteBundles],
+export const selectIsActiveBundleInFavourites = createSelector(
+    [selectTabletsActiveBundle, selectFavouriteBundles],
     prepareIsInFavourites,
 );
 
 // ************ Selectors for Chaos bundles ***********
 
-export const getFavouriteChaosBundles = createSelector(
+export const selectFavouriteChaosBundles = createSelector(
     [makeGetSetting, selectChaosBundlesNS],
     prepareFavourites,
 );
 
-export const isActiveChaosBundleInFavourites = createSelector(
-    [selectChaosActiveBundle, getFavouriteChaosBundles],
+export const selectIsActiveChaosBundleInFavourites = createSelector(
+    [selectChaosActiveBundle, selectFavouriteChaosBundles],
     prepareIsInFavourites,
 );
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/i3hgLhei7ZbRQp
<!-- nda-end -->## Summary by Sourcery

Rename favourites-related selectors across the UI store and consumers to use a `select*` naming convention instead of `get*`.

Enhancements:
- Standardize favourites selectors naming from `get*`/`is*` to `select*` across accounts, navigation, scheduling, bundles, and chyt modules.
- Update all connected components, hooks, and dashboard selectors to use the new favourites selector names.