### PR TITLE
chore: deprecate some settings components [YTFRONT-5728]

### DIFF
--- a/packages/ui/src/server/middlewares/check-configuration.ts
+++ b/packages/ui/src/server/middlewares/check-configuration.ts
@@ -19,7 +19,7 @@ export function createConfigurationErrorsMidleware({ctx, config}: NodeKit) {
     const configurationErrors: Array<string> = [];
     if (process.env.YT_AUTH_CLUSTER_ID) {
         ctx.logError(
-            'The YT_AUTH_CLUSTER_ID environment variable is depricated, please replace it with ALLOW_PASSWORD_AUTH',
+            'The YT_AUTH_CLUSTER_ID environment variable is deprecated, please replace it with ALLOW_PASSWORD_AUTH',
         );
     }
 

--- a/packages/ui/src/shared/constants/settings.ts
+++ b/packages/ui/src/shared/constants/settings.ts
@@ -1,6 +1,9 @@
 import {createNS, createNestedNS} from '../utils/settings';
 
-// @depricated Please use `settings-types.ts` to add new options
+/**
+ * @deprecated
+ * Please use `settings-types.ts` to add new options.
+ */
 export const Page = {
     BAN: 'ban',
     JOB: 'job',
@@ -24,7 +27,10 @@ export const Page = {
     CHYT: 'chyt',
 } as const;
 
-// @depricated Please use `settings-types.ts` to add new options
+/**
+ * @deprecated
+ * Please use `settings-types.ts` to add new options.
+ */
 export const SettingName = {
     LOCAL: {
         FAVOURITES: 'favourites',
@@ -140,7 +146,10 @@ const SCHEDULING = createNestedNS('scheduling', GLOBAL);
 const QUERY_TRACKER = createNestedNS('queryTracker', GLOBAL);
 const CHYT = createNestedNS('chyt', GLOBAL);
 
-// @depricated Please use `settings-types.ts` to add new options
+/**
+ * @deprecated
+ * Please use `settings-types.ts` to add new options.
+ */
 export const NAMESPACES = {
     GLOBAL,
     LOCAL,

--- a/packages/ui/src/shared/constants/settings.ts
+++ b/packages/ui/src/shared/constants/settings.ts
@@ -1,6 +1,6 @@
 import {createNS, createNestedNS} from '../utils/settings';
 
-// @depricated Please use `settings-types.ts` to add new options
+// @deprecated Please use `settings-types.ts` to add new options
 export const Page = {
     BAN: 'ban',
     JOB: 'job',
@@ -24,7 +24,7 @@ export const Page = {
     CHYT: 'chyt',
 } as const;
 
-// @depricated Please use `settings-types.ts` to add new options
+// @deprecated Please use `settings-types.ts` to add new options
 export const SettingName = {
     LOCAL: {
         FAVOURITES: 'favourites',
@@ -139,7 +139,7 @@ const SCHEDULING = createNestedNS('scheduling', GLOBAL);
 const QUERY_TRACKER = createNestedNS('queryTracker', GLOBAL);
 const CHYT = createNestedNS('chyt', GLOBAL);
 
-// @depricated Please use `settings-types.ts` to add new options
+// @deprecated Please use `settings-types.ts` to add new options
 export const NAMESPACES = {
     GLOBAL,
     LOCAL,

--- a/packages/ui/src/shared/constants/settings.ts
+++ b/packages/ui/src/shared/constants/settings.ts
@@ -1,6 +1,9 @@
 import {createNS, createNestedNS} from '../utils/settings';
 
-// @deprecated Please use `settings-types.ts` to add new options
+/**
+ * @deprecated
+ * Please use `settings-types.ts` to add new options.
+ */
 export const Page = {
     BAN: 'ban',
     JOB: 'job',
@@ -24,7 +27,10 @@ export const Page = {
     CHYT: 'chyt',
 } as const;
 
-// @deprecated Please use `settings-types.ts` to add new options
+/**
+ * @deprecated
+ * Please use `settings-types.ts` to add new options.
+ */
 export const SettingName = {
     LOCAL: {
         FAVOURITES: 'favourites',
@@ -139,7 +145,10 @@ const SCHEDULING = createNestedNS('scheduling', GLOBAL);
 const QUERY_TRACKER = createNestedNS('queryTracker', GLOBAL);
 const CHYT = createNestedNS('chyt', GLOBAL);
 
-// @deprecated Please use `settings-types.ts` to add new options
+/**
+ * @deprecated
+ * Please use `settings-types.ts` to add new options.
+ */
 export const NAMESPACES = {
     GLOBAL,
     LOCAL,

--- a/packages/ui/src/ui/containers/SettingsMenu/BooleanSettingItem.tsx
+++ b/packages/ui/src/ui/containers/SettingsMenu/BooleanSettingItem.tsx
@@ -8,9 +8,12 @@ import {type KeysByType} from '../../../@types/types';
 
 import {selectSettingsData} from '../../store/selectors/settings/settings-base';
 import {setSettingByKey} from '../../store/actions/settings';
-import {SettingsItemLayot, type SettingsItemLayotProps} from './SettingsItemLayout';
+import {SettingsItemLayout, type SettingsItemLayoutProps} from './SettingsItemLayout';
 
-export type BooleanSettingItemProps<T> = {settingKey: T} & Omit<SettingsItemLayotProps, 'children'>;
+export type BooleanSettingItemProps<T> = {settingKey: T} & Omit<
+    SettingsItemLayoutProps,
+    'children'
+>;
 
 export function BooleanSettingItem<T extends KeysByType<DescribedSettings, boolean>>({
     settingKey,
@@ -20,7 +23,7 @@ export function BooleanSettingItem<T extends KeysByType<DescribedSettings, boole
     const {[settingKey]: checked} = useSelector(selectSettingsData);
 
     return (
-        <SettingsItemLayot {...rest}>
+        <SettingsItemLayout {...rest}>
             <Checkbox
                 content={rest.title}
                 checked={Boolean(checked)}
@@ -29,6 +32,6 @@ export function BooleanSettingItem<T extends KeysByType<DescribedSettings, boole
                 }}
                 qa={settingKey}
             />
-        </SettingsItemLayot>
+        </SettingsItemLayout>
     );
 }

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsItemLayout.tsx
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsItemLayout.tsx
@@ -5,7 +5,7 @@ import './SettingsItemLayout.scss';
 
 const block = cn('yt-settings-item');
 
-export type SettingsItemLayotProps = {
+export type SettingsItemLayoutProps = {
     children: React.ReactNode;
 
     title?: string;
@@ -13,7 +13,12 @@ export type SettingsItemLayotProps = {
     oneLine?: boolean;
 };
 
-export function SettingsItemLayot({title, children, description, oneLine}: SettingsItemLayotProps) {
+export function SettingsItemLayout({
+    title,
+    children,
+    description,
+    oneLine,
+}: SettingsItemLayoutProps) {
     return (
         <div
             className={block({

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuInput.js
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuInput.js
@@ -75,4 +75,10 @@ const mapStateToProps = (state) => {
     };
 };
 
+/**
+ * @deprecated
+ * Uses the legacy `settingName`/`settingNS` pattern.
+ * There is no by-key replacement yet — a new component needs to be implemented following the
+ * `settingKey` pattern, see `BooleanSettingItem` for reference.
+ */
 export default connect(mapStateToProps, {setSetting})(SettingsMenuInput);

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuItem.js
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuItem.js
@@ -94,4 +94,10 @@ function mapStateToProps(state) {
     };
 }
 
+/**
+ * @deprecated
+ * Uses the legacy `settingName`/`settingNS` pattern.
+ * Use `BooleanSettingItem` instead. Note: it does not yet support the
+ * `useSwitch`/`annotationHighlight` variants of this component — extend it if you need those.
+ */
 export default connect(mapStateToProps, {setSetting})(SettingsMenuItem);

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuRadio.tsx
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuRadio.tsx
@@ -23,6 +23,11 @@ interface BaseProps {
     get(): unknown;
 }
 
+/**
+ * @deprecated
+ * Uses the legacy `settingName`/`settingNS` pattern.
+ * Use `SettingsMenuRadioByKey` instead.
+ */
 export const SettingsMenuRadioBase = (props: BaseProps) => {
     const {
         name,
@@ -123,4 +128,9 @@ const mapStateToProps = (state: RootState) => {
 
 const connector = connect(mapStateToProps, {setSetting});
 
+/**
+ * @deprecated
+ * Uses the legacy `settingName`/`settingNS` pattern.
+ * Use `SettingsMenuRadioByKey` instead.
+ */
 export default connector(SettingsMenuRadio);

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuSelect.tsx
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuSelect.tsx
@@ -14,7 +14,7 @@ import SelectFacade, {
 import {setSettingByKey} from '../../store/actions/settings';
 import {selectSettingsData} from '../../store/selectors/settings/settings-base';
 
-import {SettingsItemLayot, type SettingsItemLayotProps} from './SettingsItemLayout';
+import {SettingsItemLayout, type SettingsItemLayoutProps} from './SettingsItemLayout';
 
 import './SettingsMenu.scss';
 
@@ -125,7 +125,7 @@ export function SettingMenuMultiSelectByKey<
 }
 
 type SettingsMenuRadioByKeyProps<K extends KeysByType<DescribedSettings, string>> = Omit<
-    SettingsItemLayotProps,
+    SettingsItemLayoutProps,
     'children'
 > & {
     settingKey: K;
@@ -140,14 +140,14 @@ export function SettingsMenuRadioByKey<K extends KeysByType<DescribedSettings, s
     const {value, onUpdate} = useSettingByKey(settingKey);
 
     return (
-        <SettingsItemLayot {...rest}>
+        <SettingsItemLayout {...rest}>
             <SegmentedRadioGroup
                 options={options}
                 value={value}
                 onUpdate={onUpdate}
                 qa={settingKey}
             />
-        </SettingsItemLayot>
+        </SettingsItemLayout>
     );
 }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/pWeQXfw-7ZcdGa
<!-- nda-end -->  ## Summary by Sourcery

Deprecate legacy settings APIs and standardize the settings item layout naming.

Bug Fixes:
- Correct spelling in the deprecated environment-variable warning.

Enhancements:
- Mark legacy settings constants and components as deprecated, with guidance toward key-based replacements.
- Rename the settings item layout component and its props to use the correct `Layout` spelling across current consumers.