### PR TITLE
fix(System): word 'nvme' should be in UPPERCASE [YTFRONT-5534]

### DIFF
--- a/packages/components/src/utils/hammer/format.js
+++ b/packages/components/src/utils/hammer/format.js
@@ -43,6 +43,7 @@ function postformat(value) {
         ['Yamr', 'YaMR'],
         ['Io', 'IO'],
         ['Ssd', 'SSD'],
+        ['nvme', 'NVME'],
         ['hdd', 'HDD'],
         ['Rpc', 'RPC'],
         ['VCPU', 'vCPU'],


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Normalize the 'nvme' label to uppercase 'NVME' in the postformat utility for display consistency.