### PR TITLE
feat(Queries): new spyt settings [YTFRONT-5378]

### DIFF
--- a/packages/ui/src/shared/utils/toolkit/type/index.ts
+++ b/packages/ui/src/shared/utils/toolkit/type/index.ts
@@ -1,1 +1,2 @@
 export * from './isTruthy';
+export * from './isPlainObject';

--- a/packages/ui/src/shared/utils/toolkit/type/isPlainObject.ts
+++ b/packages/ui/src/shared/utils/toolkit/type/isPlainObject.ts
@@ -1,0 +1,18 @@
+function isObject(o: unknown): o is object {
+    return Object.prototype.toString.call(o) === '[object Object]';
+}
+
+export const isPlainObject = (value: unknown): value is Record<PropertyKey, unknown> => {
+    if (isObject(value) === false) return false;
+
+    // If has modified constructor
+    const ctor = value.constructor;
+    if (ctor === undefined) return true;
+
+    // If has modified prototype
+    const prot = ctor.prototype;
+    if (isObject(prot) === false) return false;
+
+    // If constructor does not have an Object-specific method
+    return Object.prototype.hasOwnProperty.call(prot, 'isPrototypeOf');
+};

--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -557,8 +557,6 @@ export type YqlEnginesInfo = {
 
 export type SpytEnginesInfo = {
     clusters: string[];
-    default_engine: string;
-    engines: ('livy' | 'connect')[];
     default_settings?: {
         connect?: {
             executor_cores?: number;

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/FullTextSearch/i18n/en.json
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/FullTextSearch/i18n/en.json
@@ -1,4 +1,4 @@
 {
-  "title_fulltext-search-empty": "No queries to show",
+  "title_fulltext-search-empty": "The list is empty",
   "context_fulltext-search-empty-hint": "Try changing filters or the search query"
 }

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditor.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditor.tsx
@@ -21,11 +21,17 @@ type Props = {
     onStartQuery?: (queryId: string) => boolean | void;
     showStatusInTitle?: boolean;
     pathNavigation?: boolean;
+    hideAco?: boolean;
 };
 
 export type ResultMode = 'full' | 'minimized' | 'split';
 
-export const QueryEditor: FC<Props> = ({onStartQuery, showStatusInTitle, pathNavigation}) => {
+export const QueryEditor: FC<Props> = ({
+    onStartQuery,
+    showStatusInTitle,
+    pathNavigation,
+    hideAco,
+}) => {
     const dispatch = useDispatch();
     const query = useCurrentQuery();
     const {isQueryTrackerInfoLoading} = useQueryACO();
@@ -74,7 +80,11 @@ export const QueryEditor: FC<Props> = ({onStartQuery, showStatusInTitle, pathNav
                 getInitialSizes={() => partSizes}
             >
                 {resultViewMode !== 'full' && (
-                    <QueryEditorView onStartQuery={onStartQuery} pathNavigation={pathNavigation} />
+                    <QueryEditorView
+                        onStartQuery={onStartQuery}
+                        pathNavigation={pathNavigation}
+                        hideAco={hideAco}
+                    />
                 )}
 
                 {query?.id && isExecuted && (
@@ -82,6 +92,7 @@ export const QueryEditor: FC<Props> = ({onStartQuery, showStatusInTitle, pathNav
                         query={query}
                         setResultViewMode={setResultViewMode}
                         resultViewMode={resultViewMode}
+                        hideShareButton={hideAco}
                     />
                 )}
             </FlexSplitPane>

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
@@ -26,6 +26,7 @@ const b = cn('yt-qt-query-editor-view');
 type Props = {
     onStartQuery?: (queryId: string) => boolean | void;
     pathNavigation?: boolean;
+    hideAco?: boolean;
 };
 
 const INACTIVE_CLIQUE_REFRESH_INTERVAL = 5000;
@@ -33,6 +34,7 @@ const INACTIVE_CLIQUE_REFRESH_INTERVAL = 5000;
 export const QueryEditorView = memo<Props>(function QueryEditorView({
     onStartQuery,
     pathNavigation,
+    hideAco,
 }) {
     const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
     const {setEditor} = useMonaco();
@@ -141,7 +143,7 @@ export const QueryEditorView = memo<Props>(function QueryEditorView({
                                     </Button>
                                 </>
                             ) : null}
-                            {isACOSupported && <QueryACOSelect />}
+                            {isACOSupported && !hideAco && <QueryACOSelect />}
                         </>
                     )}
                 </div>

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/ResultView.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/ResultView.tsx
@@ -17,12 +17,14 @@ type Props = {
     query: QueryItem;
     resultViewMode: ResultMode;
     setResultViewMode: (v: ResultMode) => void;
+    hideShareButton?: boolean;
 };
 
 export const ResultView = memo<Props>(function ResultView({
     query,
     resultViewMode,
     setResultViewMode,
+    hideShareButton,
 }) {
     return (
         <QueryResults
@@ -32,7 +34,7 @@ export const ResultView = memo<Props>(function ResultView({
             toolbar={
                 <>
                     <Flex gap={2} className={b('results-toolbar-buttons')}>
-                        <ShareButton />
+                        {!hideShareButton && <ShareButton />}
                         <EditQueryACOModal query_id={query.id} />
                     </Flex>
                     {resultViewMode === 'split' ? (

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/PopupWithCloseButton.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/PopupWithCloseButton.tsx
@@ -9,6 +9,7 @@ const block = cn('popup-with-close-button');
 type Props = {
     anchorRef: React.RefObject<HTMLElement>;
     open: boolean;
+    showCloseButton?: boolean;
     className?: string;
     placement?: PopupProps['placement'];
     onClose: () => void;
@@ -21,6 +22,7 @@ export const PopupWithCloseButton: FC<PropsWithChildren<Props>> = ({
     children,
     className,
     placement = 'bottom',
+    showCloseButton = true,
 }) => {
     return (
         <Popup
@@ -34,9 +36,11 @@ export const PopupWithCloseButton: FC<PropsWithChildren<Props>> = ({
             }}
             placement={placement}
         >
-            <Button view="flat" className={block('close-button')} onClick={onClose}>
-                <Icon data={XmarkIcon} />
-            </Button>
+            {showCloseButton && (
+                <Button view="flat" className={block('close-button')} onClick={onClose}>
+                    <Icon data={XmarkIcon} />
+                </Button>
+            )}
             {children}
         </Popup>
     );

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettings.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettings.scss
@@ -1,0 +1,7 @@
+.yt-query-settings {
+    &__item {
+        &:last-of-type {
+            border-bottom: none;
+        }
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettings.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettings.tsx
@@ -1,0 +1,89 @@
+import React, {type FC, useCallback} from 'react';
+import {SettingsAddForm} from './SettingsAddForm';
+import {SettingsItem} from './SettingsItem';
+import {VALIDATOR_ERRORS_TEXT, formValidator} from './formValidator';
+import {type SaveFormData, type Props as SettingsItemEditFormProps} from './SettingsItemForm';
+import './QuerySettings.scss';
+import cn from 'bem-cn-lite';
+import {type DraftQuery} from '../../../types/query-tracker/api';
+
+const SETTINGS_WITHOUT_EDIT_NODE = ['cluster', 'clique'];
+const SETTING_WITHOUT_REMOVE = 'cluster';
+
+const block = cn('yt-query-settings');
+
+type Props = {
+    settings?: DraftQuery['settings'];
+    onChange: (settings: DraftQuery['settings']) => void;
+};
+
+export const QuerySettings: FC<Props> = ({settings, onChange}) => {
+    const handleDelete = useCallback(
+        (name: string) => {
+            const newSettings = {...settings};
+            if (name in newSettings) delete newSettings[name];
+            onChange(newSettings);
+        },
+        [onChange, settings],
+    );
+
+    const handleAddSettings = useCallback(
+        ({name, value}: SaveFormData) => {
+            const newSettings = {...settings};
+            newSettings[name] = value;
+            onChange(newSettings);
+        },
+        [onChange, settings],
+    );
+
+    const handleChangeSettings = useCallback(
+        ({oldName, name, value}: SaveFormData) => {
+            const newSettings = {...settings};
+            if (oldName !== name) {
+                delete newSettings[oldName];
+            }
+            newSettings[name] = value;
+            onChange(newSettings);
+        },
+        [onChange, settings],
+    );
+
+    const validator = useCallback<SettingsItemEditFormProps['validator']>(
+        (oldName, name, value) => {
+            const result = formValidator(name, value);
+            if (settings && name in settings) {
+                if (oldName === name) return result;
+                result.name = VALIDATOR_ERRORS_TEXT.NAME_ALREADY_EXIST;
+            }
+            return result;
+        },
+        [settings],
+    );
+
+    return (
+        <>
+            <div className={block()}>
+                {Object.entries(settings || {}).map(([name, value]) => {
+                    const canEdit = SETTINGS_WITHOUT_EDIT_NODE.includes(name)
+                        ? undefined
+                        : {name: true, value: true};
+
+                    return (
+                        <SettingsItem
+                            className={block('item')}
+                            key={name}
+                            name={name}
+                            value={value as string}
+                            canEdit={canEdit}
+                            canRemove={name !== SETTING_WITHOUT_REMOVE}
+                            validator={validator}
+                            onDelete={handleDelete}
+                            onChange={handleChangeSettings}
+                        />
+                    );
+                })}
+            </div>
+            <SettingsAddForm onAdd={handleAddSettings} validator={validator} />
+        </>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettingsButton/QuerySettingsButton.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettingsButton/QuerySettingsButton.scss
@@ -7,10 +7,4 @@
     &__header {
         padding-bottom: 12px;
     }
-
-    &__body {
-        .settings-item:last-of-type {
-            border-bottom: none;
-        }
-    }
 }

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettingsButton/QuerySettingsButton.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettingsButton/QuerySettingsButton.tsx
@@ -1,84 +1,46 @@
 import {Button, Icon, Text} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {type FC, useMemo, useRef} from 'react';
 import GearIcon from '@gravity-ui/icons/svgs/gear.svg';
 import GearDotIcon from '@gravity-ui/icons/svgs/gear-dot.svg';
-import {SettingsItem} from '../SettingsItem';
-import {type SaveFormData, type Props as SettingsItemEditFormProps} from '../SettingsItemForm';
 import './QuerySettingsButton.scss';
-import {SettingsAddForm} from '../SettingsAddForm';
 import {PopupWithCloseButton} from '../PopupWithCloseButton';
-import {VALIDATOR_ERRORS_TEXT, formValidator} from '../formValidator';
 import i18n from './i18n';
-
-const SETTINGS_WITHOUT_EDIT_NODE = ['cluster', 'clique'];
-const SETTING_WITHOUT_REMOVE = 'cluster';
+import {useToggle} from 'react-use';
+import {QueryEngine} from '../../../../../shared/constants/engines';
+import {QuerySettings} from '../QuerySettings';
+import {SpytSettings} from '../SpytSettings/SpytSettings';
+import {type DraftQuery} from '../../../../types/query-tracker/api';
 
 const block = cn('query-settings-popup');
 
-export const QuerySettingsButton = ({
+type Props = {
+    className?: string;
+    popupClassName?: string;
+    onChange: (settings: DraftQuery['settings']) => void;
+    settings?: DraftQuery['settings'];
+    engine: QueryEngine;
+};
+
+export const QuerySettingsButton: FC<Props> = ({
     settings,
+    engine,
     className,
     popupClassName,
     onChange,
-}: {
-    className?: string;
-    popupClassName?: string;
-    onChange: (settings: Record<string, string>) => void;
-    settings?: Record<string, string>;
 }) => {
-    const [opened, setOpened] = useState<boolean>(false);
+    const [opened, toggleOpened] = useToggle(false);
     const ref = useRef(null);
-
-    const toggleOpened = useCallback(() => {
-        setOpened(!opened);
-    }, [setOpened, opened]);
 
     const count = useMemo(() => {
         return settings ? Object.keys(settings).length : 0;
     }, [settings]);
+    const isSpyt = engine === QueryEngine.SPYT;
 
-    const handleDelete = useCallback(
-        (name: string) => {
-            const newSettings = {...settings};
-            if (name in newSettings) delete newSettings[name];
-            onChange(newSettings);
-        },
-        [onChange, settings],
-    );
-
-    const handleAddSettings = useCallback(
-        ({name, value}: SaveFormData) => {
-            const newSettings = {...settings};
-            newSettings[name] = value;
-            onChange(newSettings);
-        },
-        [onChange, settings],
-    );
-
-    const handleChangeSettings = useCallback(
-        ({oldName, name, value}: SaveFormData) => {
-            const newSettings = {...settings};
-            if (oldName !== name) {
-                delete newSettings[oldName];
-            }
-            newSettings[name] = value;
-            onChange(newSettings);
-        },
-        [onChange, settings],
-    );
-
-    const validator = useCallback<SettingsItemEditFormProps['validator']>(
-        (oldName, name, value) => {
-            const result = formValidator(name, value);
-            if (settings && name in settings) {
-                if (oldName === name) return result;
-                result.name = VALIDATOR_ERRORS_TEXT.NAME_ALREADY_EXIST;
-            }
-            return result;
-        },
-        [settings],
-    );
+    const handleSpytChange = (newSettings: NonNullable<DraftQuery['settings']>) => {
+        onChange(newSettings);
+        toggleOpened();
+    };
 
     return (
         <>
@@ -97,6 +59,7 @@ export const QuerySettingsButton = ({
                 open={opened}
                 className={block(null, popupClassName)}
                 onClose={toggleOpened}
+                showCloseButton={!isSpyt}
             >
                 <div className={block('header')}>
                     <Text variant="subheader-3">{i18n('title_settings')} </Text>
@@ -106,25 +69,15 @@ export const QuerySettingsButton = ({
                         </Text>
                     )}
                 </div>
-                <div className={block('body')}>
-                    {Object.entries(settings || {}).map(([name, value]) => (
-                        <SettingsItem
-                            key={name}
-                            name={name}
-                            value={value}
-                            canEdit={
-                                SETTINGS_WITHOUT_EDIT_NODE.includes(name)
-                                    ? undefined
-                                    : {name: true, value: true}
-                            }
-                            canRemove={name !== SETTING_WITHOUT_REMOVE}
-                            validator={validator}
-                            onDelete={handleDelete}
-                            onChange={handleChangeSettings}
-                        />
-                    ))}
-                </div>
-                <SettingsAddForm onAdd={handleAddSettings} validator={validator} />
+                {isSpyt ? (
+                    <SpytSettings
+                        settings={settings}
+                        onChange={handleSpytChange}
+                        onCancel={toggleOpened}
+                    />
+                ) : (
+                    <QuerySettings settings={settings} onChange={onChange} />
+                )}
             </PopupWithCloseButton>
         </>
     );

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SettingsItem/SettingsItem.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SettingsItem/SettingsItem.tsx
@@ -22,6 +22,7 @@ type Props = {
     validator: SettingsItemEditFormProps['validator'];
     canEdit?: SettingsItemEditFormProps['config'];
     canRemove?: boolean;
+    className?: string;
 };
 
 export const SettingsItem: FC<Props> = ({
@@ -32,6 +33,7 @@ export const SettingsItem: FC<Props> = ({
     onDelete,
     validator,
     onChange,
+    className,
 }) => {
     const [edit, setEdit] = useState(false);
     const handleDelete = () => {
@@ -63,7 +65,7 @@ export const SettingsItem: FC<Props> = ({
     }
 
     return (
-        <div className={block()}>
+        <div className={block(null, className)}>
             <div className={block('info')}>
                 <Icon className={block('icon')} data={GearIcon} size={16} />
                 <Text variant="subheader-2" ellipsis>

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/SpytSettings.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/SpytSettings.scss
@@ -1,0 +1,12 @@
+.yt-query-spyt-settings {
+    width: 100%;
+
+    &__header {
+        padding-bottom: 12px;
+    }
+
+    &__editor {
+        height: 300px;
+        border: 1px solid var(--dark-divider);
+    }
+}

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/SpytSettings.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/SpytSettings.tsx
@@ -1,0 +1,80 @@
+import React, {type FC, useEffect, useMemo, useState} from 'react';
+import cn from 'bem-cn-lite';
+import MonacoEditor, {
+    type MonacoEditorConfig,
+} from '../../../../components/MonacoEditor/MonacoEditor';
+import './SpytSettings.scss';
+import {Button, Flex, Icon} from '@gravity-ui/uikit';
+import CheckIcon from '@gravity-ui/icons/svgs/check.svg';
+import XmarkIcon from '@gravity-ui/icons/svgs/xmark.svg';
+import {type DraftQuery} from '../../../../types/query-tracker/api';
+import {toaster} from '../../../../utils/toaster';
+import i18n from './i18n';
+import {isPlainObject} from '../../../../../shared/utils/toolkit';
+
+const block = cn('yt-query-spyt-settings');
+
+const MONACO_CONFIG: MonacoEditorConfig = {
+    contextmenu: false,
+    minimap: {
+        enabled: false,
+    },
+    overviewRulerLanes: 0,
+    glyphMargin: false,
+};
+
+type Props = {
+    settings?: DraftQuery['settings'];
+    onChange: (value: NonNullable<DraftQuery['settings']>) => void;
+    onCancel?: () => void;
+};
+
+export const SpytSettings: FC<Props> = ({settings, onChange, onCancel}) => {
+    const canonicalValue = useMemo(() => JSON.stringify(settings ?? {}, null, 2), [settings]);
+    const [value, setValue] = useState(canonicalValue);
+
+    useEffect(() => {
+        setValue(canonicalValue);
+    }, [canonicalValue]);
+
+    const handleOnCancel = () => {
+        setValue(canonicalValue);
+        onCancel?.();
+    };
+
+    const handleOnSave = () => {
+        try {
+            const parsed: unknown = JSON.parse(value);
+            if (!isPlainObject(parsed)) {
+                throw new Error('Invalid settings shape');
+            }
+            onChange(parsed as NonNullable<DraftQuery['settings']>);
+        } catch {
+            toaster.add({
+                name: 'spyt_settings_invalid_json',
+                theme: 'danger',
+                title: i18n('alert_invalid-spyt-json'),
+            });
+        }
+    };
+
+    return (
+        <Flex className={block()} direction="column" gap={2}>
+            <MonacoEditor
+                className={block('editor')}
+                language="json"
+                value={value}
+                monacoConfig={MONACO_CONFIG}
+                onChange={setValue}
+            />
+            <Flex gap={1} justifyContent="flex-end">
+                <Button view="action" size="l" onClick={handleOnSave}>
+                    <Icon data={CheckIcon} size={16} />
+                </Button>
+                <Button view="outlined" size="l" onClick={handleOnCancel}>
+                    <Icon data={XmarkIcon} size={16} />
+                </Button>
+            </Flex>
+        </Flex>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/i18n/en.json
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "alert_invalid-spyt-json": "Invalid JSON. Settings must be a JSON object with valid syntax."
+}

--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/i18n/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/SpytSettings/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:query-tracker.spyt-settings', dicts);

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/QueryEngineSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/QueryEngineSelector.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../store/selectors/query-tracker/query';
 import {
     createQueryFromTablePath,
-    updateQueryDraft,
+    setQueryEngine,
 } from '../../../../store/actions/query-tracker/query';
 import {type QueryEngine} from '../../../../../shared/constants/engines';
 import {ModalWithoutHandledScrollBar as Modal} from '../../../../components/Modal/Modal';
@@ -19,23 +19,45 @@ import {Select} from '@gravity-ui/uikit';
 import './QueryEngineSelector.scss';
 import cn from 'bem-cn-lite';
 import i18n from './i18n';
+import {toaster} from '../../../../utils/toaster';
 
 const block = cn('yt-query-engine-selector');
 
 type Props = {
     isDesktop?: boolean;
     className?: string;
-    onChange?: (newEngine: QueryEngine) => void;
+    onChange?: (newEngine: QueryEngine) => void | Promise<void>;
+    tableCluster?: string;
+    tablePath?: string;
 };
 
-export const QueryEngineSelector: FC<Props> = ({isDesktop, className, onChange}) => {
+export const QueryEngineSelector: FC<Props> = ({
+    isDesktop,
+    className,
+    onChange,
+    tableCluster,
+    tablePath,
+}) => {
     const dispatch = useDispatch();
     const engine = useSelector(selectQueryEngine);
     const options = useSelector(selectSupportedEnginesOptions);
     const isEdited = useSelector(selectIsQueryDraftEditted);
     const hasLoadedQuery = useSelector(selectHasLoadedQueryItem);
     const loading = useSelector(selectClusterLoading);
-    const {cluster, path} = useSelector(selectQueryGetParams);
+    const {cluster: paramCluster, path: paramPath} = useSelector(selectQueryGetParams);
+
+    const hasFullParams = Boolean(paramCluster && paramPath);
+    const hasFullTableFallback = Boolean(tableCluster && tablePath);
+    let cluster: string | undefined;
+    let path: string | undefined;
+
+    if (hasFullParams) {
+        cluster = paramCluster;
+        path = paramPath;
+    } else if (hasFullTableFallback) {
+        cluster = tableCluster;
+        path = tablePath;
+    }
 
     const showPrompt = Boolean((isEdited || hasLoadedQuery) && cluster && path);
 
@@ -43,13 +65,21 @@ export const QueryEngineSelector: FC<Props> = ({isDesktop, className, onChange})
     const [selectedEngine, setSelectedEngine] = useState<QueryEngine | undefined>(undefined);
 
     const handleChangeEngine = useCallback(
-        (newEngine: QueryEngine) => {
-            if (cluster && path) {
-                dispatch(createQueryFromTablePath(newEngine, cluster, path));
-            } else {
-                dispatch(updateQueryDraft({engine: newEngine}));
+        async (newEngine: QueryEngine) => {
+            try {
+                if (cluster && path) {
+                    await dispatch(createQueryFromTablePath(newEngine, cluster, path));
+                } else {
+                    dispatch(setQueryEngine(newEngine));
+                }
+                await onChange?.(newEngine);
+            } catch {
+                toaster.add({
+                    name: 'query_engine_selector_change_failed',
+                    theme: 'danger',
+                    title: i18n('alert_change-engine-failed'),
+                });
             }
-            onChange?.(newEngine);
         },
         [cluster, dispatch, onChange, path],
     );
@@ -58,6 +88,7 @@ export const QueryEngineSelector: FC<Props> = ({isDesktop, className, onChange})
         (value: string | string[]) => {
             const newEngine = (Array.isArray(value) ? value[0] : value) as QueryEngine;
             setSelectedEngine(newEngine);
+
             if (showPrompt) {
                 setModalVisibility(true);
             } else {
@@ -73,9 +104,13 @@ export const QueryEngineSelector: FC<Props> = ({isDesktop, className, onChange})
     }, []);
 
     const handleConfirm = useCallback(() => {
+        const engineToApply = selectedEngine;
         setSelectedEngine(undefined);
-        if (selectedEngine) handleChangeEngine(selectedEngine);
         setModalVisibility(false);
+
+        if (engineToApply) {
+            handleChangeEngine(engineToApply);
+        }
     }, [selectedEngine, handleChangeEngine]);
 
     return (

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/i18n/en.json
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/i18n/en.json
@@ -1,5 +1,5 @@
 {
   "title_switching-engine": "Switching engine",
-  "confirm_switching-engine": "All the changes will be lost. Are you sure you want to switch the engine?"
+  "confirm_switching-engine": "All the changes will be lost. Are you sure you want to switch the engine?",
+  "alert_change-engine-failed": "Could not switch query engine"
 }
-

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/index.tsx
@@ -5,7 +5,6 @@ import {Page} from '../../../../shared/constants/settings';
 import {selectQueryDraft} from '../../../store/selectors/query-tracker/query';
 import {
     resetQueryTracker,
-    setQueryEngine,
     setUserLastChoice,
     updateQueryDraft,
 } from '../../../store/actions/query-tracker/query';
@@ -24,7 +23,7 @@ import {setSettingByKey} from '../../../store/actions/settings';
 import {useIsDesktop} from '../../../hooks/useIsDesktop';
 import {QueryClusterSelector} from './QueryClusterSelector';
 import {LazyQueryTokenButton} from '../QueryToken/lazy';
-import {setQueryName} from '../../../store/actions/query-tracker/api';
+import {type DraftQuery, setQueryName} from '../../../store/actions/query-tracker/api';
 import {updateQueryInList} from '../../../store/actions/query-tracker/queriesList';
 import i18n from './i18n';
 
@@ -34,12 +33,11 @@ const block = cn('query-tracker-top-row');
 const QueryTrackerTopRow: FC = () => {
     const dispatch = useDispatch();
     const isDesktop = useIsDesktop();
-    const {id, annotations, settings} = useSelector(selectQueryDraft);
+    const {id, annotations, settings, engine} = useSelector(selectQueryDraft);
     const [nameEdit, setNameEdit] = useState(false);
 
     const handleChangeEngine = useCallback(
         (newEngine: QueryEngine) => {
-            dispatch(setQueryEngine(newEngine));
             dispatch(setSettingByKey(`global::queryTracker::lastEngine`, newEngine));
             dispatch(setUserLastChoice());
         },
@@ -69,7 +67,7 @@ const QueryTrackerTopRow: FC = () => {
     );
 
     const handleSettingsChange = useCallback(
-        (newSettings: Record<string, string>) =>
+        (newSettings: DraftQuery['settings']) =>
             dispatch(updateQueryDraft({settings: newSettings})),
         [dispatch],
     );
@@ -104,6 +102,7 @@ const QueryTrackerTopRow: FC = () => {
                         <Flex gap={2}>
                             <QuerySettingsButton
                                 settings={settings}
+                                engine={engine}
                                 onChange={handleSettingsChange}
                             />
                             <QueryFilesButton />

--- a/packages/ui/src/ui/pages/query-tracker/QueryWidget/QueryMetaForm.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryWidget/QueryMetaForm.tsx
@@ -1,10 +1,10 @@
 import React, {useCallback} from 'react';
 import cn from 'bem-cn-lite';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
-import {selectQueryDraft} from '../../../store/selectors/query-tracker/query';
+import {selectQueryDraft, selectQueryEngine} from '../../../store/selectors/query-tracker/query';
 import {QuerySettingsButton} from '../QuerySettingsButton';
 import {QueryFilesButton} from '../QueryFilesButton';
-import {loadTablePromptToQuery, updateQueryDraft} from '../../../store/actions/query-tracker/query';
+import {updateQueryDraft} from '../../../store/actions/query-tracker/query';
 import {NewQueryButton} from '../NewQueryButton';
 import {QueryEngineSelector} from '../QueryTrackerTopRow/QueryEngineSelector';
 import {QueryTrackerOpenButton} from '../QueryTrackerOpenButton/QueryTrackerOpenButton';
@@ -12,8 +12,8 @@ import {QueryTrackerOpenButton} from '../QueryTrackerOpenButton/QueryTrackerOpen
 import './QueryMetaForm.scss';
 import {QuerySelectorsByEngine} from '../QueryTrackerTopRow/QuerySelectorsByEngine';
 import {Flex} from '@gravity-ui/uikit';
-import {type QueryEngine} from '../../../../shared/constants/engines';
 import {QueryClusterSelector} from '../QueryTrackerTopRow/QueryClusterSelector';
+import {type DraftQuery} from '../../../types/query-tracker/api';
 
 const block = cn('query-tracker-meta-form');
 export function QueryMetaForm({
@@ -29,28 +29,22 @@ export function QueryMetaForm({
 }) {
     const dispatch = useDispatch();
     const draft = useSelector(selectQueryDraft);
+    const engine = useSelector(selectQueryEngine);
 
     const onSettingsChange = useCallback(
-        (settings: Record<string, string>) => dispatch(updateQueryDraft({settings})),
+        (settings: DraftQuery['settings']) => dispatch(updateQueryDraft({settings})),
         [dispatch],
-    );
-
-    const handleChangeEngine = useCallback(
-        (newEngine: QueryEngine) => {
-            dispatch(
-                loadTablePromptToQuery(cluster, path, newEngine, {
-                    cluster: draft.settings?.cluster!,
-                }),
-            );
-        },
-        [dispatch, cluster, path, draft.settings],
     );
 
     return (
         <Flex className={block(null, className)} gap={3} justifyContent="space-between" grow={1}>
             <Flex gap={3}>
                 <QueryClusterSelector className={block('cluster')} />
-                <QueryEngineSelector onChange={handleChangeEngine} className={block('engine')} />
+                <QueryEngineSelector
+                    className={block('engine')}
+                    tableCluster={cluster}
+                    tablePath={path}
+                />
                 <QuerySelectorsByEngine />
             </Flex>
 
@@ -58,6 +52,7 @@ export function QueryMetaForm({
                 <QuerySettingsButton
                     popupClassName={block('settings')}
                     settings={draft.settings}
+                    engine={engine}
                     onChange={onSettingsChange}
                 />
                 <QueryFilesButton popupClassName={block('files')} />

--- a/packages/ui/src/ui/pages/query-tracker/QueryWidget/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import cn from 'bem-cn-lite';
 import {Button, Flex} from '@gravity-ui/uikit';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
@@ -9,6 +9,7 @@ import {QueryEditor} from '../QueryEditor';
 import {QueryMetaForm} from './QueryMetaForm';
 import {QueriesPooling} from '../hooks/QueriesPooling/context';
 import {createQueryFromTablePath} from '../../../store/actions/query-tracker/query';
+import {getQueryTrackerInfo} from '../../../store/actions/query-tracker/queryAco';
 import {QueryEngine} from '../../../../shared/constants/engines';
 
 import './index.scss';
@@ -22,6 +23,10 @@ export default function QueryWidget({onClose}: QueryWidgetProps) {
     const cluster = useSelector(selectCluster);
     const path = useSelector(getPath);
     const stablePath = useRef(path); // save table path after open widget
+
+    useEffect(() => {
+        dispatch(getQueryTrackerInfo());
+    }, [dispatch, cluster]);
 
     const handleClickOnNewQueryButton = () => {
         dispatch(createQueryFromTablePath(QueryEngine.YQL, cluster, stablePath.current));
@@ -45,7 +50,7 @@ export default function QueryWidget({onClose}: QueryWidgetProps) {
                         <Icon awesome="times" size={16} />
                     </Button>
                 </Flex>
-                <QueryEditor pathNavigation={false} />
+                <QueryEditor pathNavigation={false} hideAco />
             </QueriesPooling>
         </div>
     );

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -84,6 +84,7 @@ import {
     resetQueryTabs,
 } from '../../reducers/query-tracker/queryTabsSlice';
 import {updateQueryTabs} from './queryTabs/queryTabs';
+import {selectSpytDefaultSettings} from '../../selectors/query-tracker/queryTrackerEnginesInfo';
 
 type AsyncAction = ThunkAction<void, RootState, unknown, any>;
 
@@ -199,22 +200,16 @@ export const loadTablePromptToQuery =
 export const setQueryEngine =
     (engine: QueryEngine): AsyncAction =>
     (dispatch, getState) => {
-        const settings = selectQueryDraftSettings(getState());
+        const state = getState();
+        const {cluster} = selectQueryDraftSettings(state);
+        const spytDefaultConfig = selectSpytDefaultSettings(state);
 
-        const newSettings = {...settings};
-        if (engine !== QueryEngine.SPYT) {
-            delete newSettings.discovery_group;
+        let newSettings: DraftQuery['settings'] = cluster ? {cluster} : {};
+        if (engine === QueryEngine.SPYT) {
+            newSettings = {...spytDefaultConfig, ...newSettings};
         }
 
-        if (engine !== QueryEngine.CHYT) {
-            delete newSettings.clique;
-        }
-
-        if (engine !== QueryEngine.YQL) {
-            delete newSettings.yql_version;
-        }
-
-        dispatch(updateQueryDraft({settings: newSettings}));
+        dispatch(updateQueryDraft({engine, settings: newSettings}));
     };
 
 export const setQueryCluster =
@@ -380,6 +375,31 @@ export function updateQueryDraft(data: Partial<QueryState['draft']>) {
     return {type: SET_QUERY_PATCH, data};
 }
 
+export const mergeSpytDefaultSettingsIntoDraft = (): AsyncAction => (dispatch, getState) => {
+    const state = getState();
+
+    if (selectQuery(state)?.id) {
+        return;
+    }
+
+    const engine = selectQueryEngine(state);
+    if (engine !== QueryEngine.SPYT) {
+        return;
+    }
+
+    const spytDefaultSettings = selectSpytDefaultSettings(state);
+    if (!Object.keys(spytDefaultSettings).length) {
+        return;
+    }
+
+    const settings = selectQueryDraftSettings(state) ?? {};
+    dispatch(
+        updateQueryDraft({
+            settings: {...spytDefaultSettings, ...settings},
+        }),
+    );
+};
+
 export function createQueryFromTablePath(
     engine: QueryEngine,
     cluster: string,
@@ -427,6 +447,9 @@ export function createQueryFromTablePath(
                         },
                     });
                 }
+                if (engine === QueryEngine.SPYT) {
+                    dispatch(mergeSpytDefaultSettingsIntoDraft());
+                }
             } else {
                 dispatch(createEmptyQuery(engine));
             }
@@ -448,10 +471,12 @@ export function createEmptyQuery(
         const state = getState();
         const lastEngine = getLastUserChoiceQueryEngine(state);
         const defaultQueryACO = selectDefaultQueryACO(state);
+        const defaultSpytSettings = selectSpytDefaultSettings(state);
 
         const initialEngine = engine || lastEngine || QueryEngine.YQL;
+        const isSpyt = initialEngine === QueryEngine.SPYT;
+        const querySettings = {...(isSpyt ? defaultSpytSettings : {}), ...(settings || {})};
 
-        const defaultSettings: DraftQuery['settings'] = {};
         UIFactory.getInlineSuggestionsApi()?.onQueryCreate();
         dispatch({
             type: SET_QUERY,
@@ -461,7 +486,7 @@ export function createEmptyQuery(
                     access_control_objects: [defaultQueryACO],
                     query: query || '',
                     engine: initialEngine,
-                    settings: settings || defaultSettings,
+                    settings: querySettings,
                 } as QueryItem,
             },
         });

--- a/packages/ui/src/ui/store/actions/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryAco.ts
@@ -1,16 +1,20 @@
 import {type AnyAction} from 'redux';
 import {type ThunkAction} from 'redux-thunk';
 import {type AxiosError} from 'axios';
+import isEqual_ from 'lodash/isEqual';
 import {YTApiId, ytApiV4Id} from '../../../rum/rum-wrap-api';
 import {
     selectEffectiveApiStage,
+    selectQueryId,
     selectQueryTrackerRequestOptions,
 } from '../../selectors/query-tracker/query';
 import {showErrorPopup} from '../../../utils/utils';
 import {QUERY_ACO_LOADING, type QueryACOActions} from '../../reducers/query-tracker/queryAco';
 import {type RootState} from '../../reducers';
+import {selectSpytDefaultSettings} from '../../selectors/query-tracker/queryTrackerEnginesInfo';
 import {setSettingByKey} from '../settings';
 import {toaster} from '../../../utils/toaster';
+import {mergeSpytDefaultSettingsIntoDraft} from './query';
 
 type QueryTrackerInfoResponse = Awaited<ReturnType<typeof ytApiV4Id.getQueryTrackerInfo>>;
 
@@ -49,10 +53,25 @@ export const getQueryTrackerInfo = (): ThunkAction<
                 parameters: {stage},
             })
             .then((data) => {
+                const stateBefore = getState();
+                const prevDefaults = selectSpytDefaultSettings(stateBefore);
+                const prevKeyCount = Object.keys(prevDefaults).length;
+
                 dispatch({
                     type: QUERY_ACO_LOADING.SUCCESS,
                     data: {data},
                 });
+
+                const nextDefaults = data?.engines_info?.spyt?.default_settings || {};
+                const nextKeyCount = Object.keys(nextDefaults).length;
+                const defaultsChanged =
+                    nextKeyCount > 0 &&
+                    (prevKeyCount === 0 || !isEqual_(prevDefaults, nextDefaults));
+
+                const isNewDraft = !selectQueryId(getState());
+                if (defaultsChanged && isNewDraft) {
+                    dispatch(mergeSpytDefaultSettingsIntoDraft());
+                }
 
                 return data;
             })

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -74,7 +74,12 @@ export const selectIsQueryButtonActive = createSelector(
         if (!clique || !cluster) return true;
 
         if (cluster in cliqueMap) {
-            const currentClique = cliqueMap[cluster].chyt.find((i) => i.alias === clique);
+            const chytList = cliqueMap[cluster]?.chyt;
+            if (!chytList) {
+                return false;
+            }
+
+            const currentClique = chytList.find((i) => i.alias === clique);
             if (!currentClique) return false;
 
             return currentClique.state === 'active';

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryTrackerEnginesInfo.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryTrackerEnginesInfo.ts
@@ -16,3 +16,19 @@ export const selectDefaultYqlVersion = createSelector([selectQueryTrackerInfo], 
 export const selectSpytEnginesInfo = (state: RootState) => {
     return selectQueryTrackerInfo(state)?.engines_info?.spyt;
 };
+
+const selectQueryTrackerInfoLoaded = (state: RootState) => state.queryTracker.aco.loaded;
+
+export const selectSpytDefaultSettings = createSelector(
+    [
+        (state: RootState) => selectSpytEnginesInfo(state)?.default_settings,
+        selectQueryTrackerInfoLoaded,
+    ],
+    (defaultSettings, loaded) => {
+        if (!loaded || !defaultSettings || !Object.keys(defaultSettings).length) {
+            return {};
+        }
+
+        return defaultSettings;
+    },
+);

--- a/packages/ui/src/ui/types/query-tracker/api.ts
+++ b/packages/ui/src/ui/types/query-tracker/api.ts
@@ -48,7 +48,7 @@ export interface DraftQuery {
         discovery_path?: string; // old request type. Deprecated
         discovery_group?: string;
         execution_mode?: 'validate' | 'optimize';
-    } & Record<string, string>;
+    } & Record<string, unknown>;
     error?: unknown;
     access_control_object: string;
     access_control_objects?: string[];

--- a/packages/ui/src/ui/utils/query-tracker/convertSettingsTypes.ts
+++ b/packages/ui/src/ui/utils/query-tracker/convertSettingsTypes.ts
@@ -1,15 +1,23 @@
+import {isPlainObject} from '../../../shared/utils/toolkit';
+import {type DraftQuery} from '../../types/query-tracker/api';
+
 export function convertSettingsTypes(
     settings?: Record<string, unknown>,
-): Record<string, string | number | boolean> {
+): Required<DraftQuery>['settings'] {
     if (!settings) {
         return {};
     }
 
-    const converted: Record<string, string | number | boolean> = {};
+    const converted: Record<string, string | number | boolean | Record<string, unknown>> = {};
 
     for (const [key, value] of Object.entries(settings)) {
         if (typeof value === 'number' || typeof value === 'boolean') {
             converted[key] = value;
+            continue;
+        }
+
+        if (isPlainObject(value)) {
+            converted[key] = convertSettingsTypes(value);
             continue;
         }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/5Vw_4Fiu7aBWux
<!-- nda-end -->       ## Summary by Sourcery

Introduce dedicated SPYT query settings support and default settings integration while tightening control over ACO visibility and query settings typing.

New Features:
- Add SPYT-specific settings editor with JSON Monaco editor and validation within the query settings popup.
- Apply default SPYT engine settings automatically when creating or switching to SPYT queries, including from table paths.

Bug Fixes:
- Ensure new drafts consistently include SPYT default settings when available and avoid overwriting user settings when defaults change.

Enhancements:
- Refactor query settings popup into generic QuerySettings and SPYT-specific SpytSettings components and wire them by engine type.
- Update engine selector and query creation flows to preserve cluster, respect default engine-specific settings, and better handle async engine changes.
- Hide ACO-related controls (selector, share, and edit) behind a configurable flag to disable them in embedded query widgets.
- Extend query settings typing to support nested, non-string values and enhance settings type conversion to handle nested objects.
- Improve robustness of CHYT clique validation when query button availability is computed.
- Load query tracker info (including engine defaults) for the inline QueryWidget on mount and refresh SPYT defaults into new drafts when they change.