### PR TITLE
chore: rename components selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/pages/components/Components/ComponentsTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/components/Components/ComponentsTopRowContent.tsx
@@ -6,7 +6,7 @@ import {Breadcrumbs} from '@gravity-ui/uikit';
 import {Tab as ComponentsTab} from '../../../constants/components/main';
 import {Page} from '../../../constants/index';
 import {RowWithName} from '../../../containers/AppNavigation/TopRowContent/SectionName';
-import {nodeHostSelector} from '../../../store/selectors/components/node/node';
+import {selectNodeHost} from '../../../store/selectors/components/node/node';
 import {selectCluster} from '../../../store/selectors/global';
 
 import './ComponentsTopRowContent.scss';
@@ -35,7 +35,7 @@ function ComponentsNodeTopRowContent() {
 
 function ComponentsBreadcrumbs() {
     const cluster = useSelector(selectCluster);
-    const nodeHost = useSelector(nodeHostSelector);
+    const nodeHost = useSelector(selectNodeHost);
     const history = useHistory();
     const items = React.useMemo(() => {
         const nodesPageUrl = `/${cluster}/${Page.COMPONENTS}/${ComponentsTab.NODES}`;

--- a/packages/ui/src/ui/pages/components/NodeMaintenanceModal/NodeMaintenanceModal.tsx
+++ b/packages/ui/src/ui/pages/components/NodeMaintenanceModal/NodeMaintenanceModal.tsx
@@ -14,8 +14,8 @@ import type {
     NodeResourceLimits,
 } from '../../../store/reducers/components/node-maintenance-modal';
 import {
-    getNodeMaintenanceModalInitialValues,
-    getNodeMaintenanceModalState,
+    selectNodeMaintenanceModalInitialValues,
+    selectNodeMaintenanceModalState,
 } from '../../../store/selectors/components/node-maintenance-modal';
 import {
     applyMaintenance,
@@ -37,8 +37,8 @@ export function NodeMaintenanceModal() {
     const dispatch = useDispatch();
     const [error, setError] = React.useState<YTError | undefined>();
 
-    const initialValues = useSelector(getNodeMaintenanceModalInitialValues);
-    const {address, component, resourceLimits} = useSelector(getNodeMaintenanceModalState);
+    const initialValues = useSelector(selectNodeMaintenanceModalInitialValues);
+    const {address, component, resourceLimits} = useSelector(selectNodeMaintenanceModalState);
 
     const allowedMaintenanceTypes: Array<AddMaintenanceParams['type']> =
         component === 'cluster_node'

--- a/packages/ui/src/ui/pages/components/tabs/Proxies/Proxies.js
+++ b/packages/ui/src/ui/pages/components/tabs/Proxies/Proxies.js
@@ -27,9 +27,9 @@ import {
     resetProxyState,
 } from '../../../../store/actions/components/proxies/proxies';
 import {
-    getRoles,
-    getStates,
-    getVisibleProxies,
+    selectRoles,
+    selectStates,
+    selectVisibleProxies,
 } from '../../../../store/selectors/components/proxies/proxies';
 import {mergeScreen, splitScreen as splitScreenAction} from '../../../../store/actions/global';
 import {proxiesTableColumnItems} from '../../../../utils/components/proxies/table';
@@ -373,9 +373,9 @@ const mapStateToProps = (state) => {
     } = components.proxies.proxies;
     const {splitScreen} = global;
 
-    const visibleProxies = getVisibleProxies(state);
-    const states = getStates(state);
-    const roles = getRoles(state);
+    const visibleProxies = selectVisibleProxies(state);
+    const states = selectStates(state);
+    const roles = selectRoles(state);
     const initialLoading = loading && !loaded;
 
     return {

--- a/packages/ui/src/ui/pages/components/tabs/Versions/VersionSummary.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/Versions/VersionSummary.tsx
@@ -9,10 +9,10 @@ import {DataTableYT} from '../../../../components/DataTableYT';
 import * as DT100 from '@gravity-ui/react-data-table';
 import DataTable from '@gravity-ui/react-data-table';
 import {
-    getHideOfflineValue,
-    getSummarySortState,
-    getVersions,
-    getVersionsSummaryData,
+    selectHideOfflineValue,
+    selectSummarySortState,
+    selectVersions,
+    selectVersionsSummaryData,
 } from '../../../../store/selectors/components/versions/versions_v2-ts';
 
 import hammer from '../../../../common/hammer';
@@ -338,10 +338,10 @@ const mapStateToProps = (state: RootState) => {
     const {loading, loaded} = state.components.versionsV2;
     const cluster = selectCluster(state);
 
-    const sortState = getSummarySortState(state);
+    const sortState = selectSummarySortState(state);
 
-    const visibleColumns = getVersions(state);
-    const items = getVersionsSummaryData(state);
+    const visibleColumns = selectVersions(state);
+    const items = selectVersionsSummaryData(state);
 
     return {
         loading: loading as boolean,
@@ -349,7 +349,7 @@ const mapStateToProps = (state: RootState) => {
         cluster,
         items,
         sortState,
-        checkedHideOffline: getHideOfflineValue(state),
+        checkedHideOffline: selectHideOfflineValue(state),
         visibleColumns,
     };
 };

--- a/packages/ui/src/ui/pages/components/tabs/Versions/VersionsV2.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/Versions/VersionsV2.tsx
@@ -22,11 +22,11 @@ import format from '../../../../common/hammer/format';
 import {VersionCellWithAction} from '../../../../pages/components/tabs/Versions/VersionCell';
 
 import {
-    getBannedSelectItems,
-    getStatesSelectItems,
-    getTypeSelectItems,
-    getVersionSelectItems,
-    getVisibleDetails,
+    selectBannedSelectItems,
+    selectStatesSelectItems,
+    selectTypeSelectItems,
+    selectVersionSelectItems,
+    selectVisibleDetails,
 } from '../../../../store/selectors/components/versions/versions_v2';
 import {
     changeBannedFilter,
@@ -299,11 +299,11 @@ const mapStateToProps = (state: RootState) => {
         details: allDetails,
     } = state.components.versionsV2;
 
-    const details = getVisibleDetails(state);
-    const versionSelectItems = getVersionSelectItems(state);
-    const typeSelectItems = getTypeSelectItems(state);
-    const stateSelectItems = getStatesSelectItems(state);
-    const bannedSelectItems = getBannedSelectItems(state);
+    const details = selectVisibleDetails(state);
+    const versionSelectItems = selectVersionSelectItems(state);
+    const typeSelectItems = selectTypeSelectItems(state);
+    const stateSelectItems = selectStatesSelectItems(state);
+    const bannedSelectItems = selectBannedSelectItems(state);
 
     const showingItems = details.length;
     const totalItems = allDetails.length;

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeAlerts/NodeAlerts.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeAlerts/NodeAlerts.tsx
@@ -4,7 +4,7 @@ import map_ from 'lodash/map';
 
 import cn from 'bem-cn-lite';
 
-import {getNodeAlerts} from '../../../../../store/selectors/components/node/node';
+import {selectNodeAlerts} from '../../../../../store/selectors/components/node/node';
 import {useSelector} from '../../../../../store/redux-hooks';
 import {YTAlertBlock} from '../../../../../components/Alert/Alert';
 
@@ -13,7 +13,7 @@ import './NodeAlerts.scss';
 const block = cn('yt-node-alerts');
 
 function NodeAlerts() {
-    const alerts = useSelector(getNodeAlerts);
+    const alerts = useSelector(selectNodeAlerts);
     return (
         <div>
             {map_(alerts, (item, index) => (

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeBundles/NodeBundles.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeBundles/NodeBundles.tsx
@@ -8,19 +8,19 @@ import {
     toggleNodeMemoryBundleExpanded,
 } from '../../../../../store/actions/components/node/memory';
 import {
-    getNodeMemoryLoaded,
-    getNodeMemoryLoading,
-    getNodeMemorySortOrder,
-    getNodeMemoryUsageBundlesItems,
+    selectNodeMemoryLoaded,
+    selectNodeMemoryLoading,
+    selectNodeMemorySortOrder,
+    selectNodeMemoryUsageBundlesItems,
 } from '../../../../../store/selectors/components/node/memory';
 import {SortState} from '../../../../../types';
 
 function NodeBundles() {
     const dispatch = useDispatch();
-    const loading = useSelector(getNodeMemoryLoading);
-    const loaded = useSelector(getNodeMemoryLoaded);
-    const items = useSelector(getNodeMemoryUsageBundlesItems);
-    const sortOrder = useSelector(getNodeMemorySortOrder);
+    const loading = useSelector(selectNodeMemoryLoading);
+    const loaded = useSelector(selectNodeMemoryLoaded);
+    const items = useSelector(selectNodeMemoryUsageBundlesItems);
+    const sortOrder = useSelector(selectNodeMemorySortOrder);
 
     const toggleExpandState = React.useCallback((item: (typeof items)[0]) => {
         dispatch(toggleNodeMemoryBundleExpanded(item.name));

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeBundlesTotal/NodeBundlesTotal.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeBundlesTotal/NodeBundlesTotal.tsx
@@ -11,10 +11,10 @@ import format from '../../../../../common/hammer/format';
 import {MetaTable, Tooltip} from '@ytsaurus/components';
 
 import {
-    getNodeMemoryUsageTotalRowCache,
-    getNodeMemoryUsageTotalStorePreload,
-    getNodeMemoryUsageTotalTableStatic,
-    getNodeMemoryUsageTotalTabletDynamic,
+    selectNodeMemoryUsageTotalRowCache,
+    selectNodeMemoryUsageTotalStorePreload,
+    selectNodeMemoryUsageTotalTableStatic,
+    selectNodeMemoryUsageTotalTabletDynamic,
 } from '../../../../../store/selectors/components/node/memory';
 import {
     STACKED_PROGRESS_BAR_COLORS,
@@ -28,10 +28,10 @@ const block = cn('node-bundles-total');
 const progressClass = block('progress');
 
 function NodeBundlesTotal() {
-    const tabletDynamic = useSelector(getNodeMemoryUsageTotalTabletDynamic) || {};
-    const tabletStatic = useSelector(getNodeMemoryUsageTotalTableStatic) || {};
-    const rowCache = useSelector(getNodeMemoryUsageTotalRowCache) || {};
-    const storePreload = useSelector(getNodeMemoryUsageTotalStorePreload);
+    const tabletDynamic = useSelector(selectNodeMemoryUsageTotalTabletDynamic) || {};
+    const tabletStatic = useSelector(selectNodeMemoryUsageTotalTableStatic) || {};
+    const rowCache = useSelector(selectNodeMemoryUsageTotalRowCache) || {};
+    const storePreload = useSelector(selectNodeMemoryUsageTotalStorePreload);
 
     return (
         <div className={block(null, 'elements-section')}>

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeGeneralTab/NodeGeneralTab.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeGeneralTab/NodeGeneralTab.tsx
@@ -12,7 +12,7 @@ import NodeResources, {
 import NodeStorage, {
     hasStorageMeta,
 } from '../../../../../pages/components/tabs/node/NodeStorage/NodeStorage';
-import {nodeSelector} from '../../../../../store/selectors/components/node/node';
+import {selectNode} from '../../../../../store/selectors/components/node/node';
 
 import './NodeGeneralTab.scss';
 import {YTAlertBlock} from '../../../../../components/Alert/Alert';
@@ -20,7 +20,7 @@ import {YTAlertBlock} from '../../../../../components/Alert/Alert';
 const block = cn('node-general');
 
 function NodeGeneralTab(): ReturnType<React.VFC> {
-    const {node} = useSelector(nodeSelector);
+    const {node} = useSelector(selectNode);
 
     if (!node) {
         return null;

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeLocations/NodeLocations.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeLocations/NodeLocations.tsx
@@ -7,7 +7,7 @@ import {Progress} from '@gravity-ui/uikit';
 import format from '../../../../../common/hammer/format';
 import {ClipboardButton} from '@ytsaurus/components';
 import {DataTableYT} from '../../../../../components/DataTableYT';
-import {nodeSelector} from '../../../../../store/selectors/components/node/node';
+import {selectNode} from '../../../../../store/selectors/components/node/node';
 import Label from '../../../../../components/Label';
 
 interface LocationInfo {
@@ -105,7 +105,7 @@ const columns: Array<Column<LocationInfo>> = [
 ];
 
 function NodeLocations(): ReturnType<React.VFC> {
-    const {node} = useSelector(nodeSelector);
+    const {node} = useSelector(selectNode);
 
     if (!(node && node.locations.length > 0)) {
         return null;

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeMemoryUsage/NodeMemoryUsage.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeMemoryUsage/NodeMemoryUsage.tsx
@@ -7,8 +7,8 @@ import NodeBundles from '../../../../../pages/components/tabs/node/NodeBundles/N
 import NodeTables from '../../../../../pages/components/tabs/node/NodeTables/NodeTables';
 import {loadNodeMemoryUsage} from '../../../../../store/actions/components/node/memory';
 import {
-    getNodeMemoryError,
-    getNodeMemoryViewMode,
+    selectNodeMemoryError,
+    selectNodeMemoryViewMode,
 } from '../../../../../store/selectors/components/node/memory';
 import {useUpdater} from '../../../../../hooks/use-updater';
 import {YTErrorBlock} from '../../../../../components/Error/Error';
@@ -26,7 +26,7 @@ interface Props extends RouteComponentProps<RouteParams> {}
 function NodeMemoryUsage({match}: Props): ReturnType<React.VFC> {
     const dispatch = useDispatch();
 
-    const error = useSelector(getNodeMemoryError);
+    const error = useSelector(selectNodeMemoryError);
 
     const host = decodeURIComponent(match.params.host);
 
@@ -36,7 +36,7 @@ function NodeMemoryUsage({match}: Props): ReturnType<React.VFC> {
 
     useUpdater(updateFn, {timeout: 15 * 1000});
 
-    const viewMode = useSelector(getNodeMemoryViewMode);
+    const viewMode = useSelector(selectNodeMemoryViewMode);
 
     return (
         <div className={block()}>

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeMemoryUsage/NodeMemoryUsageToolbar.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeMemoryUsage/NodeMemoryUsageToolbar.tsx
@@ -4,8 +4,8 @@ import cn from 'bem-cn-lite';
 
 import CustomRadioButton from '../../../../../components/RadioButton/RadioButton';
 import {
-    getNodeMemoryFilter,
-    getNodeMemoryViewMode,
+    selectNodeMemoryFilter,
+    selectNodeMemoryViewMode,
 } from '../../../../../store/selectors/components/node/memory';
 import {setNodeMemoryFilters} from '../../../../../store/actions/components/node/memory';
 import Filter from '../../../../../components/Filter/Filter';
@@ -16,8 +16,8 @@ const block = cn('node-memory-usage-toolbar');
 
 function NodeMemoryUsageToolbar() {
     const dispatch = useDispatch();
-    const viewMode = useSelector(getNodeMemoryViewMode);
-    const filter = useSelector(getNodeMemoryFilter);
+    const viewMode = useSelector(selectNodeMemoryViewMode);
+    const filter = useSelector(selectNodeMemoryFilter);
 
     const handleViewMode = React.useCallback((value: string) => {
         dispatch(

--- a/packages/ui/src/ui/pages/components/tabs/node/NodePage.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodePage.tsx
@@ -14,7 +14,7 @@ import {loadNodeAttributes} from '../../../../store/actions/components/node/node
 import {useUpdater} from '../../../../hooks/use-updater';
 import {makeTabProps} from '../../../../utils';
 import type {RootState} from '../../../../store/reducers';
-import {selectNodeAlertCount, selectNode} from '../../../../store/selectors/components/node/node';
+import {selectNode, selectNodeAlertCount} from '../../../../store/selectors/components/node/node';
 import {selectSortedItems} from '../../../../store/selectors/components/nodes/node-card';
 import NodeMeta from './NodeMeta/NodeMeta';
 

--- a/packages/ui/src/ui/pages/components/tabs/node/NodePage.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodePage.tsx
@@ -14,7 +14,7 @@ import {loadNodeAttributes} from '../../../../store/actions/components/node/node
 import {useUpdater} from '../../../../hooks/use-updater';
 import {makeTabProps} from '../../../../utils';
 import type {RootState} from '../../../../store/reducers';
-import {getNodeAlertCount, nodeSelector} from '../../../../store/selectors/components/node/node';
+import {selectNodeAlertCount, selectNode} from '../../../../store/selectors/components/node/node';
 import {getSortedItems} from '../../../../store/selectors/components/nodes/node-card';
 import NodeMeta from './NodeMeta/NodeMeta';
 
@@ -35,10 +35,10 @@ export interface NodeDetailsProps extends RouteComponentProps<RouteParams> {}
 function NodePage({match}: NodeDetailsProps): ReturnType<React.VFC> {
     const dispatch = useDispatch();
 
-    const {node, loading, loaded, error, errorData} = useSelector(nodeSelector);
+    const {node, loading, loaded, error, errorData} = useSelector(selectNode);
 
     const host = decodeURIComponent(match.params.host);
-    const alertCount = useSelector(getNodeAlertCount);
+    const alertCount = useSelector(selectNodeAlertCount);
 
     const updateFn = React.useCallback(() => {
         dispatch(loadNodeAttributes(host));

--- a/packages/ui/src/ui/pages/components/tabs/node/NodePage.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodePage.tsx
@@ -15,7 +15,7 @@ import {useUpdater} from '../../../../hooks/use-updater';
 import {makeTabProps} from '../../../../utils';
 import type {RootState} from '../../../../store/reducers';
 import {selectNodeAlertCount, selectNode} from '../../../../store/selectors/components/node/node';
-import {getSortedItems} from '../../../../store/selectors/components/nodes/node-card';
+import {selectSortedItems} from '../../../../store/selectors/components/nodes/node-card';
 import NodeMeta from './NodeMeta/NodeMeta';
 
 import './NodePage.scss';
@@ -48,7 +48,7 @@ function NodePage({match}: NodeDetailsProps): ReturnType<React.VFC> {
 
     const initialLoading = loading && (!loaded || host !== node?.host);
 
-    const tabletSlots = useSelector((state: RootState) => node && getSortedItems(state, {node}));
+    const tabletSlots = useSelector((state: RootState) => node && selectSortedItems(state, {node}));
 
     const matchUrl = match.url;
     const tabProps = React.useMemo(

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeTables/NodeTables.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeTables/NodeTables.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 
 import {
-    getNodeMemoryLoaded,
-    getNodeMemoryLoading,
-    getNodeMemoryUsageTablesItemsSorted,
-    getNodeMemoryUsageTablesSortOrder,
+    selectNodeMemoryLoaded,
+    selectNodeMemoryLoading,
+    selectNodeMemoryUsageTablesItemsSorted,
+    selectNodeMemoryUsageTablesSortOrder,
 } from '../../../../../store/selectors/components/node/memory';
 import NodeMemoryDetailsTable from '../NodeMemoryDetailsTable/NodeMemoryDetailsTable';
 import {
@@ -16,10 +16,10 @@ import {SortState} from '../../../../../types';
 
 function NodeTables() {
     const dispatch = useDispatch();
-    const loading = useSelector(getNodeMemoryLoading);
-    const loaded = useSelector(getNodeMemoryLoaded);
-    const items = useSelector(getNodeMemoryUsageTablesItemsSorted);
-    const sortOrder = useSelector(getNodeMemoryUsageTablesSortOrder);
+    const loading = useSelector(selectNodeMemoryLoading);
+    const loaded = useSelector(selectNodeMemoryLoaded);
+    const items = useSelector(selectNodeMemoryUsageTablesItemsSorted);
+    const sortOrder = useSelector(selectNodeMemoryUsageTablesSortOrder);
 
     const handleSort = React.useCallback((sortOrder: Array<SortState>) => {
         dispatch(setNodeMemoryTablesSort(sortOrder));

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeTabletSlotsTab/NodeTabletSlotsTab.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeTabletSlotsTab/NodeTabletSlotsTab.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 
 import NodeTabletSlots from '../../../../../pages/components/tabs/node/NodeTabletSlots/NodeTabletSlots';
 import type {RootState} from '../../../../../store/reducers';
-import {getSortedItems} from '../../../../../store/selectors/components/nodes/node-card';
+import {selectSortedItems} from '../../../../../store/selectors/components/nodes/node-card';
 import {selectNode} from '../../../../../store/selectors/components/node/node';
 
 function NodeTabletSlotsTab(): ReturnType<React.VFC> {
     const {node} = useSelector(selectNode);
-    const tabletSlots = useSelector((state: RootState) => node && getSortedItems(state, {node}));
+    const tabletSlots = useSelector((state: RootState) => node && selectSortedItems(state, {node}));
 
     if (!(node && tabletSlots.length > 0)) {
         return null;

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeTabletSlotsTab/NodeTabletSlotsTab.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeTabletSlotsTab/NodeTabletSlotsTab.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import NodeTabletSlots from '../../../../../pages/components/tabs/node/NodeTabletSlots/NodeTabletSlots';
 import type {RootState} from '../../../../../store/reducers';
 import {getSortedItems} from '../../../../../store/selectors/components/nodes/node-card';
-import {nodeSelector} from '../../../../../store/selectors/components/node/node';
+import {selectNode} from '../../../../../store/selectors/components/node/node';
 
 function NodeTabletSlotsTab(): ReturnType<React.VFC> {
-    const {node} = useSelector(nodeSelector);
+    const {node} = useSelector(selectNode);
     const tabletSlots = useSelector((state: RootState) => node && getSortedItems(state, {node}));
 
     if (!(node && tabletSlots.length > 0)) {

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeUnrecognizedOptions/NodeUnrecognizedOptions.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeUnrecognizedOptions/NodeUnrecognizedOptions.tsx
@@ -8,8 +8,8 @@ const block = cn('node-unrecognized-options');
 
 import {loadNodeUnrecognizedOptions} from '../../../../../store/actions/components/node/unrecognized-options';
 import {
-    getNodeUnrecognizedOptionsData,
-    getNodeUnrecognizedOptionsError,
+    selectNodeUnrecognizedOptionsData,
+    selectNodeUnrecognizedOptionsError,
 } from '../../../../../store/selectors/components/node/unrecognized-options';
 import {YTErrorBlock} from '../../../../../components/Error/Error';
 import Yson from '../../../../../components/Yson/Yson';
@@ -23,8 +23,8 @@ export function NodeUnrecognizedOptions({host}: {host: string}) {
         dispatch(loadNodeUnrecognizedOptions(host));
     }, [host, dispatch]);
 
-    const data = useSelector(getNodeUnrecognizedOptionsData);
-    const error = useSelector(getNodeUnrecognizedOptionsError);
+    const data = useSelector(selectNodeUnrecognizedOptionsData);
+    const error = useSelector(selectNodeUnrecognizedOptionsError);
 
     const unipikaSettings = useSelector(getNodeUnrecognizedOptionsYsonSettings);
 

--- a/packages/ui/src/ui/pages/components/tabs/nodes/FilterPresets/FiltersPresets.js
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/FilterPresets/FiltersPresets.js
@@ -7,7 +7,7 @@ import map_ from 'lodash/map';
 
 import Icon from '../../../../../components/Icon/Icon';
 
-import {getPresets} from '../../../../../store/selectors/components/nodes/filters-presets';
+import {selectPresets} from '../../../../../store/selectors/components/nodes/filters-presets';
 import {applyPreset, removePreset} from '../../../../../store/actions/components/nodes/nodes';
 
 import './FiltersPresets.scss';
@@ -80,6 +80,6 @@ class FiltersPresets extends Component {
     }
 }
 
-const mapStateToProps = (state) => ({presets: getPresets(state)});
+const mapStateToProps = (state) => ({presets: selectPresets(state)});
 
 export default connect(mapStateToProps, {applyPreset, removePreset})(FiltersPresets);

--- a/packages/ui/src/ui/pages/components/tabs/nodes/NodeCard/NodeCard.js
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/NodeCard/NodeCard.js
@@ -19,7 +19,7 @@ import {Template} from '../../../../../components/MetaTable/templates/Template';
 import CollapsibleSection from '../../../../../components/CollapsibleSection/CollapsibleSection';
 
 import {loadNodeAttributes} from '../../../../../store/actions/components/node/node';
-import {getSortedItems} from '../../../../../store/selectors/components/nodes/node-card';
+import {selectSortedItems} from '../../../../../store/selectors/components/nodes/node-card';
 
 import {selectNode} from '../../../../../store/selectors/components/node/node';
 import {selectCluster, selectCurrentClusterConfig} from '../../../../../store/selectors/global';
@@ -342,7 +342,7 @@ const mapStateToProps = (state) => {
         errorData,
         loaded,
         node,
-        tabletSlots: node && getSortedItems(state, {node}),
+        tabletSlots: node && selectSortedItems(state, {node}),
         clusterConfig: selectCurrentClusterConfig(state),
     };
 };

--- a/packages/ui/src/ui/pages/components/tabs/nodes/NodeCard/NodeCard.js
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/NodeCard/NodeCard.js
@@ -21,7 +21,7 @@ import CollapsibleSection from '../../../../../components/CollapsibleSection/Col
 import {loadNodeAttributes} from '../../../../../store/actions/components/node/node';
 import {getSortedItems} from '../../../../../store/selectors/components/nodes/node-card';
 
-import {nodeSelector} from '../../../../../store/selectors/components/node/node';
+import {selectNode} from '../../../../../store/selectors/components/node/node';
 import {selectCluster, selectCurrentClusterConfig} from '../../../../../store/selectors/global';
 import hammer from '../../../../../common/hammer';
 import NodeCpuAndMemory, {
@@ -333,7 +333,7 @@ class NodeCard extends Component {
 }
 
 const mapStateToProps = (state) => {
-    const {node, loaded, error, errorData} = nodeSelector(state);
+    const {node, loaded, error, errorData} = selectNode(state);
     const cluster = selectCluster(state);
 
     return {

--- a/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
@@ -32,7 +32,7 @@ import NodeCard from '../NodeCard/NodeCard';
 import {ComponentsNodeTypeSelector} from '../../../../../pages/system/Nodes/NodeTypeSelector';
 
 import {
-    getComponentNodesFiltersCount,
+    selectComponentNodesFiltersCount,
     selectComponentNodesTableProps,
     selectComponentsNodesNodeTypes,
     selectRequiredAttributes,
@@ -407,7 +407,7 @@ const mapStateToProps = (state: RootState) => {
         nodesTableProps,
         sideBarEnabled,
         nodeTypes: selectComponentsNodesNodeTypes(state),
-        filterCount: getComponentNodesFiltersCount(state),
+        filterCount: selectComponentNodesFiltersCount(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
@@ -33,10 +33,10 @@ import {ComponentsNodeTypeSelector} from '../../../../../pages/system/Nodes/Node
 
 import {
     getComponentNodesFiltersCount,
-    getComponentNodesTableProps,
-    getComponentsNodesNodeTypes,
-    getRequiredAttributes,
-    getVisibleNodes,
+    selectComponentNodesTableProps,
+    selectComponentsNodesNodeTypes,
+    selectRequiredAttributes,
+    selectVisibleNodes,
 } from '../../../../../store/selectors/components/nodes/nodes';
 import {getSelectedColumns} from '../../../../../store/selectors/settings';
 import {getSettingsEnableSideBar} from '../../../../../store/selectors/settings/settings-ts';
@@ -79,8 +79,8 @@ type State = {
 function NodesUpdater() {
     const dispatch = useDispatch();
 
-    const attributes = useSelector(getRequiredAttributes);
-    const nodeTypes = useSelector(getComponentsNodesNodeTypes);
+    const attributes = useSelector(selectRequiredAttributes);
+    const nodeTypes = useSelector(selectComponentsNodesNodeTypes);
 
     const updateFn = React.useCallback(
         (...args: Parameters<typeof getNodes>) => {
@@ -382,11 +382,11 @@ const mapStateToProps = (state: RootState) => {
     const {contentMode, nodes, loading, loaded, error, errorData, hostFilter} =
         state.components.nodes.nodes;
 
-    const visibleNodes = getVisibleNodes(state);
+    const visibleNodes = selectVisibleNodes(state);
     const selectedColumns = getSelectedColumns(state) || defaultColumns;
     const initialLoading = loading && !loaded;
 
-    const nodesTableProps = getComponentNodesTableProps(state);
+    const nodesTableProps = selectComponentNodesTableProps(state);
 
     const sideBarEnabled = getSettingsEnableSideBar(state);
 
@@ -406,7 +406,7 @@ const mapStateToProps = (state: RootState) => {
         initialLoading,
         nodesTableProps,
         sideBarEnabled,
-        nodeTypes: getComponentsNodesNodeTypes(state),
+        nodeTypes: selectComponentsNodesNodeTypes(state),
         filterCount: getComponentNodesFiltersCount(state),
     };
 };

--- a/packages/ui/src/ui/pages/components/tabs/nodes/SetupModal/SetupModal.js
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/SetupModal/SetupModal.js
@@ -29,7 +29,7 @@ import {parseBytes} from '../../../../../utils/parse/parse-bytes';
 import {getMediumListNoCache} from '../../../../../store/selectors/thor';
 import TagsFilter from './TagsFilter/TagsFilter';
 import {
-    getComponentNodesFiltersSetup,
+    selectComponentNodesFiltersSetup,
     selectComponentNodesRacks,
     selectComponentNodesTags,
 } from '../../../../../store/selectors/components/nodes/nodes';
@@ -812,7 +812,7 @@ export class SetupModal extends Component {
 
 const mapStateToProps = (state) => {
     return {
-        setup: getComponentNodesFiltersSetup(state),
+        setup: selectComponentNodesFiltersSetup(state),
         mediumList: getMediumListNoCache(state),
         nodeTags: selectComponentNodesTags(state),
         nodeRacks: selectComponentNodesRacks(state),

--- a/packages/ui/src/ui/pages/components/tabs/nodes/SetupModal/SetupModal.js
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/SetupModal/SetupModal.js
@@ -30,12 +30,12 @@ import {getMediumListNoCache} from '../../../../../store/selectors/thor';
 import TagsFilter from './TagsFilter/TagsFilter';
 import {
     getComponentNodesFiltersSetup,
-    getComponentNodesRacks,
-    getComponentNodesTags,
+    selectComponentNodesRacks,
+    selectComponentNodesTags,
 } from '../../../../../store/selectors/components/nodes/nodes';
 import {
     COMPONENTS_AVAILABLE_STATES,
-    getComponentNodesFilterSetupStateValue,
+    selectComponentNodesFilterSetupStateValue,
 } from '../../../../../store/selectors/components/nodes/nodes/data';
 
 import './SetupModal.scss';
@@ -814,10 +814,10 @@ const mapStateToProps = (state) => {
     return {
         setup: getComponentNodesFiltersSetup(state),
         mediumList: getMediumListNoCache(state),
-        nodeTags: getComponentNodesTags(state),
-        nodeRacks: getComponentNodesRacks(state),
+        nodeTags: selectComponentNodesTags(state),
+        nodeRacks: selectComponentNodesRacks(state),
         nodeStates: COMPONENTS_AVAILABLE_STATES,
-        stateValue: getComponentNodesFilterSetupStateValue(state),
+        stateValue: selectComponentNodesFilterSetupStateValue(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/system/Nodes/NodeTypeSelector.tsx
+++ b/packages/ui/src/ui/pages/system/Nodes/NodeTypeSelector.tsx
@@ -7,7 +7,7 @@ import {NODE_TYPE_ITEMS} from '../../../constants/components/nodes/nodes';
 import {getSystemNodesNodeTypesToLoad} from '../../../store/selectors/system/nodes';
 import {setSysmetNodesNodeType} from '../../../store/actions/system/nodes-ts';
 import {NODE_TYPE, NodeType} from '../../../../shared/constants/system';
-import {getComponentsNodesNodeTypes} from '../../../store/selectors/components/nodes/nodes';
+import {selectComponentsNodesNodeTypes} from '../../../store/selectors/components/nodes/nodes';
 import {componentsNodesSetNodeTypes} from '../../../store/actions/components/nodes/nodes';
 import {updateListWithAll} from '../../../utils';
 
@@ -53,7 +53,7 @@ export function SystemNodeTypeSelector() {
 export function ComponentsNodeTypeSelector({className}: {className?: string}) {
     const dispatch = useDispatch();
 
-    const value = useSelector(getComponentsNodesNodeTypes);
+    const value = useSelector(selectComponentsNodesNodeTypes);
     return (
         <NodeTypeSelector
             className={className}

--- a/packages/ui/src/ui/store/actions/components/node-maintenance-modal.ts
+++ b/packages/ui/src/ui/store/actions/components/node-maintenance-modal.ts
@@ -12,8 +12,8 @@ import {
     NodeResourceLimits,
 } from '../../../store/reducers/components/node-maintenance-modal';
 import {
-    isAllowedMaintenanceApiNodes,
-    isAllowedMaintenanceApiProxies,
+    selectIsAllowedMaintenanceApiNodes,
+    selectIsAllowedMaintenanceApiProxies,
 } from '../../../store/selectors/components/node-maintenance-modal';
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {YTApiId, ytApiV3Id, ytApiV4Id} from '../../../rum/rum-wrap-api';
@@ -306,10 +306,10 @@ function isMaintenanceApiAllowedForComponent(
 ) {
     switch (component) {
         case 'cluster_node':
-            return isAllowedMaintenanceApiNodes(state);
+            return selectIsAllowedMaintenanceApiNodes(state);
         case 'http_proxy':
         case 'rpc_proxy':
-            return isAllowedMaintenanceApiProxies(state);
+            return selectIsAllowedMaintenanceApiProxies(state);
         default:
             return false;
     }

--- a/packages/ui/src/ui/store/actions/components/node/memory.ts
+++ b/packages/ui/src/ui/store/actions/components/node/memory.ts
@@ -10,8 +10,8 @@ import type {RootState} from '../../../../store/reducers';
 import type {NodeMemoryLoadAction} from '../../../../store/reducers/components/node/memory';
 import type {MemoryUsage} from '../../../../types/components/node';
 import {
-    getNodeMemoryCollapsedBundles,
-    getNodeMemoryStateHost,
+    selectNodeMemoryCollapsedBundles,
+    selectNodeMemoryStateHost,
 } from '../../../../store/selectors/components/node/memory';
 import {SortState} from '../../../../types';
 import {YTApiId, ytApiV3Id} from '../../../../rum/rum-wrap-api';
@@ -27,7 +27,7 @@ export function loadNodeMemoryUsage(host: string): NodeMemoryThunkAction {
                 path: `//sys/cluster_nodes/${host}/orchid/tablet_slot_manager/memory_usage_statistics`,
             })
             .then((memory: MemoryUsage) => {
-                const stateHost = getNodeMemoryStateHost(getState());
+                const stateHost = selectNodeMemoryStateHost(getState());
                 if (stateHost !== host) {
                     return;
                 }
@@ -38,7 +38,7 @@ export function loadNodeMemoryUsage(host: string): NodeMemoryThunkAction {
                 });
             })
             .catch((error: Error) => {
-                const stateHost = getNodeMemoryStateHost(getState());
+                const stateHost = selectNodeMemoryStateHost(getState());
                 if (stateHost !== host) {
                     return;
                 }
@@ -62,7 +62,7 @@ export function setNodeBundlesSort(sortOrder: Array<SortState>): NodeMemoryThunk
 
 export function toggleNodeMemoryBundleExpanded(name: string): NodeMemoryThunkAction {
     return (dispatch, getState) => {
-        const collapsedBundles = [...getNodeMemoryCollapsedBundles(getState())];
+        const collapsedBundles = [...selectNodeMemoryCollapsedBundles(getState())];
         const index = collapsedBundles.indexOf(name);
         if (index === -1) {
             collapsedBundles.push(name);

--- a/packages/ui/src/ui/store/actions/components/nodes/nodes.ts
+++ b/packages/ui/src/ui/store/actions/components/nodes/nodes.ts
@@ -12,8 +12,8 @@ import ypath from '../../../../common/thor/ypath';
 import {setSetting} from '../../../../store/actions/settings';
 import {NAMESPACES, SettingName} from '../../../../../shared/constants/settings';
 import {
-    selectRequiredAttributes,
     selectRacksFromAttributes,
+    selectRequiredAttributes,
     selectTagsFromAttributes,
 } from '../../../../store/selectors/components/nodes/nodes';
 import {getTemplates} from '../../../../store/selectors/settings';

--- a/packages/ui/src/ui/store/actions/components/nodes/nodes.ts
+++ b/packages/ui/src/ui/store/actions/components/nodes/nodes.ts
@@ -12,9 +12,9 @@ import ypath from '../../../../common/thor/ypath';
 import {setSetting} from '../../../../store/actions/settings';
 import {NAMESPACES, SettingName} from '../../../../../shared/constants/settings';
 import {
-    getRequiredAttributes,
-    useRacksFromAttributes,
-    useTagsFromAttributes,
+    selectRequiredAttributes,
+    selectRacksFromAttributes,
+    selectTagsFromAttributes,
 } from '../../../../store/selectors/components/nodes/nodes';
 import {getTemplates} from '../../../../store/selectors/settings';
 import type {RootState} from '../../../../store/reducers';
@@ -62,7 +62,7 @@ export function getNodes({
     attributes,
     nodeTypes,
 }: {
-    attributes: ReturnType<typeof getRequiredAttributes>;
+    attributes: ReturnType<typeof selectRequiredAttributes>;
     nodeTypes: Array<NodeType>;
 }): NodesThunkAction {
     return (dispatch) => {
@@ -208,8 +208,8 @@ export function getComponentsNodesFilterOptions(): NodesThunkAction {
         const state = getState();
 
         const attributes = compact_([
-            !useTagsFromAttributes(state) && 'tags',
-            !useRacksFromAttributes(state) && 'rack',
+            !selectTagsFromAttributes(state) && 'tags',
+            !selectRacksFromAttributes(state) && 'rack',
         ]);
 
         if (0 === attributes.length) {

--- a/packages/ui/src/ui/store/selectors/components/node-maintenance-modal.ts
+++ b/packages/ui/src/ui/store/selectors/components/node-maintenance-modal.ts
@@ -5,11 +5,11 @@ import {RootState} from '../../reducers';
 import {selectClusterUiConfig} from '../global';
 import {NodeResourceLimits} from '../../../store/reducers/components/node-maintenance-modal';
 
-export const getNodeMaintenanceModalState = (state: RootState) =>
+export const selectNodeMaintenanceModalState = (state: RootState) =>
     state.components.nodeMaintenanceModal;
 
-export const getNodeMaintenanceModalInitialValues = createSelector(
-    [getNodeMaintenanceModalState],
+export const selectNodeMaintenanceModalInitialValues = createSelector(
+    [selectNodeMaintenanceModalState],
     ({maintenance, resourceLimitsOverrides, role}) => {
         return {
             ...maintenance,
@@ -27,8 +27,8 @@ export const getNodeMaintenanceModalInitialValues = createSelector(
     },
 );
 
-export const isAllowedMaintenanceApiNodes = (state: RootState) =>
+export const selectIsAllowedMaintenanceApiNodes = (state: RootState) =>
     selectClusterUiConfig(state).enable_maintenance_api_nodes;
 
-export const isAllowedMaintenanceApiProxies = (state: RootState) =>
+export const selectIsAllowedMaintenanceApiProxies = (state: RootState) =>
     selectClusterUiConfig(state).enable_maintenance_api_proxies;

--- a/packages/ui/src/ui/store/selectors/components/node/memory.ts
+++ b/packages/ui/src/ui/store/selectors/components/node/memory.ts
@@ -18,44 +18,46 @@ import {selectCluster} from '../../../../store/selectors/global';
 import {SortState} from '../../../../types';
 import {orderTypeToOldSortState} from '../../../../utils/sort-helpers';
 
-export const nodeMemorySelector = (state: RootState) => state.components.node.memory;
+export const selectNodeMemory = (state: RootState) => state.components.node.memory;
 
-export const getNodeMemoryLoaded = (state: RootState) => state.components.node.memory.loaded;
+export const selectNodeMemoryLoaded = (state: RootState) => state.components.node.memory.loaded;
 
-export const getNodeMemoryLoading = (state: RootState) => state.components.node.memory.loading;
+export const selectNodeMemoryLoading = (state: RootState) => state.components.node.memory.loading;
 
-export const getNodeMemoryError = (state: RootState) => state.components.node.memory.error;
+export const selectNodeMemoryError = (state: RootState) => state.components.node.memory.error;
 
-export const getNodeMemoryViewMode = (state: RootState) => state.components.node.memory.viewMode;
+export const selectNodeMemoryViewMode = (state: RootState) => state.components.node.memory.viewMode;
 
-export const getNodeMemoryFilter = (state: RootState) => state.components.node.memory.filter;
+export const selectNodeMemoryFilter = (state: RootState) => state.components.node.memory.filter;
 
-export const getNodeMemoryStateHost = (state: RootState) => state.components.node.memory.host;
+export const selectNodeMemoryStateHost = (state: RootState) => state.components.node.memory.host;
 
-export const getNodeMemorySortOrder = (state: RootState) => state.components.node.memory.sortOrder;
+export const selectNodeMemorySortOrder = (state: RootState) =>
+    state.components.node.memory.sortOrder;
 
-export const getNodeMemoryCollapsedBundles = (state: RootState) =>
+export const selectNodeMemoryCollapsedBundles = (state: RootState) =>
     state.components.node.memory.collapsedBundles;
 
-const getNodeMemoryUsageTotal = (state: RootState) => state.components.node.memory.memory?.total;
+const selectNodeMemoryUsageTotal = (state: RootState) => state.components.node.memory.memory?.total;
 
-const getNodeMemoryUsageBundles = (state: RootState) =>
+const selectNodeMemoryUsageBundles = (state: RootState) =>
     state.components.node.memory.memory?.bundles;
 
-const getNodeMemoryUsageTables = (state: RootState) => state.components.node.memory.memory?.tables;
+const selectNodeMemoryUsageTables = (state: RootState) =>
+    state.components.node.memory.memory?.tables;
 
-export const getNodeMemoryUsageTablesSortOrder = (state: RootState) =>
+export const selectNodeMemoryUsageTablesSortOrder = (state: RootState) =>
     state.components.node.memory.tablesSortOrder;
 
-export const getNodeMemoryUsageTotalStorePreload = createSelector(
-    [getNodeMemoryUsageTotal],
+export const selectNodeMemoryUsageTotalStorePreload = createSelector(
+    [selectNodeMemoryUsageTotal],
     calculateStorePreload,
 );
 
-export const getNodeMemoryUsageTotalTableStatic = (state: RootState) =>
+export const selectNodeMemoryUsageTotalTableStatic = (state: RootState) =>
     state.components.node.memory.memory?.total.tablet_static;
 
-export const getNodeMemoryUsageTotalRowCache = (state: RootState) =>
+export const selectNodeMemoryUsageTotalRowCache = (state: RootState) =>
     state.components.node.memory.memory?.total.row_cache;
 
 function calculateStorePreload(total?: NodeMemoryUsagePreload) {
@@ -73,8 +75,8 @@ function calculateStorePreload(total?: NodeMemoryUsagePreload) {
     };
 }
 
-export const getNodeMemoryUsageTotalTabletDynamic = createSelector(
-    [getNodeMemoryUsageTotal],
+export const selectNodeMemoryUsageTotalTabletDynamic = createSelector(
+    [selectNodeMemoryUsageTotal],
     (total) => {
         const {active, passive, backing, usage, limit, ...others} = total?.tablet_dynamic || {};
 
@@ -104,8 +106,8 @@ export interface NodeMemoryInfo {
     url: string;
 }
 
-const getNodeMemoryUsageBundlesByName = createSelector(
-    [getNodeMemoryUsageBundles, selectCluster],
+const selectNodeMemoryUsageBundlesByName = createSelector(
+    [selectNodeMemoryUsageBundles, selectCluster],
     (bundles, cluster) => {
         const itemsByName: Record<string, NodeMemoryInfo> = {};
 
@@ -141,8 +143,8 @@ const getNodeMemoryUsageBundlesByName = createSelector(
     },
 );
 
-const getNodeMemoryUsageBundlesTreeRoot = createSelector(
-    [getNodeMemoryUsageBundles, getNodeMemoryUsageBundlesByName, selectCluster],
+const selectNodeMemoryUsageBundlesTreeRoot = createSelector(
+    [selectNodeMemoryUsageBundles, selectNodeMemoryUsageBundlesByName, selectCluster],
     (bundles, bundlesInfo, cluster) => {
         const itemsByName: Record<string, NodeMemoryInfo> = {...bundlesInfo};
 
@@ -172,8 +174,12 @@ const getNodeMemoryUsageBundlesTreeRoot = createSelector(
     },
 );
 
-export const getNodeMemoryUsageBundlesTreeRootFiltered = createSelector(
-    [getNodeMemoryUsageBundlesTreeRoot, getNodeMemoryCollapsedBundles, getNodeMemoryFilter],
+export const selectNodeMemoryUsageBundlesTreeRootFiltered = createSelector(
+    [
+        selectNodeMemoryUsageBundlesTreeRoot,
+        selectNodeMemoryCollapsedBundles,
+        selectNodeMemoryFilter,
+    ],
     (root, collapsedBundles, filter) => {
         const collapsed = new Set(collapsedBundles);
         let res: typeof root = {...root};
@@ -205,8 +211,8 @@ export const getNodeMemoryUsageBundlesTreeRootFiltered = createSelector(
     },
 );
 
-export const getNodeMemoryUsageBundlesItems = createSelector(
-    [getNodeMemoryUsageBundlesTreeRootFiltered, getNodeMemorySortOrder],
+export const selectNodeMemoryUsageBundlesItems = createSelector(
+    [selectNodeMemoryUsageBundlesTreeRootFiltered, selectNodeMemorySortOrder],
     (root, [sortOrder]) => {
         if (!root) {
             return [];
@@ -254,17 +260,17 @@ function sortTreeInPlace(root: TreeNode<NodeMemoryInfo, NodeMemoryInfo>, sortOrd
     }
 }
 
-const allowBundlesForTables = createSelector([getNodeMemoryUsageTables], (tables) => {
+const selectAllowBundlesForTables = createSelector([selectNodeMemoryUsageTables], (tables) => {
     const [first] = toArray_(tables);
     return first?.tablet_cell_bundle !== undefined;
 });
 
-const getNodeMemoryUsageTablesAndBundlesByName = createSelector(
+const selectNodeMemoryUsageTablesAndBundlesByName = createSelector(
     [
-        allowBundlesForTables,
-        getNodeMemoryUsageTables,
+        selectAllowBundlesForTables,
+        selectNodeMemoryUsageTables,
         selectCluster,
-        getNodeMemoryUsageBundlesByName,
+        selectNodeMemoryUsageBundlesByName,
     ],
     (allowBundles, tables, cluster, bundles) => {
         let maxRowCache = 0;
@@ -315,8 +321,8 @@ const getNodeMemoryUsageTablesAndBundlesByName = createSelector(
     },
 );
 
-export const getNodeMemoryUsageTablesTree = createSelector(
-    [getNodeMemoryUsageTablesAndBundlesByName],
+export const selectNodeMemoryUsageTablesTree = createSelector(
+    [selectNodeMemoryUsageTablesAndBundlesByName],
     (tablesAndBundles) => {
         const tree = prepareTree(tablesAndBundles, (item) => item.parent);
 
@@ -324,8 +330,8 @@ export const getNodeMemoryUsageTablesTree = createSelector(
     },
 );
 
-export const getNodeMemoryUsageTablesFiltered = createSelector(
-    [getNodeMemoryUsageTablesTree, getNodeMemoryCollapsedBundles, getNodeMemoryFilter],
+export const selectNodeMemoryUsageTablesFiltered = createSelector(
+    [selectNodeMemoryUsageTablesTree, selectNodeMemoryCollapsedBundles, selectNodeMemoryFilter],
     (root, collapsedBundles, filter) => {
         const collapsed = new Set(collapsedBundles);
         let res: typeof root;
@@ -357,8 +363,8 @@ export const getNodeMemoryUsageTablesFiltered = createSelector(
     },
 );
 
-export const getNodeMemoryUsageTablesItemsSorted = createSelector(
-    [getNodeMemoryUsageTablesFiltered, getNodeMemoryUsageTablesSortOrder],
+export const selectNodeMemoryUsageTablesItemsSorted = createSelector(
+    [selectNodeMemoryUsageTablesFiltered, selectNodeMemoryUsageTablesSortOrder],
     (root, [sortOrder]) => {
         if (sortOrder && root) {
             sortTreeInPlace(root, sortOrder);

--- a/packages/ui/src/ui/store/selectors/components/node/node.ts
+++ b/packages/ui/src/ui/store/selectors/components/node/node.ts
@@ -1,9 +1,10 @@
 import type {RootState} from '../../../../store/reducers/index';
 
-export const nodeSelector = (state: RootState) => state.components.node.node;
+export const selectNode = (state: RootState) => state.components.node.node;
 
-export const nodeHostSelector = (state: RootState) => nodeSelector(state).node?.host;
+export const selectNodeHost = (state: RootState) => selectNode(state).node?.host;
 
-export const getNodeAlertCount = (state: RootState) => state.components.node.node.node?.alertCount;
+export const selectNodeAlertCount = (state: RootState) =>
+    state.components.node.node.node?.alertCount;
 
-export const getNodeAlerts = (state: RootState) => state.components.node.node.node?.alerts;
+export const selectNodeAlerts = (state: RootState) => state.components.node.node.node?.alerts;

--- a/packages/ui/src/ui/store/selectors/components/node/unrecognized-options.ts
+++ b/packages/ui/src/ui/store/selectors/components/node/unrecognized-options.ts
@@ -1,6 +1,7 @@
 import {RootState} from '../../../reducers';
 
-export const getNodeUnrecognizedOptionsData = (state: RootState) =>
+export const selectNodeUnrecognizedOptionsData = (state: RootState) =>
     state.components.node.unrecognizedOptions.data;
-export const getNodeUnrecognizedOptionsError = (state: RootState) =>
+
+export const selectNodeUnrecognizedOptionsError = (state: RootState) =>
     state.components.node.unrecognizedOptions.error;

--- a/packages/ui/src/ui/store/selectors/components/nodes/filters-presets.js
+++ b/packages/ui/src/ui/store/selectors/components/nodes/filters-presets.js
@@ -9,11 +9,11 @@ const getDefaultPreset = () => ({
     isDefault: true,
 });
 
-const getSavedPresets = createSelector(getTemplates, (presets = {}) =>
+const selectSavedPresets = createSelector(getTemplates, (presets = {}) =>
     transform_(presets, (res, data, name) => res.push({name, data, isDefault: false}), []),
 );
 
-export const getPresets = createSelector(
-    [getDefaultPreset, getSavedPresets],
+export const selectPresets = createSelector(
+    [getDefaultPreset, selectSavedPresets],
     (defaultPreset, savedPresets) => [defaultPreset, ...savedPresets],
 );

--- a/packages/ui/src/ui/store/selectors/components/nodes/node-card.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/node-card.ts
@@ -6,12 +6,13 @@ import type {Node} from '../../../../store/reducers/components/nodes/nodes/node'
 import {nodeTableProps} from '../../../../utils/components/nodes/node';
 import hammer from '../../../../common/hammer';
 
-const getSortState = (state: RootState) => state.tables[COMPONENTS_NODES_NODE_TABLE_ID];
-const getTabletSlots = (_state: RootState, props: {node: Pick<Node, 'tabletSlots'>}) =>
+const selectSortState = (state: RootState) => state.tables[COMPONENTS_NODES_NODE_TABLE_ID];
+
+const selectTabletSlots = (_state: RootState, props: {node: Pick<Node, 'tabletSlots'>}) =>
     props.node.tabletSlots;
 
-export const getSortedItems = createSelector(
-    [getSortState, getTabletSlots],
+export const selectSortedItems = createSelector(
+    [selectSortState, selectTabletSlots],
     (sortState, tabletSlots) =>
         tabletSlots
             ? hammer.utils.sort(tabletSlots.raw, sortState, nodeTableProps.columns.items)

--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
@@ -30,32 +30,37 @@ import {
 } from './predicates';
 import {NODE_TYPE, NodeType} from '../../../../../../shared/constants/system';
 
-const getContentMode = (state: RootState) => state.components.nodes.nodes.contentMode;
-const getHostFilter = (state: RootState) => state.components.nodes.nodes.hostFilter.toLowerCase();
-const getSortState = (state: RootState) => state.tables[COMPONENTS_NODES_TABLE_ID];
-const getComponentsNodesNodeTypeRaw = (state: RootState) => state.components.nodes.nodes.nodeTypes;
+const selectContentMode = (state: RootState) => state.components.nodes.nodes.contentMode;
 
-const getCustomColumns = (state: RootState) => getSelectedColumns(state) || defaultColumns;
+const selectHostFilter = (state: RootState) =>
+    state.components.nodes.nodes.hostFilter.toLowerCase();
 
-const getMediumsPredicates = createSelector(
+const selectSortState = (state: RootState) => state.tables[COMPONENTS_NODES_TABLE_ID];
+
+const selectComponentsNodesNodeTypeRaw = (state: RootState) =>
+    state.components.nodes.nodes.nodeTypes;
+
+const selectCustomColumns = (state: RootState) => getSelectedColumns(state) || defaultColumns;
+
+const selectMediumsPredicates = createSelector(
     [getComponentNodesFiltersSetup, getMediumListNoCache],
     createMediumsPredicates,
 );
 
 const getPropertiesRequiredForMediums = createSelector(
-    [getMediumsPredicates],
+    [selectMediumsPredicates],
     (mediumsPredicates) => (mediumsPredicates.length > 0 ? (['IOWeight'] as const) : []),
 );
 
-const getFilteredByHost = createSelector([getNodes, getHostFilter], (nodes, hostFilter) => {
+const selectFilteredByHost = createSelector([getNodes, selectHostFilter], (nodes, hostFilter) => {
     const hostFilters = hostFilter.split(/\s+/);
     return filter_(nodes, (node) => {
         return some_(hostFilters, (hostFilter) => node?.host?.toLowerCase().includes(hostFilter));
     });
 });
 
-const getFilteredNodes = createSelector(
-    [getFilteredByHost, getComponentNodesFilterPredicates, getMediumsPredicates],
+const selectFilteredNodes = createSelector(
+    [selectFilteredByHost, getComponentNodesFilterPredicates, selectMediumsPredicates],
     (nodes, predicates, mediumsPredicates) => {
         const predicatesArray = predicates.concat(mediumsPredicates);
         if (!predicatesArray.length) {
@@ -69,8 +74,8 @@ const getFilteredNodes = createSelector(
     },
 );
 
-export const getVisibleNodes = createSelector(
-    [getFilteredNodes, getSortState, getMediumListNoCache, selectCluster],
+export const selectVisibleNodes = createSelector(
+    [selectFilteredNodes, selectSortState, getMediumListNoCache, selectCluster],
     (nodes, sortState, mediumList, cluster) => {
         return hammer.utils.sort(
             nodes.map((n) => ({...n, cluster})),
@@ -80,19 +85,19 @@ export const getVisibleNodes = createSelector(
     },
 );
 
-export const getComponentNodesTableProps = createSelector(
+export const selectComponentNodesTableProps = createSelector(
     [getMediumListNoCache],
     getNodeTablesProps,
 );
 
-const getVisibleColumns = createSelector(
-    [getComponentNodesTableProps, getContentMode, getCustomColumns],
+const selectVisibleColumns = createSelector(
+    [selectComponentNodesTableProps, selectContentMode, selectCustomColumns],
     (nodesTableProps, contentMode, customColumns) =>
         contentMode === 'custom' ? customColumns : nodesTableProps.columns.sets[contentMode].items,
 );
 
-const getPropertiesRequiredForRender = createSelector(
-    [getVisibleColumns],
+const selectPropertiesRequiredForRender = createSelector(
+    [selectVisibleColumns],
     (visibleColumns /* : Array<keyof typeof PropertiesByColumn> */) => {
         const requiredProperties = union_(
             ...visibleColumns.map(
@@ -104,9 +109,9 @@ const getPropertiesRequiredForRender = createSelector(
     },
 );
 
-export const getRequiredAttributes = createSelector(
+export const selectRequiredAttributes = createSelector(
     [
-        getPropertiesRequiredForRender,
+        selectPropertiesRequiredForRender,
         getPropertiesRequiredForFilters,
         getPropertiesRequiredForMediums,
     ],
@@ -127,21 +132,25 @@ export const getRequiredAttributes = createSelector(
     },
 );
 
-export const useTagsFromAttributes = createSelector([getRequiredAttributes], (attributes) => {
+export const selectTagsFromAttributes = createSelector([selectRequiredAttributes], (attributes) => {
     return attributes.indexOf('tags') >= 0;
 });
 
-export const useRacksFromAttributes = createSelector([getRequiredAttributes], (attributes) => {
-    return attributes.indexOf('rack') >= 0;
-});
+export const selectRacksFromAttributes = createSelector(
+    [selectRequiredAttributes],
+    (attributes) => {
+        return attributes.indexOf('rack') >= 0;
+    },
+);
 
-const getFetchedTags = (state: RootState): string[] =>
+const selectFetchedTags = (state: RootState): string[] =>
     state.components.nodes.nodes.filterOptionsTags;
-const getFetchedRacks = (state: RootState): string[] =>
+
+const selectFetchedRacks = (state: RootState): string[] =>
     state.components.nodes.nodes.filterOptionsRacks;
 
-export const getComponentNodesTags = createSelector(
-    [useTagsFromAttributes, getFetchedTags, getComponentNodesIndexByTag],
+export const selectComponentNodesTags = createSelector(
+    [selectTagsFromAttributes, selectFetchedTags, getComponentNodesIndexByTag],
     (useFromAttrs, fetchedTags, nodesByTag) => {
         if (!useFromAttrs) {
             return fetchedTags;
@@ -151,8 +160,8 @@ export const getComponentNodesTags = createSelector(
     },
 );
 
-export const getComponentNodesRacks = createSelector(
-    [useRacksFromAttributes, getFetchedRacks, getComponentNodesIndexByRack],
+export const selectComponentNodesRacks = createSelector(
+    [selectRacksFromAttributes, selectFetchedRacks, getComponentNodesIndexByRack],
     (useFromAttrs, fetchedRacks, nodesByRack) => {
         if (!useFromAttrs) {
             return fetchedRacks;
@@ -162,8 +171,8 @@ export const getComponentNodesRacks = createSelector(
     },
 );
 
-export const getComponentsNodesNodeTypes = createSelector(
-    [getComponentsNodesNodeTypeRaw],
+export const selectComponentsNodesNodeTypes = createSelector(
+    [selectComponentsNodesNodeTypeRaw],
     (types) => {
         const res: Array<NodeType> = [...types];
         if (res.length === 0) {
@@ -184,7 +193,7 @@ export const COMPONENTS_AVAILABLE_STATES = [
     'unknown',
 ];
 
-export const getComponentNodesFilterSetupStateValue = createSelector(
+export const selectComponentNodesFilterSetupStateValue = createSelector(
     [getComponentNodesFilterStatePredicate],
     (predicate) => {
         if (!predicate) {

--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
@@ -20,13 +20,13 @@ import {
     getNodeTablesProps,
 } from '../../../../../pages/components/tabs/nodes/tables';
 import {
-    getComponentNodesFilterPredicates,
-    getComponentNodesFilterStatePredicate,
-    getComponentNodesFiltersSetup,
-    getComponentNodesIndexByRack,
-    getComponentNodesIndexByTag,
-    getNodes,
-    getPropertiesRequiredForFilters,
+    selectComponentNodesFilterPredicates,
+    selectComponentNodesFilterStatePredicate,
+    selectComponentNodesFiltersSetup,
+    selectComponentNodesIndexByRack,
+    selectComponentNodesIndexByTag,
+    selectNodes,
+    selectPropertiesRequiredForFilters,
 } from './predicates';
 import {NODE_TYPE, NodeType} from '../../../../../../shared/constants/system';
 
@@ -43,7 +43,7 @@ const selectComponentsNodesNodeTypeRaw = (state: RootState) =>
 const selectCustomColumns = (state: RootState) => getSelectedColumns(state) || defaultColumns;
 
 const selectMediumsPredicates = createSelector(
-    [getComponentNodesFiltersSetup, getMediumListNoCache],
+    [selectComponentNodesFiltersSetup, getMediumListNoCache],
     createMediumsPredicates,
 );
 
@@ -52,15 +52,20 @@ const getPropertiesRequiredForMediums = createSelector(
     (mediumsPredicates) => (mediumsPredicates.length > 0 ? (['IOWeight'] as const) : []),
 );
 
-const selectFilteredByHost = createSelector([getNodes, selectHostFilter], (nodes, hostFilter) => {
-    const hostFilters = hostFilter.split(/\s+/);
-    return filter_(nodes, (node) => {
-        return some_(hostFilters, (hostFilter) => node?.host?.toLowerCase().includes(hostFilter));
-    });
-});
+const selectFilteredByHost = createSelector(
+    [selectNodes, selectHostFilter],
+    (nodes, hostFilter) => {
+        const hostFilters = hostFilter.split(/\s+/);
+        return filter_(nodes, (node) => {
+            return some_(hostFilters, (hostFilter) =>
+                node?.host?.toLowerCase().includes(hostFilter),
+            );
+        });
+    },
+);
 
 const selectFilteredNodes = createSelector(
-    [selectFilteredByHost, getComponentNodesFilterPredicates, selectMediumsPredicates],
+    [selectFilteredByHost, selectComponentNodesFilterPredicates, selectMediumsPredicates],
     (nodes, predicates, mediumsPredicates) => {
         const predicatesArray = predicates.concat(mediumsPredicates);
         if (!predicatesArray.length) {
@@ -112,7 +117,7 @@ const selectPropertiesRequiredForRender = createSelector(
 export const selectRequiredAttributes = createSelector(
     [
         selectPropertiesRequiredForRender,
-        getPropertiesRequiredForFilters,
+        selectPropertiesRequiredForFilters,
         getPropertiesRequiredForMediums,
     ],
     (propertiesRequiredForRender, propertiesRequiredForFilters, propertiesRequiredForMediums) => {
@@ -150,7 +155,7 @@ const selectFetchedRacks = (state: RootState): string[] =>
     state.components.nodes.nodes.filterOptionsRacks;
 
 export const selectComponentNodesTags = createSelector(
-    [selectTagsFromAttributes, selectFetchedTags, getComponentNodesIndexByTag],
+    [selectTagsFromAttributes, selectFetchedTags, selectComponentNodesIndexByTag],
     (useFromAttrs, fetchedTags, nodesByTag) => {
         if (!useFromAttrs) {
             return fetchedTags;
@@ -161,7 +166,7 @@ export const selectComponentNodesTags = createSelector(
 );
 
 export const selectComponentNodesRacks = createSelector(
-    [selectRacksFromAttributes, selectFetchedRacks, getComponentNodesIndexByRack],
+    [selectRacksFromAttributes, selectFetchedRacks, selectComponentNodesIndexByRack],
     (useFromAttrs, fetchedRacks, nodesByRack) => {
         if (!useFromAttrs) {
             return fetchedRacks;
@@ -194,7 +199,7 @@ export const COMPONENTS_AVAILABLE_STATES = [
 ];
 
 export const selectComponentNodesFilterSetupStateValue = createSelector(
-    [getComponentNodesFilterStatePredicate],
+    [selectComponentNodesFilterStatePredicate],
     (predicate) => {
         if (!predicate) {
             return ['all'];

--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/predicates.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/predicates.ts
@@ -26,12 +26,12 @@ import {isRangeFilterDefined} from '../../../../../utils/components/nodes/setup'
 import {toaster} from '../../../../../utils/toaster';
 import {RootState} from '../../../../reducers';
 
-export const getSetupFiltersRaw = (state: RootState) => state.components.nodes.setup;
+export const selectSetupFiltersRaw = (state: RootState) => state.components.nodes.setup;
 
-export const getNodes = (state: RootState): Array<Node> => state.components.nodes.nodes.nodes;
+export const selectNodes = (state: RootState): Array<Node> => state.components.nodes.nodes.nodes;
 
-export const getComponentNodesFilterStatePredicate = createSelector(
-    [getSetupFiltersRaw],
+export const selectComponentNodesFilterStatePredicate = createSelector(
+    [selectSetupFiltersRaw],
     ({default: {state}}) => {
         if (!state.length || (state.length === 1 && state[0] === 'all')) {
             return undefined;
@@ -73,8 +73,8 @@ export const getComponentNodesFilterStatePredicate = createSelector(
     },
 );
 
-export const getComponentNodesFiltersSetup = createSelector(
-    [getSetupFiltersRaw, getMediumListNoCache],
+export const selectComponentNodesFiltersSetup = createSelector(
+    [selectSetupFiltersRaw, getMediumListNoCache],
     (setup, mediumList) => {
         const mediumDefaults = reduce_(
             mediumList,
@@ -88,7 +88,7 @@ export const getComponentNodesFiltersSetup = createSelector(
     },
 );
 
-export const getComponentNodesIndexByTag = createSelector([getNodes], (nodes) => {
+export const selectComponentNodesIndexByTag = createSelector([selectNodes], (nodes) => {
     const res = reduce_(
         nodes,
         (acc, node) => {
@@ -107,7 +107,7 @@ export const getComponentNodesIndexByTag = createSelector([getNodes], (nodes) =>
     return res;
 });
 
-export const getComponentNodesIndexByRack = createSelector([getNodes], (nodes) => {
+export const selectComponentNodesIndexByRack = createSelector([selectNodes], (nodes) => {
     return reduce_(
         nodes,
         (acc, node) => {
@@ -189,8 +189,8 @@ type Predicates = {
         | ((node: NodeWithProps<P>) => boolean);
 };
 
-const getRackPredicate = createSelector(
-    [getSetupFiltersRaw, getComponentNodesIndexByRack],
+const selectRackPredicate = createSelector(
+    [selectSetupFiltersRaw, selectComponentNodesIndexByRack],
     (setupFilters, nodesByRack) => {
         const {rack} = setupFilters.default;
         if ('string' !== typeof rack && rack.selected?.[0] === UNAWARE) {
@@ -202,12 +202,12 @@ const getRackPredicate = createSelector(
     },
 );
 
-const getFilterPredicatesObject = createSelector(
+const selectFilterPredicatesObject = createSelector(
     [
-        getSetupFiltersRaw,
-        getComponentNodesIndexByTag,
-        getRackPredicate,
-        getComponentNodesFilterStatePredicate,
+        selectSetupFiltersRaw,
+        selectComponentNodesIndexByTag,
+        selectRackPredicate,
+        selectComponentNodesFilterStatePredicate,
     ],
     (setupFilters, nodesByTags, rackPredicate, statePredicate) => {
         const predicates: Predicates = {
@@ -466,8 +466,8 @@ const getFilterPredicatesObject = createSelector(
     },
 );
 
-export const getComponentNodesFiltersCount = createSelector(
-    [getFilterPredicatesObject],
+export const selectComponentNodesFiltersCount = createSelector(
+    [selectFilterPredicatesObject],
     (filters) => {
         return reduce_(
             filters,
@@ -479,15 +479,15 @@ export const getComponentNodesFiltersCount = createSelector(
     },
 );
 
-export const getComponentNodesFilterPredicates = createSelector(
-    [getFilterPredicatesObject],
+export const selectComponentNodesFilterPredicates = createSelector(
+    [selectFilterPredicatesObject],
     (filterPredicatesObject) => {
         return filter_(filterPredicatesObject, (p) => p) as Array<(node: Node) => boolean>;
     },
 );
 
-export const getPropertiesRequiredForFilters = createSelector(
-    [getFilterPredicatesObject],
+export const selectPropertiesRequiredForFilters = createSelector(
+    [selectFilterPredicatesObject],
     (filterPredicatesObject) => {
         const picked = values_(
             pickBy_(

--- a/packages/ui/src/ui/store/selectors/components/proxies/proxies.js
+++ b/packages/ui/src/ui/store/selectors/components/proxies/proxies.js
@@ -46,22 +46,27 @@ const getSelectItems = (allItems, visibleItems, hostFilter, selectFilter) => {
     return [allItemsSection, ...items];
 };
 
-const getProxies = (state) => state.components.proxies.proxies.proxies;
-const getHostFilter = (state) => state.components.proxies.proxies.hostFilter;
-const getStateFilter = (state) => state.components.proxies.proxies.stateFilter;
-const getRoleFilter = (state) => state.components.proxies.proxies.roleFilter;
-const getBannedFilter = (state) => state.components.proxies.proxies.bannedFilter;
-const getSortState = (state) => state.tables[COMPONENTS_PROXIES_TABLE_ID];
+const selectProxies = (state) => state.components.proxies.proxies.proxies;
 
-const getFiltersObject = createSelector(
-    [getHostFilter, getStateFilter, getRoleFilter, getBannedFilter],
+const selectHostFilter = (state) => state.components.proxies.proxies.hostFilter;
+
+const selectStateFilter = (state) => state.components.proxies.proxies.stateFilter;
+
+const selectRoleFilter = (state) => state.components.proxies.proxies.roleFilter;
+
+const selectBannedFilter = (state) => state.components.proxies.proxies.bannedFilter;
+
+const selectSortState = (state) => state.tables[COMPONENTS_PROXIES_TABLE_ID];
+
+const selectFiltersObject = createSelector(
+    [selectHostFilter, selectStateFilter, selectRoleFilter, selectBannedFilter],
     (hostFilter, stateFilter, roleFilter, bannedFilter) => {
         return {hostFilter, stateFilter, roleFilter, bannedFilter};
     },
 );
 
-const getFilteredProxies = createSelector(
-    [getProxies, getFiltersObject],
+const selectFilteredProxies = createSelector(
+    [selectProxies, selectFiltersObject],
     (proxies, filtersObject) => {
         return filterProxies(proxies, filtersObject);
     },
@@ -78,29 +83,32 @@ function filterProxies(proxies, {hostFilter, stateFilter, roleFilter, bannedFilt
     return predicates.length ? filter_(proxies, concatByAnd(...predicates)) : proxies;
 }
 
-const getAllRoles = createSelector([getProxies], (proxy) => aggregateRoleItems(proxy));
+const selectAllRoles = createSelector([selectProxies], (proxy) => aggregateRoleItems(proxy));
 
-const getVisibleRoles = createSelector([getProxies, getFiltersObject], (proxies, filtersObject) => {
-    const filtered = filterProxies(proxies, omit_(filtersObject, ['roleFilter']));
+const selectVisibleRoles = createSelector(
+    [selectProxies, selectFiltersObject],
+    (proxies, filtersObject) => {
+        const filtered = filterProxies(proxies, omit_(filtersObject, ['roleFilter']));
 
-    return aggregateRoleItems(filtered);
-});
+        return aggregateRoleItems(filtered);
+    },
+);
 
-const getAllStates = createSelector([getProxies], (proxy) => aggregateStateItems(proxy));
+const selectAllStates = createSelector([selectProxies], (proxy) => aggregateStateItems(proxy));
 
-const getVisibleStates = createSelector([getProxies], (proxy) => aggregateStateItems(proxy));
+const selectVisibleStates = createSelector([selectProxies], (proxy) => aggregateStateItems(proxy));
 
-export const getVisibleProxies = createSelector(
-    [getFilteredProxies, getSortState],
+export const selectVisibleProxies = createSelector(
+    [selectFilteredProxies, selectSortState],
     (proxies, sortState) => hammer.utils.sort(proxies, sortState, proxiesTableColumnItems),
 );
 
-export const getRoles = createSelector(
-    [getAllRoles, getVisibleRoles, getHostFilter, getStateFilter],
+export const selectRoles = createSelector(
+    [selectAllRoles, selectVisibleRoles, selectHostFilter, selectStateFilter],
     getSelectItems,
 );
 
-export const getStates = createSelector(
-    [getAllStates, getVisibleStates, getHostFilter, getRoleFilter],
+export const selectStates = createSelector(
+    [selectAllStates, selectVisibleStates, selectHostFilter, selectRoleFilter],
     getSelectItems,
 );

--- a/packages/ui/src/ui/store/selectors/components/versions/versions_v2-ts.ts
+++ b/packages/ui/src/ui/store/selectors/components/versions/versions_v2-ts.ts
@@ -7,23 +7,23 @@ import {
     VersionSummaryRow,
 } from '../../../../store/reducers/components/versions/versions_v2';
 
-export const getSummarySortState = (
+export const selectSummarySortState = (
     state: RootState,
 ): undefined | SortState<keyof VersionSummaryItem> =>
     (state.components.versionsV2 as FIX_MY_TYPE).summarySortState;
 
-const getSummary = (state: RootState): Array<VersionSummaryItem> =>
+const selectSummary = (state: RootState): Array<VersionSummaryItem> =>
     state.components.versionsV2.summary;
 
-export const getHideOfflineValue = (state: RootState): boolean =>
+export const selectHideOfflineValue = (state: RootState): boolean =>
     state.components.versionsV2.checkedHideOffline;
 
-function getTotalElementOfSummary(summary: ReturnType<typeof getSummary>) {
+function getTotalElementOfSummary(summary: ReturnType<typeof selectSummary>) {
     return summary[summary.length - 1];
 }
 
-export const getVisibleSummaryItems = createSelector(
-    [getSummary, getHideOfflineValue],
+export const selectVisibleSummaryItems = createSelector(
+    [selectSummary, selectHideOfflineValue],
     (summary = [], checkedHideOffline) => {
         let items = summary;
         if (checkedHideOffline) {
@@ -33,7 +33,7 @@ export const getVisibleSummaryItems = createSelector(
     },
 );
 
-export const getVersions = createSelector([getVisibleSummaryItems], (summary = []) => {
+export const selectVersions = createSelector([selectVisibleSummaryItems], (summary = []) => {
     const versions = [];
     for (const item of summary) {
         if (item) {
@@ -46,8 +46,8 @@ export const getVersions = createSelector([getVisibleSummaryItems], (summary = [
     return versions;
 });
 
-export const getVersionsSummaryData = createSelector(
-    [getSummary, getSummarySortState, getHideOfflineValue],
+export const selectVersionsSummaryData = createSelector(
+    [selectSummary, selectSummarySortState, selectHideOfflineValue],
     (summary = [], sortState, checkedHideOffline) => {
         const error = summary[summary.length - 2];
         const total = getTotalElementOfSummary(summary);

--- a/packages/ui/src/ui/store/selectors/components/versions/versions_v2.ts
+++ b/packages/ui/src/ui/store/selectors/components/versions/versions_v2.ts
@@ -40,7 +40,7 @@ function getSelectItems(
     allItems: ReturnType<typeof aggregateItems>,
     visibleItems: ReturnType<typeof aggregateItems>,
     hostFilter: string,
-    otherFilters: Partial<ReturnType<typeof getFilters>>,
+    otherFilters: Partial<ReturnType<typeof selectFilters>>,
 ) {
     const isAllSelected = isEmpty_(otherFilters);
 
@@ -59,26 +59,33 @@ function getSelectItems(
     return [allItemsSection, ...items];
 }
 
-const getDetails = (state: RootState) => state.components.versionsV2.details;
+const selectDetails = (state: RootState) => state.components.versionsV2.details;
 
-const getHostFilter = (state: RootState) => state.components.versionsV2.hostFilter;
-const getVersionFilter = (state: RootState) => state.components.versionsV2.versionFilter;
-const getTypeFilter = (state: RootState) => state.components.versionsV2.typeFilter;
-const getStateFilter = (state: RootState) => state.components.versionsV2.stateFilter;
-const getBannedFilter = (state: RootState) => state.components.versionsV2.bannedFilter;
+const selectHostFilter = (state: RootState) => state.components.versionsV2.hostFilter;
 
-const getDetailsSortState = (state: RootState) =>
+const selectVersionFilter = (state: RootState) => state.components.versionsV2.versionFilter;
+
+const selectTypeFilter = (state: RootState) => state.components.versionsV2.typeFilter;
+
+const selectStateFilter = (state: RootState) => state.components.versionsV2.stateFilter;
+
+const selectBannedFilter = (state: RootState) => state.components.versionsV2.bannedFilter;
+
+const selectDetailsSortState = (state: RootState) =>
     state.tables[COMPONENTS_VERSIONS_DETAILED_TABLE_ID];
 
-const getFilteredByHost = createSelector([getDetails, getHostFilter], (details, hostFilter) => {
-    if (!hostFilter) {
-        return details;
-    }
-    return filter_(details, ({address}) => address?.toLowerCase().includes(hostFilter));
-});
+const selectFilteredByHost = createSelector(
+    [selectDetails, selectHostFilter],
+    (details, hostFilter) => {
+        if (!hostFilter) {
+            return details;
+        }
+        return filter_(details, ({address}) => address?.toLowerCase().includes(hostFilter));
+    },
+);
 
-const getFilters = createSelector(
-    [getVersionFilter, getTypeFilter, getStateFilter, getBannedFilter],
+const selectFilters = createSelector(
+    [selectVersionFilter, selectTypeFilter, selectStateFilter, selectBannedFilter],
     (version, type, state, banned) => {
         return reduce_(
             {
@@ -104,85 +111,103 @@ const getFilters = createSelector(
     },
 );
 
-const getFiltersSkipVersion = createSelector([getFilters], (filters) => {
+const selectFiltersSkipVersion = createSelector([selectFilters], (filters) => {
     const {version: _x, ...rest} = filters;
     return rest;
 });
 
-const getFiltersSkipType = createSelector([getFilters], (filters) => {
+const selectFiltersSkipType = createSelector([selectFilters], (filters) => {
     const {type: _x, ...rest} = filters;
     return rest;
 });
 
-const getFiltersSkipState = createSelector([getFilters], (filters) => {
+const selectFiltersSkipState = createSelector([selectFilters], (filters) => {
     const {state: _x, ...rest} = filters;
     return rest;
 });
 
-const getFiltersSkipBanned = createSelector([getFilters], (filters) => {
+const selectFiltersSkipBanned = createSelector([selectFilters], (filters) => {
     const {banned: _x, ...rest} = filters;
     return rest;
 });
 
-const getFilteredDetails = createSelector([getFilteredByHost, getFilters], (data, filters) => {
-    return filter_(data, filters) as Array<VersionHostInfo>;
-});
+const selectFilteredDetails = createSelector(
+    [selectFilteredByHost, selectFilters],
+    (data, filters) => {
+        return filter_(data, filters) as Array<VersionHostInfo>;
+    },
+);
 
-export const getVisibleDetails = createSelector(
-    [getFilteredDetails, getDetailsSortState],
+export const selectVisibleDetails = createSelector(
+    [selectFilteredDetails, selectDetailsSortState],
     (details, sortState): typeof details =>
         hammer.utils.sort(details, sortState, detailsTableProps.columns.items),
 );
 
-const getAllVersions = createSelector([getDetails], (versions) =>
+const selectAllVersions = createSelector([selectDetails], (versions) =>
     aggregateItems(versions, 'version'),
 );
-const getAllTypes = createSelector([getDetails], (versions) => aggregateItems(versions, 'type'));
-const getAllStates = createSelector([getDetails], (versions) => aggregateItems(versions, 'state'));
 
-const getAllBanned = createSelector([getDetails], (version) => aggregateItems(version, 'banned'));
+const selectAllTypes = createSelector([selectDetails], (versions) =>
+    aggregateItems(versions, 'type'),
+);
 
-const getVisibleVersions = createSelector(
-    [getFilteredByHost, getFiltersSkipVersion],
+const selectAllStates = createSelector([selectDetails], (versions) =>
+    aggregateItems(versions, 'state'),
+);
+
+const selectAllBanned = createSelector([selectDetails], (version) =>
+    aggregateItems(version, 'banned'),
+);
+
+const selectVisibleVersions = createSelector(
+    [selectFilteredByHost, selectFiltersSkipVersion],
     (data, filters) => {
         const items = filter_(data, filters) as Array<VersionHostInfo>;
         return aggregateItems(items, 'version');
     },
 );
-const getVisibleTypes = createSelector([getFilteredByHost, getFiltersSkipType], (data, filters) => {
-    const items = filter_(data, filters) as Array<VersionHostInfo>;
-    return aggregateItems(items, 'type');
-});
-const getVisibleStates = createSelector(
-    [getFilteredByHost, getFiltersSkipState],
+
+const selectVisibleTypes = createSelector(
+    [selectFilteredByHost, selectFiltersSkipType],
+    (data, filters) => {
+        const items = filter_(data, filters) as Array<VersionHostInfo>;
+        return aggregateItems(items, 'type');
+    },
+);
+
+const selectVisibleStates = createSelector(
+    [selectFilteredByHost, selectFiltersSkipState],
     (data, filters) => {
         const items = filter_(data, filters) as Array<VersionHostInfo>;
         return aggregateItems(items, 'state');
     },
 );
 
-const getVisibleBanned = createSelector(
-    [getFilteredByHost, getFiltersSkipBanned],
+const selectVisibleBanned = createSelector(
+    [selectFilteredByHost, selectFiltersSkipBanned],
     (data, filters) => {
         const items = filter_(data, filters) as Array<VersionHostInfo>;
         return aggregateItems(items, 'banned');
     },
 );
 
-export const getVersionSelectItems = createSelector(
-    [getAllVersions, getVisibleVersions, getHostFilter, getFiltersSkipVersion],
-    getSelectItems,
-);
-export const getTypeSelectItems = createSelector(
-    [getAllTypes, getVisibleTypes, getHostFilter, getFiltersSkipType],
-    getSelectItems,
-);
-export const getStatesSelectItems = createSelector(
-    [getAllStates, getVisibleStates, getHostFilter, getFiltersSkipState],
+export const selectVersionSelectItems = createSelector(
+    [selectAllVersions, selectVisibleVersions, selectHostFilter, selectFiltersSkipVersion],
     getSelectItems,
 );
 
-export const getBannedSelectItems = createSelector(
-    [getAllBanned, getVisibleBanned, getHostFilter, getFiltersSkipBanned],
+export const selectTypeSelectItems = createSelector(
+    [selectAllTypes, selectVisibleTypes, selectHostFilter, selectFiltersSkipType],
+    getSelectItems,
+);
+
+export const selectStatesSelectItems = createSelector(
+    [selectAllStates, selectVisibleStates, selectHostFilter, selectFiltersSkipState],
+    getSelectItems,
+);
+
+export const selectBannedSelectItems = createSelector(
+    [selectAllBanned, selectVisibleBanned, selectHostFilter, selectFiltersSkipBanned],
     getSelectItems,
 );


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Tajpd0yn7ZiNLM
<!-- nda-end --> ## Summary by Sourcery

Enhancements:
- Align selector naming conventions in components, nodes, versions, proxies, and node maintenance-related modules to use the `select*` prefix consistently.