### PR TITLE
fix: show all attributes of job [YTFRONT-4414]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
@@ -25,8 +25,8 @@ import {
     getJobs,
     hideInputPaths,
     showInputPaths,
+    showJobAttributesModal,
 } from '../../../../../../store/actions/operations/jobs';
-import {openAttributesModal} from '../../../../../../store/actions/modals/attributes-modal';
 import {promptAction, showErrorModal} from '../../../../../../store/actions/actions';
 import {performJobAction} from '../utils';
 import {LOADING_STATUS} from '../../../../../../constants/index';
@@ -68,7 +68,7 @@ class OperationJobsTable extends React.Component {
             }),
         }),
 
-        openAttributesModal: PropTypes.func.isRequired,
+        showJobAttributesModal: PropTypes.func.isRequired,
         showErrorModal: PropTypes.func.isRequired,
         showInputPaths: PropTypes.func.isRequired,
         hideInputPaths: PropTypes.func.isRequired,
@@ -244,7 +244,7 @@ class OperationJobsTable extends React.Component {
     };
 
     renderActions = (item) => {
-        const {openAttributesModal} = this.props;
+        const {showJobAttributesModal, operationId} = this.props;
 
         const button = (
             <Button view="flat-secondary" title="Show actions">
@@ -259,11 +259,7 @@ class OperationJobsTable extends React.Component {
         const secondGroup = [
             {
                 text: 'Show attributes',
-                action: () =>
-                    openAttributesModal({
-                        title: item.id,
-                        attributes: item.attributes,
-                    }),
+                action: () => showJobAttributesModal(operationId, item.id),
             },
         ];
 
@@ -527,6 +523,7 @@ function mapStateToProps(state, props) {
         inputPaths,
         cluster,
         login,
+        operationId,
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
         isLoading: props.isLoading || operationId !== jobsOperationId,
         taskNamesNumber,
@@ -534,7 +531,7 @@ function mapStateToProps(state, props) {
 }
 
 const mapDispatchToProps = {
-    openAttributesModal,
+    showJobAttributesModal,
     showInputPaths,
     hideInputPaths,
     showErrorModal,

--- a/packages/ui/src/ui/store/actions/operations/jobs.ts
+++ b/packages/ui/src/ui/store/actions/operations/jobs.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 import {type ThunkAction} from 'redux-thunk';
+import {type Action} from 'redux';
 
 import {
     EXTRA_JOBS_COUNT,
@@ -35,6 +36,8 @@ import {type KeysByType} from '../../../../@types/types';
 import {type TablesSortOrderAction} from '../../../store/reducers/tables';
 import {selectJobsOperationIncarnationsFilter} from '../../../store/selectors/operations/jobs';
 import {fetchOperationIncarnationAvailableItems} from './jobs-operation-incarnations';
+import {openModal} from '../modals/attributes-modal';
+import {showToasterError} from '../../../utils/utils';
 
 const requests = new CancelHelper();
 
@@ -79,6 +82,26 @@ export function getJob(): JobsListThunkAction {
                     });
                 }
             });
+    };
+}
+
+export function showJobAttributesModal(
+    operationId: string,
+    jobId: string,
+): ThunkAction<void, RootState, null, Action> {
+    return (dispatch) => {
+        const promise = ytApiV3
+            .getJob({
+                parameters: {
+                    operation_id: operationId,
+                    job_id: jobId,
+                },
+            })
+            .catch((error) => {
+                showToasterError('Get job attributes', error);
+                throw error;
+            });
+        dispatch(openModal({title: jobId, promise}));
     };
 }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/JbIbcSLp7aGCze
<!-- nda-end -->       ## Summary by Sourcery

Load full job attributes on demand and show them in the attributes modal instead of relying on the partial attributes present in the jobs table.

New Features:
- Add a thunk action to fetch a job by operation and job id and open the attributes modal with the result.

Enhancements:
- Wire the jobs table actions menu to the new thunk so that the "Show attributes" action always displays up-to-date job attributes.