### PR TITLE
fix(Navigation/tablets): correcting the sorting and display of fields…

### DIFF
--- a/packages/ui/src/ui/constants/accounts/accounts.ts
+++ b/packages/ui/src/ui/constants/accounts/accounts.ts
@@ -118,7 +118,7 @@ export const ACCOUNT_RESOURCE_TYPES_DESCRIPTION = {
     [AccountResourceName.TABLET_STATIC_MEMORY]: {
         format: 'Bytes' as const,
         getInfo: (account: AccountSelector, recursive?: boolean): AccountResourceInfo => {
-            return account?.getTabletStaticMemoryInfo(recursive) || {};
+            return account?.selectTabletstaticMemoryInfo(recursive) || {};
         },
     },
     [AccountResourceName.MASTER_MEMORY]: {

--- a/packages/ui/src/ui/constants/accounts/accounts.ts
+++ b/packages/ui/src/ui/constants/accounts/accounts.ts
@@ -118,7 +118,7 @@ export const ACCOUNT_RESOURCE_TYPES_DESCRIPTION = {
     [AccountResourceName.TABLET_STATIC_MEMORY]: {
         format: 'Bytes' as const,
         getInfo: (account: AccountSelector, recursive?: boolean): AccountResourceInfo => {
-            return account?.selectTabletstaticMemoryInfo(recursive) || {};
+            return account?.selectTabletStaticMemoryInfo(recursive) || {};
         },
     },
     [AccountResourceName.MASTER_MEMORY]: {

--- a/packages/ui/src/ui/pages/accounts/selector.js
+++ b/packages/ui/src/ui/pages/accounts/selector.js
@@ -97,7 +97,7 @@ export default class Account {
         };
     }
 
-    getTabletStaticMemoryInfo(recursive = true) {
+    selectTabletstaticMemoryInfo(recursive = true) {
         const src = this.getResourceInfoSource(recursive);
         return {
             committed: src.committedTabletStaticMemory,

--- a/packages/ui/src/ui/pages/accounts/selector.js
+++ b/packages/ui/src/ui/pages/accounts/selector.js
@@ -97,7 +97,7 @@ export default class Account {
         };
     }
 
-    selectTabletstaticMemoryInfo(recursive = true) {
+    selectTabletStaticMemoryInfo(recursive = true) {
         const src = this.getResourceInfoSource(recursive);
         return {
             committed: src.committedTabletStaticMemory,

--- a/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.js
+++ b/packages/ui/src/ui/pages/navigation/tabs/Tablets/Tablets.js
@@ -24,10 +24,10 @@ import {getPath, getType} from '../../../../store/selectors/navigation';
 
 import {
     getActiveHistogram,
-    getNavigationTabletsLoadingStatus,
-    getTablets,
-    hasReplicationData,
     selectHistogram,
+    selectIsReplicationDataExist,
+    selectNavigationTabletsLoadingStatus,
+    selectTablets,
 } from '../../../../store/selectors/navigation/tabs/tablets';
 
 import {NAVIGATION_TABLETS_TABLE_ID} from '../../../../constants/navigation/tabs/tablets';
@@ -56,8 +56,8 @@ import {isFinalLoadingStatus} from '../../../../utils/utils';
 import {useAppRumMeasureStart} from '../../../../rum/rum-app-measures';
 import {Host} from '../../../../containers/Host/Host';
 import {
-    getTabletsByName,
-    getTabletsMax,
+    selectTabletsByName,
+    selectTabletsMax,
 } from '../../../../store/selectors/navigation/tabs/tablets-ts';
 import {getProgressBarColorByIndex} from '../../../../constants/colors';
 
@@ -272,6 +272,11 @@ class Tablets extends Component {
         );
     }
 
+    static renderReplicationLag(item, columnName) {
+        const replicationLag = item[columnName];
+        return hammer.format['TimeDuration'](replicationLag);
+    }
+
     static renderReplicationMode(item, columnName) {
         const replicationMode = item[columnName];
         return typeof replicationMode !== 'undefined' ? (
@@ -470,8 +475,8 @@ class Tablets extends Component {
                 dynamic_delete: asNumber,
                 unmerged_row_read_rate: asNumber,
                 merged_row_read_rate: asNumber,
-                replication_lag_time: asNumber,
-                replication_mode: this.renderReplicationMode,
+                replication_lag_time: Tablets.renderReplicationLag,
+                replication_mode: Tablets.renderReplicationMode,
             },
             computeKey(item) {
                 return item.name || item.tablet_id;
@@ -648,18 +653,18 @@ const mapStateToProps = (state) => {
     let tablets;
     let maxByLevel = [];
     if (tabletsMode === 'by_host' || tabletsMode === 'by_cell') {
-        const data = getTabletsByName(state);
+        const data = selectTabletsByName(state);
         tablets = data.items;
         maxByLevel = data.maxByLevel;
     } else {
-        tablets = getTablets(state);
-        maxByLevel = [getTabletsMax(state)];
+        tablets = selectTablets(state);
+        maxByLevel = [selectTabletsMax(state)];
     }
 
     const histogram = selectHistogram(state);
     const activeHistogram = getActiveHistogram(state);
     const type = getType(state);
-    const hasReplication = hasReplicationData(state);
+    const hasReplication = selectIsReplicationDataExist(state);
 
     return {
         loading,
@@ -693,7 +698,7 @@ const mapDispatchToProps = {
 const TabletsConnected = connect(mapStateToProps, mapDispatchToProps)(Tablets);
 
 export default function TabletsWithRum() {
-    const loadState = useSelector(getNavigationTabletsLoadingStatus);
+    const loadState = useSelector(selectNavigationTabletsLoadingStatus);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.NAVIGATION_TAB_TABLETS,

--- a/packages/ui/src/ui/store/actions/navigation/tabs/tablets.js
+++ b/packages/ui/src/ui/store/actions/navigation/tabs/tablets.js
@@ -11,7 +11,7 @@ import {
     TOGGLE_HISTOGRAM,
 } from '../../../../constants/navigation/tabs/tablets';
 import {YTApiId, ytApiV3Id} from '../../../../rum/rum-wrap-api';
-import {getTabletsExpandedHosts} from '../../../../store/selectors/navigation/tabs/tablets-ts';
+import {selectTabletsExpandedHosts} from '../../../../store/selectors/navigation/tabs/tablets-ts';
 
 const requests = new CancelHelper();
 
@@ -70,7 +70,7 @@ export function changeTabletsMode(evt) {
 
 export function toggleExpandedHost(name) {
     return (dispatch, getState) => {
-        const expandedHosts = getTabletsExpandedHosts(getState()).slice();
+        const expandedHosts = selectTabletsExpandedHosts(getState()).slice();
         const index = expandedHosts.indexOf(name);
         if (index >= 0) {
             expandedHosts.splice(index, 1);

--- a/packages/ui/src/ui/store/location.main.ts
+++ b/packages/ui/src/ui/store/location.main.ts
@@ -69,9 +69,9 @@ import {
 import {getSystemPreparedState, systemParams} from '../store/reducers/system/url-mapping';
 import {
     bundlesPrometheusParams,
-    getTabletsBundlesAclPreparedState,
-    getTabletsBundlesPreparedState,
-    getTabletsCellsPreparedState,
+    selectTabletsBundlesAclPreparedState,
+    selectTabletsBundlesPreparedState,
+    selectTabletsCellsPreparedState,
     tabletsAllBundlesParams,
     tabletsBundlesAclParams,
     tabletsBundlesParams,
@@ -170,17 +170,17 @@ export const getMainLocations = (): Array<[string, PathParameters]> => [
 
     [
         `/*/${Page.TABLET_CELL_BUNDLES}/${TabletsTab.TABLET_CELLS}`,
-        [tabletsTabletCellsParams, getTabletsCellsPreparedState],
+        [tabletsTabletCellsParams, selectTabletsCellsPreparedState],
     ],
 
     [
         `/*/${Page.TABLET_CELL_BUNDLES}/${TabletsTab.ACL}`,
-        [tabletsBundlesAclParams, getTabletsBundlesAclPreparedState],
+        [tabletsBundlesAclParams, selectTabletsBundlesAclPreparedState],
     ],
 
-    [`/*/${Page.TABLET_CELL_BUNDLES}`, [tabletsAllBundlesParams, getTabletsBundlesPreparedState]],
+    [`/*/${Page.TABLET_CELL_BUNDLES}`, [tabletsAllBundlesParams, selectTabletsBundlesPreparedState]],
     [`/*/${Page.TABLET_CELL_BUNDLES}/monitor`, [bundlesPrometheusParams]],
-    [`/*/${Page.TABLET_CELL_BUNDLES}/*`, [tabletsBundlesParams, getTabletsBundlesPreparedState]],
+    [`/*/${Page.TABLET_CELL_BUNDLES}/*`, [tabletsBundlesParams, selectTabletsBundlesPreparedState]],
 
     [
         `/*/${Page.CHAOS_CELL_BUNDLES}/${TabletsTab.CHAOS_CELLS}`,

--- a/packages/ui/src/ui/store/reducers/tablet_cell_bundles/url-mapping.ts
+++ b/packages/ui/src/ui/store/reducers/tablet_cell_bundles/url-mapping.ts
@@ -18,7 +18,7 @@ export const tabletsBundlesParams = {
     ...tabletErrorsByBundleParams,
 };
 
-export function getTabletsBundlesPreparedState(
+export function selectTabletsBundlesPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -89,7 +89,7 @@ export const tabletsTabletCellsParams = {
     },
 };
 
-export function getTabletsCellsPreparedState(
+export function selectTabletsCellsPreparedState(
     state: RootState,
     {query}: {query: RootState},
 ): RootState {
@@ -110,7 +110,7 @@ export const tabletsBundlesAclParams = {
     ...aclFiltersParams,
 };
 
-export function getTabletsBundlesAclPreparedState(
+export function selectTabletsBundlesAclPreparedState(
     prevState: RootState,
     {query}: {query: RootState},
 ): RootState {

--- a/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
@@ -73,7 +73,7 @@ export interface AccountSelector {
 
     getNodeCountProgressInfo(recursive?: boolean): ProgressInfo;
     getChunkCountProgressInfo(recursive?: boolean): ProgressInfo;
-    getTabletStaticMemoryInfo(recursive?: boolean): ProgressInfo;
+    selectTabletstaticMemoryInfo(recursive?: boolean): ProgressInfo;
 }
 
 interface ProgressInfo {

--- a/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
@@ -73,7 +73,7 @@ export interface AccountSelector {
 
     getNodeCountProgressInfo(recursive?: boolean): ProgressInfo;
     getChunkCountProgressInfo(recursive?: boolean): ProgressInfo;
-    selectTabletstaticMemoryInfo(recursive?: boolean): ProgressInfo;
+    selectTabletStaticMemoryInfo(recursive?: boolean): ProgressInfo;
 }
 
 interface ProgressInfo {

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablets-ts.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablets-ts.ts
@@ -5,7 +5,7 @@ import reduce_ from 'lodash/reduce';
 import toArray_ from 'lodash/toArray';
 
 import {createSelector} from 'reselect';
-import {getPreparedDataForColumns, getTabletsMode, getTabletsSortState} from './tablets';
+import {getTabletsMode, getTabletsSortState, selectPreparedDataForColumns} from './tablets';
 import {
     type FieldDescr,
     type TreeItem,
@@ -16,7 +16,7 @@ import {
 import {type OldSortState, type TypedKeys} from '../../../../types';
 import {type RootState} from '../../../reducers';
 
-export const getTabletsExpandedHosts = (state: RootState): Array<string> =>
+export const selectTabletsExpandedHosts = (state: RootState): Array<string> =>
     state.navigation.tabs.tablets.expandedHosts;
 
 interface TabletInfo {
@@ -63,7 +63,7 @@ function addHostItem(
     });
 }
 
-export const getTabletsMax = createSelector([getPreparedDataForColumns], (items) => {
+export const selectTabletsMax = createSelector([selectPreparedDataForColumns], (items) => {
     const max = {
         unmerged_row_count: 0,
         uncompressed_data_size: 0,
@@ -78,8 +78,8 @@ export const getTabletsMax = createSelector([getPreparedDataForColumns], (items)
     return max;
 });
 
-const getTabletsByNameRoot = createSelector(
-    [getPreparedDataForColumns, getTabletsSortState, getTabletsMode],
+const selectTabletsByNameRoot = createSelector(
+    [selectPreparedDataForColumns, getTabletsSortState, getTabletsMode],
     (sortedAndFilteredItems, sortState, mode) => {
         const groupByKey = mode === 'by_host' ? 'cell_leader_address' : 'cell_id';
 
@@ -134,8 +134,8 @@ const getTabletsByNameRoot = createSelector(
     },
 );
 
-export const getTabletsByName = createSelector(
-    [getTabletsByNameRoot, getTabletsExpandedHosts],
+export const selectTabletsByName = createSelector(
+    [selectTabletsByNameRoot, selectTabletsExpandedHosts],
     ({root, maxByLevel}, expandedHosts) => {
         const expanded = new Set(expandedHosts);
         const children = map_(root.children, (item) => {

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
@@ -18,52 +18,45 @@ export const getTabletsSortState = (state) => state.tables[NAVIGATION_TABLETS_TA
 const getTabletsFilter = (state) => state.navigation.tabs.tablets.tabletsFilter;
 export const getActiveHistogram = (state) => state.navigation.tabs.tablets.histogramType;
 
-const selectSortedReplicationLagTimes = createSelector(
-    [getRawReplicationLagTimes, getTabletsSortState],
-    (rawTablets, sortState) => hammer.utils.sort(rawTablets, sortState, tableItems),
-);
+const selectMergedRawTablets = createSelector(
+    [getRawTablets, getRawReplicationLagTimes],
+    (rawTablets, rawReplicationLagTimes) => {
+        if (!rawReplicationLagTimes || rawReplicationLagTimes.length === 0) {
+            return rawTablets;
+        }
 
-const selectFilteredReplicationLagTimes = createSelector(
-    [selectSortedReplicationLagTimes, getTabletsFilter],
-    (sortedTablets, tabletsFilter) =>
-        hammer.filter.filter({
-            data: sortedTablets,
-            input: tabletsFilter,
-            factors: [
-                function (item) {
-                    return tableItems['replication_lag_time']?.get?.(item);
-                },
-                function (item) {
-                    return tableItems['replication_mode']?.get?.(item);
-                },
-            ],
-        }),
-);
-
-const selectPreparedReplicationLagTimes = createSelector(
-    [selectFilteredReplicationLagTimes],
-    (items) => {
-        const res = prepareDataForColumns(items);
-        return res;
-    },
-);
-
-const selectReplicationLagTimesMap = createSelector(
-    [selectPreparedReplicationLagTimes],
-    (replicationLagTimes) => {
-        const map = new Map();
-        replicationLagTimes.forEach((item) => {
-            map.set(item.tablet_id, {
-                replication_lag_time: item.replication_lag_time,
-                replication_mode: item.replication_mode,
+        const replicationByTabletId = new Map();
+        rawReplicationLagTimes.forEach((item) => {
+            const tabletId = tableItems['tablet_id'].get(item);
+            if (!tabletId) return;
+            replicationByTabletId.set(tabletId, {
+                replication_lag_time: tableItems['replication_lag_time'].get(item),
+                replication_mode: tableItems['replication_mode'].get(item),
             });
         });
-        return map;
+
+        if (replicationByTabletId.size === 0) {
+            return rawTablets;
+        }
+
+        return rawTablets.map((tablet) => {
+            const tabletId = tableItems['tablet_id'].get(tablet);
+            const replicationFields = replicationByTabletId.get(tabletId);
+            if (!replicationFields) return tablet;
+
+            if (tablet && tablet.$value !== undefined) {
+                return {
+                    ...tablet,
+                    $value: {...tablet.$value, ...replicationFields},
+                };
+            }
+            return {...tablet, ...replicationFields};
+        });
     },
 );
 
 const selectSortedTablets = createSelector(
-    [getRawTablets, getTabletsSortState],
+    [selectMergedRawTablets, getTabletsSortState],
     (rawTablets, sortState) => hammer.utils.sort(rawTablets, sortState, tableItems),
 );
 
@@ -86,6 +79,12 @@ const selectFilteredTablets = createSelector(
                 function (item) {
                     return tableItems['cell_leader_address'].get(item);
                 },
+                function (item) {
+                    return tableItems['replication_lag_time']?.get?.(item);
+                },
+                function (item) {
+                    return tableItems['replication_mode']?.get?.(item);
+                },
             ],
         }),
 );
@@ -96,36 +95,22 @@ export const selectPreparedDataForColumns = createSelector([selectFilteredTablet
     return res;
 });
 
-const selectMergedPreparedTablets = createSelector(
-    [selectPreparedDataForColumns, selectReplicationLagTimesMap],
-    (tablets, replicationLagMap) => {
-        return tablets.map((tablet) => {
-            const replicationData = replicationLagMap.get(tablet.tablet_id);
-            if (replicationData) {
-                return {
-                    ...tablet,
-                    replication_lag_time: replicationData.replication_lag_time,
-                    replication_mode: replicationData.replication_mode,
-                };
-            }
-            return tablet;
-        });
-    },
-);
-
 export const selectIsReplicationDataExist = createSelector(
-    [selectMergedPreparedTablets],
-    (tablets) => {
-        if (!tablets || tablets.length === 0) {
+    [getRawReplicationLagTimes],
+    (rawReplicationLagTimes) => {
+        if (!rawReplicationLagTimes || rawReplicationLagTimes.length === 0) {
             return false;
         }
-        return tablets.some(
-            (tablet) => tablet && (tablet.replication_lag_time || Boolean(tablet.replication_mode)),
+        return rawReplicationLagTimes.some(
+            (item) =>
+                item &&
+                (tableItems['replication_lag_time']?.get?.(item) ||
+                    Boolean(tableItems['replication_mode']?.get?.(item))),
         );
     },
 );
 
-export const selectTablets = createSelector(selectMergedPreparedTablets, (filteredTablets) => {
+export const selectTablets = createSelector(selectPreparedDataForColumns, (filteredTablets) => {
     const aggregation = prepareAggregation(filteredTablets);
     return [aggregation, ...filteredTablets];
 });

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablets.js
@@ -13,13 +13,43 @@ export const getTabletsMode = (state) => state.navigation.tabs.tablets.tabletsMo
 const getRawTablets = (state) => state.navigation.tabs.tablets.tablets;
 const getRawReplicationLagTimes = (state) => state.navigation.tabs.tablets.replicationLagTimes;
 
-const getPreparedReplicationLagTimes = createSelector([getRawReplicationLagTimes], (items) => {
-    const res = prepareDataForColumns(items);
-    return res;
-});
+/** @returns { OldSortState } */
+export const getTabletsSortState = (state) => state.tables[NAVIGATION_TABLETS_TABLE_ID];
+const getTabletsFilter = (state) => state.navigation.tabs.tablets.tabletsFilter;
+export const getActiveHistogram = (state) => state.navigation.tabs.tablets.histogramType;
 
-const getReplicationLagTimesMap = createSelector(
-    [getPreparedReplicationLagTimes],
+const selectSortedReplicationLagTimes = createSelector(
+    [getRawReplicationLagTimes, getTabletsSortState],
+    (rawTablets, sortState) => hammer.utils.sort(rawTablets, sortState, tableItems),
+);
+
+const selectFilteredReplicationLagTimes = createSelector(
+    [selectSortedReplicationLagTimes, getTabletsFilter],
+    (sortedTablets, tabletsFilter) =>
+        hammer.filter.filter({
+            data: sortedTablets,
+            input: tabletsFilter,
+            factors: [
+                function (item) {
+                    return tableItems['replication_lag_time']?.get?.(item);
+                },
+                function (item) {
+                    return tableItems['replication_mode']?.get?.(item);
+                },
+            ],
+        }),
+);
+
+const selectPreparedReplicationLagTimes = createSelector(
+    [selectFilteredReplicationLagTimes],
+    (items) => {
+        const res = prepareDataForColumns(items);
+        return res;
+    },
+);
+
+const selectReplicationLagTimesMap = createSelector(
+    [selectPreparedReplicationLagTimes],
     (replicationLagTimes) => {
         const map = new Map();
         replicationLagTimes.forEach((item) => {
@@ -32,18 +62,13 @@ const getReplicationLagTimesMap = createSelector(
     },
 );
 
-/** @returns { OldSortState } */
-export const getTabletsSortState = (state) => state.tables[NAVIGATION_TABLETS_TABLE_ID];
-const getTabletsFilter = (state) => state.navigation.tabs.tablets.tabletsFilter;
-export const getActiveHistogram = (state) => state.navigation.tabs.tablets.histogramType;
-
-const getSortedTablets = createSelector(
+const selectSortedTablets = createSelector(
     [getRawTablets, getTabletsSortState],
     (rawTablets, sortState) => hammer.utils.sort(rawTablets, sortState, tableItems),
 );
 
-const getFilteredTablets = createSelector(
-    [getSortedTablets, getTabletsFilter],
+const selectFilteredTablets = createSelector(
+    [selectSortedTablets, getTabletsFilter],
     (sortedTablets, tabletsFilter) =>
         hammer.filter.filter({
             data: sortedTablets,
@@ -65,14 +90,14 @@ const getFilteredTablets = createSelector(
         }),
 );
 
-export const getPreparedDataForColumns = createSelector([getFilteredTablets], (items) => {
+export const selectPreparedDataForColumns = createSelector([selectFilteredTablets], (items) => {
     /** @type {Array<TabletInfo>} */
     const res = prepareDataForColumns(items);
     return res;
 });
 
-const getMergedPreparedTablets = createSelector(
-    [getPreparedDataForColumns, getReplicationLagTimesMap],
+const selectMergedPreparedTablets = createSelector(
+    [selectPreparedDataForColumns, selectReplicationLagTimesMap],
     (tablets, replicationLagMap) => {
         return tablets.map((tablet) => {
             const replicationData = replicationLagMap.get(tablet.tablet_id);
@@ -88,16 +113,19 @@ const getMergedPreparedTablets = createSelector(
     },
 );
 
-export const hasReplicationData = createSelector([getMergedPreparedTablets], (tablets) => {
-    if (!tablets || tablets.length === 0) {
-        return false;
-    }
-    return tablets.some(
-        (tablet) => tablet && (tablet.replication_lag_time || Boolean(tablet.replication_mode)),
-    );
-});
+export const selectIsReplicationDataExist = createSelector(
+    [selectMergedPreparedTablets],
+    (tablets) => {
+        if (!tablets || tablets.length === 0) {
+            return false;
+        }
+        return tablets.some(
+            (tablet) => tablet && (tablet.replication_lag_time || Boolean(tablet.replication_mode)),
+        );
+    },
+);
 
-export const getTablets = createSelector(getMergedPreparedTablets, (filteredTablets) => {
+export const selectTablets = createSelector(selectMergedPreparedTablets, (filteredTablets) => {
     const aggregation = prepareAggregation(filteredTablets);
     return [aggregation, ...filteredTablets];
 });
@@ -120,7 +148,7 @@ export const selectHistogram = createSelector(
     (histograms, activeHistogram) => histograms[activeHistogram],
 );
 
-export const getNavigationTabletsLoadingStatus = createSelector(
+export const selectNavigationTabletsLoadingStatus = createSelector(
     [
         (state) => state.navigation.tabs.tablets.loading,
         (state) => state.navigation.tabs.tablets.loaded,

--- a/packages/ui/src/ui/utils/navigation/tabs/tables.js
+++ b/packages/ui/src/ui/utils/navigation/tabs/tables.js
@@ -71,21 +71,22 @@ export const tableItems = {
         overall: 'sum',
     },
     replication_lag_time: {
-        sort: true,
         align: 'right',
         caption: 'Replication Lag',
         get(tablet) {
             return ypath.getNumberDeprecated(tablet, '/replication_lag_time', undefined);
         },
+        sort: true,
         allowedOrderTypes: DESC_ASC_UNORDERED,
     },
     replication_mode: {
-        sort: true,
         align: 'center',
         caption: 'Replication Mode',
         get(tablet) {
             return ypath.getValue(tablet, '/replication_mode');
         },
+        sort: true,
+        allowedOrderTypes: DESC_ASC_UNORDERED,
     },
     pivot_key: {
         sort: false,


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/ZqoMs_bv7a6And
<!-- nda-end -->    … [YT-5611]

## Summary by Sourcery

Fix sorting, filtering, and display of replication lag and mode columns in the Navigation tablets view.

Bug Fixes:
- Apply table sort and text filter to replication lag data before building histogram data.
- Ensure replication lag values are treated as numeric values and formatted as time durations.
- Normalize replication mode values for consistent sorting and display.

Enhancements:
- Align replication lag and replication mode column configurations with the generic table sorting/filtering utilities.