### PR TITLE
chore: rename dashboard2 and execute-batch selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/containers/AppNavigation/TopRowContent/TopRowContent.tsx
+++ b/packages/ui/src/ui/containers/AppNavigation/TopRowContent/TopRowContent.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {useSelector} from '../../../store/redux-hooks';
 
 import {selectGlobalLoadState} from '../../../store/selectors/global';
-import {getSettingNewDashboardPage} from '../../../store/selectors/dashboard2/dashboard';
+import {selectSettingNewDashboardPage} from '../../../store/selectors/dashboard2/dashboard';
 
 import {LOADING_STATUS, Page} from '../../../constants/index';
 import {Route, Switch} from 'react-router';
@@ -32,7 +32,7 @@ import {FlowPageTopRowLazy} from '../../../pages/flow/lazy';
 
 export default function TopRowContent() {
     const loadState = useSelector(selectGlobalLoadState);
-    const isNewDashboardPage = useSelector(getSettingNewDashboardPage);
+    const isNewDashboardPage = useSelector(selectSettingNewDashboardPage);
 
     return loadState !== LOADING_STATUS.LOADED ? null : (
         <Switch>

--- a/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
+++ b/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
@@ -49,7 +49,7 @@ import {selectIsExperimentalPagesReady} from '../../store/selectors/global/exper
 import {getClusterConfig} from '../../utils';
 import {NAMESPACES, SettingName} from '../../../shared/constants/settings';
 import {getClusterPagePaneSizes, getStartingPage} from '../../store/selectors/settings';
-import {getSettingNewDashboardPage} from '../../store/selectors/dashboard2/dashboard';
+import {selectSettingNewDashboardPage} from '../../store/selectors/dashboard2/dashboard';
 import SupportedFeaturesUpdater from './SupportedFeaturesUpdater';
 import {useRumMeasureStart, useRumMeasureStop} from '../../rum/RumUiContext';
 import {RumMeasureTypes} from '../../rum/rum-measure-types';
@@ -348,7 +348,7 @@ function mapStateToProps(state) {
         paramsCluster,
         allowChyt: Boolean(selectClusterUiConfig(state).chyt_controller_base_url),
         allowStartPageRedirect: selectIsExperimentalPagesReady(state),
-        isNewDashboardPage: getSettingNewDashboardPage(state),
+        isNewDashboardPage: selectSettingNewDashboardPage(state),
     };
 }
 

--- a/packages/ui/src/ui/containers/RetryBatchModal/RetryBatchModal.tsx
+++ b/packages/ui/src/ui/containers/RetryBatchModal/RetryBatchModal.tsx
@@ -6,7 +6,7 @@ import map_ from 'lodash/map';
 import {Button} from '@gravity-ui/uikit';
 import {DialogWrapper as Dialog} from '../../components/DialogWrapper/DialogWrapper';
 
-import {getExecuteBatchState} from '../../store/selectors/execute-batch';
+import {selectExecuteBatchState} from '../../store/selectors/execute-batch';
 import {ExecuteBatchStateItem} from '../../store/reducers/execute-batch';
 
 import {YTErrorBlock} from '../../components/Error/Error';
@@ -73,7 +73,7 @@ function RetryBatchImpl(props: ExecuteBatchStateItem) {
 const RetryBatch = React.memo(RetryBatchImpl);
 
 function RetryBatchModals() {
-    const state = useSelector(getExecuteBatchState);
+    const state = useSelector(selectExecuteBatchState);
     return (
         <React.Fragment>
             {map_(state, (data, key) => {

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Dashboard.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ import {
     getEdittingConfig,
     openSettingsDialog,
 } from '../../../store/reducers/dashboard2/dashboard';
-import {getDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
+import {selectDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
 import {selectCluster} from '../../../store/selectors/global';
 import {selectIsAdmin} from '../../../store/selectors/global/is-developer';
 
@@ -29,7 +29,7 @@ export function Dashboard() {
     const dispatch = useDispatch();
 
     const editMode = useSelector(getEditMode);
-    const config = useSelector(getDashboardConfig);
+    const config = useSelector(selectDashboardConfig);
     const edittingConfig = useSelector(getEdittingConfig);
     const cluster = useSelector(selectCluster);
     const isAdmin = useSelector(selectIsAdmin);

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/AccountsWidgetControls/AccountsWidgetControls.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/AccountsWidgetControls/AccountsWidgetControls.tsx
@@ -3,7 +3,7 @@ import {useDispatch, useSelector} from '../../../../../../store/redux-hooks';
 import {SegmentedRadioGroup} from '@gravity-ui/uikit';
 
 import {RootState} from '../../../../../../store/reducers';
-import {getAccountsTypeFilter} from '../../../../../../store/selectors/dashboard2/accounts';
+import {selectAccountsTypeFilter} from '../../../../../../store/selectors/dashboard2/accounts';
 import {setAccountsTypeFilter} from '../../../../../../store/actions/dashboard2/accounts';
 
 import type {AccountsWidgetProps} from '../types';
@@ -13,7 +13,7 @@ import i18n from '../i18n';
 export function AccountsWidgetControls(props: AccountsWidgetProps) {
     const dispatch = useDispatch();
 
-    const type = useSelector((state: RootState) => getAccountsTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectAccountsTypeFilter(state, props.id));
 
     const onUpdate = (value: 'favourite' | 'usable' | 'custom') => {
         dispatch(setAccountsTypeFilter(props.id, value));

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/hooks/use-accounts-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/hooks/use-accounts-widget.ts
@@ -4,7 +4,7 @@ import {RootState} from '../../../../../../store/reducers';
 import {useAccountsQuery} from '../../../../../../store/api/dashboard2/accounts';
 import {
     selectAccountsList,
-    getAccountsTypeFilter,
+    selectAccountsTypeFilter,
 } from '../../../../../../store/selectors/dashboard2/accounts';
 import {selectCluster} from '../../../../../../store/selectors/global';
 import {selectIsAdmin} from '../../../../../../store/selectors/global/is-developer';
@@ -16,7 +16,7 @@ export function useAccountsWidget(props: AccountsWidgetProps) {
     const {data} = props;
 
     const cluster = useSelector(selectCluster);
-    const type = useSelector((state: RootState) => getAccountsTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectAccountsTypeFilter(state, props.id));
     const isAdmin = useSelector(selectIsAdmin);
 
     const {isLoading: isUsableLoading, isFetching: isUsableFetching} = useUsableAccountsQuery(

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/hooks/use-accounts-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/hooks/use-accounts-widget.ts
@@ -3,7 +3,7 @@ import {useSelector} from '../../../../../../store/redux-hooks';
 import {RootState} from '../../../../../../store/reducers';
 import {useAccountsQuery} from '../../../../../../store/api/dashboard2/accounts';
 import {
-    getAccountsList,
+    selectAccountsList,
     getAccountsTypeFilter,
 } from '../../../../../../store/selectors/dashboard2/accounts';
 import {selectCluster} from '../../../../../../store/selectors/global';
@@ -25,7 +25,7 @@ export function useAccountsWidget(props: AccountsWidgetProps) {
     );
 
     const accountsList = useSelector((state: RootState) =>
-        getAccountsList(state, props.id, data?.accounts || []),
+        selectAccountsList(state, props.id, data?.accounts || []),
     );
 
     const {

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/NavigationWidgetControls/NavigationWidgetControls.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/NavigationWidgetControls/NavigationWidgetControls.tsx
@@ -3,7 +3,7 @@ import {useDispatch, useSelector} from '../../../../../../store/redux-hooks';
 import {SegmentedRadioGroup} from '@gravity-ui/uikit';
 
 import {RootState} from '../../../../../../store/reducers';
-import {getNavigationTypeFilter} from '../../../../../../store/selectors/dashboard2/navigation';
+import {selectNavigationTypeFilter} from '../../../../../../store/selectors/dashboard2/navigation';
 import {setNavigationTypeFilter} from '../../../../../../store/actions/dashboard2/navigation';
 
 import type {NavigationWidgetProps} from '../types';
@@ -12,7 +12,7 @@ import i18n from '../i18n';
 
 export function NavigationWidgetControls(props: NavigationWidgetProps) {
     const dispatch = useDispatch();
-    const type = useSelector((state: RootState) => getNavigationTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectNavigationTypeFilter(state, props.id));
     const onUpdate = (value: 'last_visited' | 'favourite') => {
         dispatch(setNavigationTypeFilter(props.id, value));
     };

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/hooks/use-navigation-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/hooks/use-navigation-widget.ts
@@ -3,14 +3,14 @@ import {useSelector} from '../../../../../../store/redux-hooks';
 import {RootState} from '../../../../../../store/reducers';
 import {usePathsQuery} from '../../../../../../store/api/dashboard2/navigation';
 import {selectCluster} from '../../../../../../store/selectors/global';
-import {getNavigationTypeFilter} from '../../../../../../store/selectors/dashboard2/navigation';
+import {selectNavigationTypeFilter} from '../../../../../../store/selectors/dashboard2/navigation';
 import {getLastVisited} from '../../../../../../store/selectors/settings';
 import {selectFavouritePaths} from '../../../../../../store/selectors/favourites';
 
 import {NavigationWidgetProps} from '../types';
 
 export function useNavigationWidget(props: NavigationWidgetProps) {
-    const type = useSelector((state: RootState) => getNavigationTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectNavigationTypeFilter(state, props.id));
     const cluster = useSelector(selectCluster);
 
     const lastVisitedPaths = useSelector(getLastVisited);

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/OperationsWidgetControls/OperationsWidgetControls.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/OperationsWidgetControls/OperationsWidgetControls.tsx
@@ -27,7 +27,9 @@ export function OperationsWidgetControls(props: OperationsWidgetProps) {
     const dispatch = useDispatch();
 
     const state = useSelector((state: RootState) => selectOperationsStateFilter(state, id));
-    const authorType = useSelector((state: RootState) => selectOperationsAuthorTypeFilter(state, id));
+    const authorType = useSelector((state: RootState) =>
+        selectOperationsAuthorTypeFilter(state, id),
+    );
 
     const onStateFilterUpdate = (value: string[]) => {
         dispatch(setOperationsStateFilter(id, value[0]));

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/OperationsWidgetControls/OperationsWidgetControls.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/OperationsWidgetControls/OperationsWidgetControls.tsx
@@ -9,8 +9,8 @@ import {
     setOperationsStateFilter,
 } from '../../../../../../store/actions/dashboard2/operations';
 import {
-    getOperationsAuthorTypeFilter,
-    getOperationsStateFilter,
+    selectOperationsAuthorTypeFilter,
+    selectOperationsStateFilter,
 } from '../../../../../../store/selectors/dashboard2/operations';
 
 import type {OperationsWidgetProps} from '../types';
@@ -26,8 +26,8 @@ export function OperationsWidgetControls(props: OperationsWidgetProps) {
 
     const dispatch = useDispatch();
 
-    const state = useSelector((state: RootState) => getOperationsStateFilter(state, id));
-    const authorType = useSelector((state: RootState) => getOperationsAuthorTypeFilter(state, id));
+    const state = useSelector((state: RootState) => selectOperationsStateFilter(state, id));
+    const authorType = useSelector((state: RootState) => selectOperationsAuthorTypeFilter(state, id));
 
     const onStateFilterUpdate = (value: string[]) => {
         dispatch(setOperationsStateFilter(id, value[0]));

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/hooks/use-operations-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/hooks/use-operations-widget.ts
@@ -15,7 +15,9 @@ export function useOperationsWidget(props: OperationsWidgetProps) {
     const cluster = useSelector(selectCluster);
 
     const state = useSelector((state: RootState) => selectOperationsStateFilter(state, id));
-    const authorType = useSelector((state: RootState) => selectOperationsAuthorTypeFilter(state, id));
+    const authorType = useSelector((state: RootState) =>
+        selectOperationsAuthorTypeFilter(state, id),
+    );
 
     const authors = data?.authors;
     const pool = data?.pool;

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/hooks/use-operations-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/hooks/use-operations-widget.ts
@@ -3,8 +3,8 @@ import {useSelector} from '../../../../../../store/redux-hooks';
 import {RootState} from '../../../../../../store/reducers';
 import {useOperationsQuery} from '../../../../../../store/api/dashboard2/operations';
 import {
-    getOperationsAuthorTypeFilter,
-    getOperationsStateFilter,
+    selectOperationsAuthorTypeFilter,
+    selectOperationsStateFilter,
 } from '../../../../../../store/selectors/dashboard2/operations';
 import {selectCluster} from '../../../../../../store/selectors/global';
 
@@ -14,8 +14,8 @@ export function useOperationsWidget(props: OperationsWidgetProps) {
     const {id, data} = props;
     const cluster = useSelector(selectCluster);
 
-    const state = useSelector((state: RootState) => getOperationsStateFilter(state, id));
-    const authorType = useSelector((state: RootState) => getOperationsAuthorTypeFilter(state, id));
+    const state = useSelector((state: RootState) => selectOperationsStateFilter(state, id));
+    const authorType = useSelector((state: RootState) => selectOperationsAuthorTypeFilter(state, id));
 
     const authors = data?.authors;
     const pool = data?.pool;

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/PoolsWidgetContent/PoolsWidgetContent.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/PoolsWidgetContent/PoolsWidgetContent.tsx
@@ -4,7 +4,7 @@ import {Text} from '@gravity-ui/uikit';
 import {createColumnHelper} from '@gravity-ui/table/tanstack';
 
 import {RootState} from '../../../../../../store/reducers';
-import {getPoolsTypeFilter} from '../../../../../../store/selectors/dashboard2/pools';
+import {selectPoolsTypeFilter} from '../../../../../../store/selectors/dashboard2/pools';
 
 import {WidgetTable} from '../../../../../../pages/dashboard2/Dashboard/components/WidgetTable/WidgetTable';
 
@@ -60,7 +60,7 @@ export function PoolsWidgetContent(props: PoolsWidgetProps) {
         data: {pools, isLoading, error},
     } = usePoolsWidget(props);
 
-    const type = useSelector((state: RootState) => getPoolsTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectPoolsTypeFilter(state, props.id));
     const itemsName = i18n(`fallback-item_${type || 'default'}`);
 
     return (

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/PoolsWidgetControls/PoolsWidgetControls.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/PoolsWidgetControls/PoolsWidgetControls.tsx
@@ -4,7 +4,7 @@ import {SegmentedRadioGroup} from '@gravity-ui/uikit';
 
 import {RootState} from '../../../../../../store/reducers';
 import {setPoolsTypeFilter} from '../../../../../../store/actions/dashboard2/pools';
-import {getPoolsTypeFilter} from '../../../../../../store/selectors/dashboard2/pools';
+import {selectPoolsTypeFilter} from '../../../../../../store/selectors/dashboard2/pools';
 
 import type {PoolsWidgetProps} from '../types';
 
@@ -13,7 +13,7 @@ import i18n from '../i18n';
 export function PoolsWidgetControls(props: PoolsWidgetProps) {
     const dispatch = useDispatch();
 
-    const type = useSelector((state: RootState) => getPoolsTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectPoolsTypeFilter(state, props.id));
 
     const onUpdate = (value: 'favourite' | 'custom') => {
         dispatch(setPoolsTypeFilter(props.id, value));

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/hooks/use-pools-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Pools/hooks/use-pools-widget.ts
@@ -9,7 +9,7 @@ import {RootState} from '../../../../../../store/reducers';
 import {PoolQueryParams} from '../../../../../../store/api/dashboard2/pools/pools';
 import {usePoolsQuery} from '../../../../../../store/api/dashboard2/pools';
 import {selectFavouritePools} from '../../../../../../store/selectors/favourites';
-import {getPoolsTypeFilter} from '../../../../../../store/selectors/dashboard2/pools';
+import {selectPoolsTypeFilter} from '../../../../../../store/selectors/dashboard2/pools';
 import {selectCluster} from '../../../../../../store/selectors/global';
 
 import type {PoolsWidgetProps} from '../types';
@@ -22,7 +22,7 @@ export function usePoolsWidget(props: PoolsWidgetProps) {
 
     const favouritePools = useSelector(selectFavouritePools);
     const cluster = useSelector(selectCluster);
-    const type = useSelector((state: RootState) => getPoolsTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectPoolsTypeFilter(state, props.id));
 
     const {data, isLoading, isFetching, error} = usePoolsQuery({
         cluster,

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Queries/QueriesWidgetContent/QueriesWidgetContent.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Queries/QueriesWidgetContent/QueriesWidgetContent.tsx
@@ -3,7 +3,7 @@ import {useSelector} from '../../../../../../store/redux-hooks';
 import {createColumnHelper} from '@gravity-ui/table/tanstack';
 
 import {RootState} from '../../../../../../store/reducers';
-import {getQueryFilterState} from '../../../../../../store/selectors/dashboard2/queries';
+import {selectQueryFilterState} from '../../../../../../store/selectors/dashboard2/queries';
 
 import {WidgetTable} from '../../../../../../pages/dashboard2/Dashboard/components/WidgetTable/WidgetTable';
 import {WidgetText} from '../../../../../../pages/dashboard2/Dashboard/components/WidgetText/WidgetText';
@@ -62,7 +62,7 @@ const columns = [
 export function QueriesWidgetContent(props: QueriesWidgetProps) {
     const {queries, error, isLoading} = useQueriesWidget(props);
 
-    const queryState = useSelector((state: RootState) => getQueryFilterState(state, props.id));
+    const queryState = useSelector((state: RootState) => selectQueryFilterState(state, props.id));
     const itemsName = i18n(`fallback-item_${queryState || 'all'}`);
 
     return (

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Queries/QueriesWidgetControls/QueriesWidgetControls.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Queries/QueriesWidgetControls/QueriesWidgetControls.tsx
@@ -10,8 +10,8 @@ import format from '../../../../../../common/hammer/format';
 import {RootState} from '../../../../../../store/reducers';
 import {
     type QueryStatusesFilter,
-    getQueryFilterEngine,
-    getQueryFilterState,
+    selectQueryFilterEngine,
+    selectQueryFilterState,
 } from '../../../../../../store/selectors/dashboard2/queries';
 import {
     setQueryEngineFilter,
@@ -55,8 +55,8 @@ export function QueriesWidgetControls(props: QueriesWidgetProps) {
 
     const dispatch = useDispatch();
 
-    const queryState = useSelector((state: RootState) => getQueryFilterState(state, id));
-    const engine = useSelector((state: RootState) => getQueryFilterEngine(state, id));
+    const queryState = useSelector((state: RootState) => selectQueryFilterState(state, id));
+    const engine = useSelector((state: RootState) => selectQueryFilterEngine(state, id));
 
     const onStateUpdate = (value: string[]) => {
         dispatch(setQueryStateFilter(id, value[0]));

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Queries/hooks/use-queries-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Queries/hooks/use-queries-widget.ts
@@ -6,8 +6,8 @@ import map_ from 'lodash/map';
 import {RootState} from '../../../../../../store/reducers';
 import {useListQueries} from '../../../../../../store/api/dashboard2/queries';
 import {
-    getQueryFilterEngine,
-    getQueryFilterState,
+    selectQueryFilterEngine,
+    selectQueryFilterState,
 } from '../../../../../../store/selectors/dashboard2/queries';
 import {selectCluster} from '../../../../../../store/selectors/global';
 
@@ -32,8 +32,8 @@ export function useQueriesWidget(props: QueriesWidgetProps) {
     const limit = data?.limit?.value || 0;
 
     const cluster = useSelector(selectCluster);
-    const queryState = useSelector((state: RootState) => getQueryFilterState(state, widgetId));
-    const engine = useSelector((state: RootState) => getQueryFilterEngine(state, widgetId));
+    const queryState = useSelector((state: RootState) => selectQueryFilterState(state, widgetId));
+    const engine = useSelector((state: RootState) => selectQueryFilterEngine(state, widgetId));
 
     let queryEngine = engine?.toLowerCase();
 

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/ServicesWidgetContent/ServicesWidgetContent.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/ServicesWidgetContent/ServicesWidgetContent.tsx
@@ -6,7 +6,7 @@ import format from '../../../../../../common/hammer/format';
 
 import {RootState} from '../../../../../../store/reducers';
 import {ServiceInfo} from '../../../../../../store/api/dashboard2/services/services';
-import {getServicesTypeFilter} from '../../../../../../store/selectors/dashboard2/services';
+import {selectServicesTypeFilter} from '../../../../../../store/selectors/dashboard2/services';
 
 import {WidgetTable} from '../../../../../../pages/dashboard2/Dashboard/components/WidgetTable/WidgetTable';
 import {GeneralCell} from '../../../../../../pages/dashboard2/Dashboard/components/GeneralCell/GeneralCell';
@@ -46,7 +46,7 @@ const columns = [
 export function ServicesWidgetContent(props: ServicesWidgetProps) {
     const {data, error, isLoading} = useServicesWidget(props);
 
-    const type = useSelector((state: RootState) => getServicesTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectServicesTypeFilter(state, props.id));
     const itemsName = i18n(`fallback-item_${type || 'default'}`);
 
     return (

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/ServicesWidgetControls/ServicesWidgetControls.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/ServicesWidgetControls/ServicesWidgetControls.tsx
@@ -4,7 +4,7 @@ import {SegmentedRadioGroup} from '@gravity-ui/uikit';
 
 import {RootState} from '../../../../../../store/reducers';
 import {setServicesTypeFilter} from '../../../../../../store/actions/dashboard2/services';
-import {getServicesTypeFilter} from '../../../../../../store/selectors/dashboard2/services';
+import {selectServicesTypeFilter} from '../../../../../../store/selectors/dashboard2/services';
 
 import type {ServicesWidgetProps} from '../types';
 
@@ -13,7 +13,7 @@ import i18n from '../i18n';
 export function ServicesWidgetControls(props: ServicesWidgetProps) {
     const dispatch = useDispatch();
 
-    const type = useSelector((state: RootState) => getServicesTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectServicesTypeFilter(state, props.id));
 
     const onUpdate = (value: 'favourite' | 'custom') => {
         dispatch(setServicesTypeFilter(props.id, value));

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/hooks/use-services-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Services/hooks/use-services-widget.ts
@@ -4,7 +4,7 @@ import {useServicesQuery} from '../../../../../../store/api/dashboard2/services'
 
 import {RootState} from '../../../../../../store/reducers';
 import {selectCluster} from '../../../../../../store/selectors/global';
-import {getServicesTypeFilter} from '../../../../../../store/selectors/dashboard2/services';
+import {selectServicesTypeFilter} from '../../../../../../store/selectors/dashboard2/services';
 import {
     selectFavouriteBundles,
     selectFavouriteChyt,
@@ -17,7 +17,7 @@ export function useServicesWidget(props: ServicesWidgetProps) {
 
     const cluster = useSelector(selectCluster);
 
-    const type = useSelector((state: RootState) => getServicesTypeFilter(state, props.id));
+    const type = useSelector((state: RootState) => selectServicesTypeFilter(state, props.id));
 
     const favouriteBundles = useSelector(selectFavouriteBundles);
     const favouriteCliques = useSelector(selectFavouriteChyt);

--- a/packages/ui/src/ui/store/actions/dashboard2/dashboard.ts
+++ b/packages/ui/src/ui/store/actions/dashboard2/dashboard.ts
@@ -14,7 +14,7 @@ import {
     setEdittingConfig,
     toggleEditting,
 } from '../../../store/reducers/dashboard2/dashboard';
-import {getDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
+import {selectDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
 
 import {defaultDashboardItems} from '../../../constants/dashboard2';
 import {makeDefaultConfig} from '../../../utils/dashboard2/make-default-config';
@@ -28,7 +28,7 @@ export function editConfig(
         const state = getState();
 
         const edittingConfig = getEdittingConfig(state);
-        const fallbackConfig = getDashboardConfig(state);
+        const fallbackConfig = selectDashboardConfig(state);
         const config = edittingConfig ?? fallbackConfig;
 
         const configItems = [...(config?.items || [])];
@@ -77,7 +77,7 @@ export function copyConfig(cluster: string): ThunkAction<void, RootState, any, a
 export function startEditting(): ThunkAction<void, RootState, any, any> {
     return (dispatch, getState) => {
         const state = getState();
-        const config = getDashboardConfig(state);
+        const config = selectDashboardConfig(state);
 
         dispatch(setEdittingConfig({edittingConfig: config}));
         dispatch(toggleEditting());

--- a/packages/ui/src/ui/store/actions/dashboard2/utils.ts
+++ b/packages/ui/src/ui/store/actions/dashboard2/utils.ts
@@ -8,7 +8,7 @@ import guid from '../../../common/hammer/guid';
 import {RootState} from '../../../store/reducers';
 import {setSettingByKey} from '../../../store/actions/settings';
 import {selectCluster} from '../../../store/selectors/global';
-import {getDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
+import {selectDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
 
 import {dashboardConfig} from '../../../constants/dashboard2';
 
@@ -19,7 +19,7 @@ export function createWidgetDataFieldAction<FieldType>(
         return (dispatch, getState) => {
             const state = getState();
             const cluster = selectCluster(state);
-            const config = getDashboardConfig(state);
+            const config = selectDashboardConfig(state);
 
             const oldItem = config.items.find((item) => item.id === id);
 

--- a/packages/ui/src/ui/store/actions/execute-batch.ts
+++ b/packages/ui/src/ui/store/actions/execute-batch.ts
@@ -14,7 +14,7 @@ import {
     EXECUTE_BATCH_RETRY_SHOW_MODAL,
 } from '../../constants/execute-batch';
 import {rumLogError} from '../../rum/rum-counter';
-import {getExecuteBatchState} from '../selectors/execute-batch';
+import {selectExecuteBatchState} from '../selectors/execute-batch';
 import {CancelTokenSource} from 'axios';
 import {ytApiV3Id} from '../../rum/rum-wrap-api';
 import {BatchResultsItem, BatchSubRequest} from '../../../shared/yt-types';
@@ -192,7 +192,7 @@ export function hideExecuteBatchRetryModal(id: string): ExecuteBatchThunkAction 
 
 export function abortExecuteBatch(id: string): ExecuteBatchThunkAction {
     return (dispatch, getState) => {
-        const {rejectCb, error} = getExecuteBatchState(getState())[id];
+        const {rejectCb, error} = selectExecuteBatchState(getState())[id];
         rejectCb!(error);
         dispatch(hideExecuteBatchRetryModal(id));
     };
@@ -200,7 +200,7 @@ export function abortExecuteBatch(id: string): ExecuteBatchThunkAction {
 
 export function skipExecuteBatch(id: string): ExecuteBatchThunkAction {
     return (dispatch, getState) => {
-        const {resolveCb} = getExecuteBatchState(getState())[id];
+        const {resolveCb} = selectExecuteBatchState(getState())[id];
         resolveCb!([]);
         dispatch(hideExecuteBatchRetryModal(id));
     };
@@ -208,7 +208,7 @@ export function skipExecuteBatch(id: string): ExecuteBatchThunkAction {
 
 export function retryExecuteBatch(id: string): ExecuteBatchThunkAction {
     return (dispatch, getState) => {
-        const item = getExecuteBatchState(getState())[id];
+        const item = selectExecuteBatchState(getState())[id];
         if (!item) {
             rumLogError({
                 message: `executeBatch with retries, store does not contain any elements with id=${id}`,

--- a/packages/ui/src/ui/store/selectors/dashboard2/accounts.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/accounts.ts
@@ -11,18 +11,24 @@ export const getAccountsTypeFilter = createWidgetDataFieldSelector<
     'favourite' | 'usable' | 'custom'
 >('type', 'favourite');
 
-const getCustomAccountsList = (_state: RootState, _widgetId: string, custom: string[]) => custom;
+const selectCustomAccountsList = (_state: RootState, _widgetId: string, custom: string[]) => custom;
 
-const getUsableAccountsImpl = (state: RootState, cluster: string) =>
+const selectUsableAccountsImpl = (state: RootState, cluster: string) =>
     accountsApi.endpoints.usableAccounts.select({cluster})(state)?.data;
 
-const getUsableAccounts = (state: RootState) => {
+const selectUsableAccounts = (state: RootState) => {
     const cluster = selectCluster(state);
-    return getUsableAccountsImpl(state, cluster);
+
+    return selectUsableAccountsImpl(state, cluster);
 };
 
-export const getAccountsList = createSelector(
-    [selectFavouriteAccounts, getUsableAccounts, getCustomAccountsList, getAccountsTypeFilter],
+export const selectAccountsList = createSelector(
+    [
+        selectFavouriteAccounts,
+        selectUsableAccounts,
+        selectCustomAccountsList,
+        getAccountsTypeFilter,
+    ],
     (favourite, usable, custom, type) => {
         if (type === 'favourite') {
             return favourite?.length ? favourite.map((item) => item?.path) : [];

--- a/packages/ui/src/ui/store/selectors/dashboard2/accounts.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/accounts.ts
@@ -7,7 +7,7 @@ import {selectCluster} from '../../../store/selectors/global/cluster';
 
 import {createWidgetDataFieldSelector} from './utils';
 
-export const getAccountsTypeFilter = createWidgetDataFieldSelector<
+export const selectAccountsTypeFilter = createWidgetDataFieldSelector<
     'favourite' | 'usable' | 'custom'
 >('type', 'favourite');
 
@@ -27,7 +27,7 @@ export const selectAccountsList = createSelector(
         selectFavouriteAccounts,
         selectUsableAccounts,
         selectCustomAccountsList,
-        getAccountsTypeFilter,
+        selectAccountsTypeFilter,
     ],
     (favourite, usable, custom, type) => {
         if (type === 'favourite') {

--- a/packages/ui/src/ui/store/selectors/dashboard2/dashboard.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/dashboard.ts
@@ -8,7 +8,7 @@ import {dashboardConfig} from '../../../constants/dashboard2';
 
 import {makeDefaultConfig} from '../../../utils/dashboard2/make-default-config';
 
-export const getDashboardConfig = createSelector(
+export const selectDashboardConfig = createSelector(
     [getSettingsData, selectCluster],
     (data, cluster) => {
         // if user setuped his dashboard on current cluster no need to retrun default values
@@ -23,5 +23,5 @@ export const getDashboardConfig = createSelector(
     },
 );
 
-export const getSettingNewDashboardPage = (state: RootState) =>
+export const selectSettingNewDashboardPage = (state: RootState) =>
     getSettingsData(state)['global::newDashboardPage'];

--- a/packages/ui/src/ui/store/selectors/dashboard2/navigation.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/navigation.ts
@@ -1,6 +1,5 @@
 import {createWidgetDataFieldSelector} from './utils';
 
-export const getNavigationTypeFilter = createWidgetDataFieldSelector<'last_visited' | 'favourite'>(
-    'type',
-    'last_visited',
-);
+export const selectNavigationTypeFilter = createWidgetDataFieldSelector<
+    'last_visited' | 'favourite'
+>('type', 'last_visited');

--- a/packages/ui/src/ui/store/selectors/dashboard2/operations.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/operations.ts
@@ -1,7 +1,8 @@
 import {createWidgetDataFieldSelector} from './utils';
 
-export const getOperationsStateFilter = createWidgetDataFieldSelector<string>('state', 'all');
-export const getOperationsAuthorTypeFilter = createWidgetDataFieldSelector<'me' | 'custom'>(
+export const selectOperationsStateFilter = createWidgetDataFieldSelector<string>('state', 'all');
+
+export const selectOperationsAuthorTypeFilter = createWidgetDataFieldSelector<'me' | 'custom'>(
     'authorType',
     'me',
 );

--- a/packages/ui/src/ui/store/selectors/dashboard2/pools.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/pools.ts
@@ -1,6 +1,6 @@
 import {createWidgetDataFieldSelector} from './utils';
 
-export const getPoolsTypeFilter = createWidgetDataFieldSelector<'favourite' | 'custom'>(
+export const selectPoolsTypeFilter = createWidgetDataFieldSelector<'favourite' | 'custom'>(
     'type',
     'favourite',
 );

--- a/packages/ui/src/ui/store/selectors/dashboard2/queries.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/queries.ts
@@ -8,5 +8,6 @@ export type QueryStatusesFilter =
     | 'aborted'
     | undefined;
 
-export const getQueryFilterState = createWidgetDataFieldSelector<QueryStatusesFilter>('state');
-export const getQueryFilterEngine = createWidgetDataFieldSelector<string | undefined>('engine');
+export const selectQueryFilterState = createWidgetDataFieldSelector<QueryStatusesFilter>('state');
+
+export const selectQueryFilterEngine = createWidgetDataFieldSelector<string | undefined>('engine');

--- a/packages/ui/src/ui/store/selectors/dashboard2/services.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/services.ts
@@ -1,6 +1,6 @@
 import {createWidgetDataFieldSelector} from './utils';
 
-export const getServicesTypeFilter = createWidgetDataFieldSelector<'favourite' | 'custom'>(
+export const selectServicesTypeFilter = createWidgetDataFieldSelector<'favourite' | 'custom'>(
     'type',
     'favourite',
 );

--- a/packages/ui/src/ui/store/selectors/dashboard2/utils.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/utils.ts
@@ -2,12 +2,16 @@ import {createSelector} from '@reduxjs/toolkit';
 
 import find_ from 'lodash/find';
 
-import {selectDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
+import {selectDashboardConfig} from './dashboard';
 
 export function createWidgetDataFieldSelector<T>(field: string, fallback?: T) {
-    return createSelector([selectDashboardConfig, (_, widgetId) => widgetId], (config, widgetId) => {
-        const items = config.items;
-        const widget = find_(items, (item) => item.id === widgetId);
-        return (widget?.data?.[field] || fallback) as T;
-    });
+    return createSelector(
+        [selectDashboardConfig, (_, widgetId) => widgetId],
+        (config, widgetId) => {
+            const items = config.items;
+            const widget = find_(items, (item) => item.id === widgetId);
+
+            return (widget?.data?.[field] || fallback) as T;
+        },
+    );
 }

--- a/packages/ui/src/ui/store/selectors/dashboard2/utils.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/utils.ts
@@ -2,10 +2,10 @@ import {createSelector} from '@reduxjs/toolkit';
 
 import find_ from 'lodash/find';
 
-import {getDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
+import {selectDashboardConfig} from '../../../store/selectors/dashboard2/dashboard';
 
 export function createWidgetDataFieldSelector<T>(field: string, fallback?: T) {
-    return createSelector([getDashboardConfig, (_, widgetId) => widgetId], (config, widgetId) => {
+    return createSelector([selectDashboardConfig, (_, widgetId) => widgetId], (config, widgetId) => {
         const items = config.items;
         const widget = find_(items, (item) => item.id === widgetId);
         return (widget?.data?.[field] || fallback) as T;

--- a/packages/ui/src/ui/store/selectors/execute-batch.ts
+++ b/packages/ui/src/ui/store/selectors/execute-batch.ts
@@ -1,5 +1,5 @@
 import {RootState} from '../reducers';
 
-export function getExecuteBatchState(state: RootState) {
+export function selectExecuteBatchState(state: RootState) {
     return state.executeBatch;
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/nTneoobC7ZiSav
<!-- nda-end -->## Summary by Sourcery

Rename dashboard v2 and execute-batch selectors to follow the `select*` naming convention and update all usages accordingly.

Enhancements:
- Align dashboard v2 selectors (accounts, navigation, operations, pools, queries, services, dashboard config, settings) with a consistent `select*` naming scheme.
- Standardize execute-batch state selector naming and update related actions and UI components to use it.