### PR TITLE
chore(Queries): rename query selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/containers/AiChat/AskAIErrorButton/AskAIErrorButton.tsx
+++ b/packages/ui/src/ui/containers/AiChat/AskAIErrorButton/AskAIErrorButton.tsx
@@ -5,13 +5,13 @@ import AiIcon from '../../../assets/img/svg/icons/ai-chat-icon.svg';
 import {createConversationWithPrompt} from '../../../store/actions/ai/chat';
 import {selectAiChatConfigured} from '../../../store/selectors/ai/chat';
 import i18n from './i18n';
-import {getQueryEngine} from '../../../store/selectors/query-tracker/query';
+import {selectQueryEngine} from '../../../store/selectors/query-tracker/query';
 import {PROMPT_MAP} from '../constants';
 
 export const AskAIErrorButton: FC = () => {
     const dispatch = useDispatch();
     const isConfigured = useSelector(selectAiChatConfigured);
-    const engine = useSelector(getQueryEngine);
+    const engine = useSelector(selectQueryEngine);
 
     if (!isConfigured) {
         return null;

--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/DefaultAcoSelect.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/DefaultAcoSelect.tsx
@@ -6,11 +6,11 @@ import {
 import {type Item} from '../../../components/Select/Select';
 import {SettingsMenuSelect} from '../../SettingsMenu/SettingsMenuSelect';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
-import {getDefaultQueryACO} from '../../../store/selectors/query-tracker/queryAco';
+import {selectDefaultQueryACO} from '../../../store/selectors/query-tracker/queryAco';
 
 export const DefaultAcoSelect: FC = () => {
     const dispatch = useDispatch();
-    const defaultUserACO = useSelector(getDefaultQueryACO);
+    const defaultUserACO = useSelector(selectDefaultQueryACO);
 
     return (
         <SettingsMenuSelect

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/ClusterList/ClusterList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/ClusterList/ClusterList.tsx
@@ -7,7 +7,7 @@ import {type ClusterConfig} from '../../../../../shared/yt-types';
 import {setNavigationCluster} from '../../../../store/actions/query-tracker/queryNavigation';
 import {
     selectClustersByFilter,
-    selectLoading,
+    selectIsQueryNavigationLoading,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
 import {ItemsList} from '../ItemsList';
 
@@ -15,7 +15,7 @@ const b = cn('navigation-cluster-list');
 
 export const ClusterList: FC = () => {
     const dispatch = useDispatch();
-    const loading = useSelector(selectLoading);
+    const loading = useSelector(selectIsQueryNavigationLoading);
     const clusters = useSelector(selectClustersByFilter);
 
     const handleClusterClick = (cluster: ClusterConfig) => {

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationHeader/HeaderActions.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationHeader/HeaderActions.tsx
@@ -16,7 +16,7 @@ import {
     selectNavigationCluster,
     selectNavigationPath,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
-import {getQueryEngine} from '../../../../store/selectors/query-tracker/query';
+import {selectQueryEngine} from '../../../../store/selectors/query-tracker/query';
 import {makePathByQueryEngine} from '../helpers/makePathByQueryEngine';
 import {insertTextWhereCursor} from '../helpers/insertTextWhereCursor';
 import {useMonaco} from '../../hooks/useMonaco';
@@ -30,7 +30,7 @@ export const HeaderActions: FC = () => {
     const path = useSelector(selectNavigationPath);
     const cluster = useSelector(selectNavigationCluster);
     const favorites = useSelector(selectFavouritePaths);
-    const engine = useSelector(getQueryEngine);
+    const engine = useSelector(selectQueryEngine);
     const {getEditor} = useMonaco();
 
     const isFavorite = favorites.includes(path);

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
@@ -7,7 +7,7 @@ import {
     selectNavigationPath,
     selectTableWithFilter,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
-import {getQueryEngine} from '../../../../store/selectors/query-tracker/query';
+import {selectQueryEngine} from '../../../../store/selectors/query-tracker/query';
 import {getPageSize} from '../../../../store/selectors/navigation/content/table-ts';
 import {setFilter} from '../../../../store/reducers/query-tracker/queryNavigationSlice';
 import {useMonaco} from '../../hooks/useMonaco';
@@ -18,7 +18,7 @@ export const NavigationTable: FC = () => {
     const dispatch = useDispatch();
     const clusterConfig = useSelector(selectNavigationClusterConfig);
     const table = useSelector(selectTableWithFilter);
-    const engine = useSelector(getQueryEngine);
+    const engine = useSelector(selectQueryEngine);
     const limit = useSelector(getPageSize);
     const path = useSelector(selectNavigationPath);
     const filter = useSelector(selectNavigationFilter);

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
@@ -1,7 +1,7 @@
 import React, {type FC, useCallback, useRef, useState} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
-    selectLoading,
+    selectIsQueryNavigationLoading,
     selectNavigationClusterConfig,
     selectNodeListByFilter,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
@@ -42,7 +42,7 @@ export const NodeList: FC = () => {
     const engine = useSelector(selectQueryEngine);
     const {pageSize} = getQueryResultGlobalSettings();
     const dirtyQuery = useSelector(selectIsQueryDraftEditted);
-    const loading = useSelector(selectLoading);
+    const loading = useSelector(selectIsQueryNavigationLoading);
     const {getEditor} = useMonaco();
 
     const handleNodeClick = (path: string, type: string | undefined) => {

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
@@ -19,7 +19,10 @@ import {isFolderNode} from '../../../../utils/navigation/isFolderNode';
 import {isTableNode} from '../../../../utils/navigation/isTableNode';
 import {useMonaco} from '../../hooks/useMonaco';
 import {insertTextWhereCursor} from '../helpers/insertTextWhereCursor';
-import {getQueryEngine, isQueryDraftEditted} from '../../../../store/selectors/query-tracker/query';
+import {
+    selectIsQueryDraftEditted,
+    selectQueryEngine,
+} from '../../../../store/selectors/query-tracker/query';
 import {makePathByQueryEngine} from '../helpers/makePathByQueryEngine';
 import {type QueryEngine} from '../../../../../shared/constants/engines';
 import {getNavigationUrl} from '../helpers/getNavigationUrl';
@@ -36,9 +39,9 @@ export const NodeList: FC = () => {
     const newQueryParams = useRef<{path: string; engine: QueryEngine} | null>(null);
     const clusterConfig = useSelector(selectNavigationClusterConfig);
     const nodes = useSelector(selectNodeListByFilter);
-    const engine = useSelector(getQueryEngine);
+    const engine = useSelector(selectQueryEngine);
     const {pageSize} = getQueryResultGlobalSettings();
-    const dirtyQuery = useSelector(isQueryDraftEditted);
+    const dirtyQuery = useSelector(selectIsQueryDraftEditted);
     const loading = useSelector(selectLoading);
     const {getEditor} = useMonaco();
 

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
@@ -27,7 +27,7 @@ import {makePathByQueryEngine} from '../helpers/makePathByQueryEngine';
 import {type QueryEngine} from '../../../../../shared/constants/engines';
 import {getNavigationUrl} from '../helpers/getNavigationUrl';
 import {createTableSelect} from '../helpers/createTableSelect';
-import {getQueryResultGlobalSettings} from '../../../../store/selectors/query-tracker/queryResult';
+import {selectQueryResultGlobalSettings} from '../../../../store/selectors/query-tracker/queryResult';
 import {NewQueryPromt} from '../../NewQueryButton/NewQueryButton';
 import {ItemsList} from '../ItemsList';
 
@@ -40,7 +40,7 @@ export const NodeList: FC = () => {
     const clusterConfig = useSelector(selectNavigationClusterConfig);
     const nodes = useSelector(selectNodeListByFilter);
     const engine = useSelector(selectQueryEngine);
-    const {pageSize} = getQueryResultGlobalSettings();
+    const {pageSize} = selectQueryResultGlobalSettings();
     const dirtyQuery = useSelector(selectIsQueryDraftEditted);
     const loading = useSelector(selectIsQueryNavigationLoading);
     const {getEditor} = useMonaco();

--- a/packages/ui/src/ui/pages/query-tracker/NewQueryButton/NewQueryButton.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/NewQueryButton/NewQueryButton.tsx
@@ -2,7 +2,7 @@ import React, {type FC, type MouseEvent, useState} from 'react';
 import {useSelector} from '../../../store/redux-hooks';
 import {Button, Icon} from '@gravity-ui/uikit';
 import Modal from '../../../components/Modal/Modal';
-import {isQueryDraftEditted} from '../../../store/selectors/query-tracker/query';
+import {selectIsQueryDraftEditted} from '../../../store/selectors/query-tracker/query';
 import FilePlusIcon from '@gravity-ui/icons/svgs/file-plus.svg';
 import {Page} from '../../../../shared/constants/settings';
 import {selectCluster} from '../../../store/selectors/global';
@@ -31,7 +31,7 @@ type Props = {
 };
 
 export const NewQueryButton: FC<Props> = ({onClick, hideText}) => {
-    const dirtyQuery = useSelector(isQueryDraftEditted);
+    const dirtyQuery = useSelector(selectIsQueryDraftEditted);
     const [visible, setVisible] = useState(false);
     const cluster = useSelector(selectCluster);
 

--- a/packages/ui/src/ui/pages/query-tracker/Plan/Graph.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/Graph.tsx
@@ -39,7 +39,7 @@ import fitIcon from '@gravity-ui/icons/svgs/target.svg';
 
 import './Graph.scss';
 import {useSelector} from '../../../store/redux-hooks';
-import {getQuerySingleProgress} from '../../../store/selectors/query-tracker/query';
+import {selectQuerySingleProgress} from '../../../store/selectors/query-tracker/query';
 
 const block = cn('graph');
 const showTooltipClass = `${block()}_show-tooltip`;
@@ -79,7 +79,7 @@ export default function Graph({isActive, className, graph, showMinimap, prepareN
     const [graphContainer, setGraphContainer] = React.useState<HTMLDivElement | null>(null);
     const colors = useGraphColors();
     const options = useConfig(colors);
-    const {yql_progress: progress} = useSelector(getQuerySingleProgress);
+    const {yql_progress: progress} = useSelector(selectQuerySingleProgress);
     const [nodes] = React.useState<DataSet<ProcessedNode>>(() => new DataSet());
     const [edges] = React.useState<DataSetEdges>(() => new DataSet());
 

--- a/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/helpers/useQueriesGraphLayout.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/helpers/useQueriesGraphLayout.tsx
@@ -8,7 +8,7 @@ import {buildConnectionsFromEdges} from './buildConnectionsFromEdges';
 import {toaster} from '../../../../../utils/toaster';
 import {type MultipointConnection} from '../types';
 import {useSelector} from '../../../../../store/redux-hooks';
-import {getQuerySingleProgress} from '../../../../../store/selectors/query-tracker/query';
+import {selectQuerySingleProgress} from '../../../../../store/selectors/query-tracker/query';
 
 export const useQueriesGraphLayout = (
     progressGraph: ProcessedGraph,
@@ -17,7 +17,7 @@ export const useQueriesGraphLayout = (
     data: {blocks: QueriesNodeBlock[]; connections: MultipointConnection[]};
     isLoading: boolean;
 } => {
-    const {yql_progress: progress} = useSelector(getQuerySingleProgress);
+    const {yql_progress: progress} = useSelector(selectQuerySingleProgress);
 
     const {blocks, connections: initialConnections} = useMemo(
         () => createBlocks(progressGraph, progress, scale),

--- a/packages/ui/src/ui/pages/query-tracker/Plan/LargeGraphInfo/LargeGraphInfo.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/LargeGraphInfo/LargeGraphInfo.tsx
@@ -7,7 +7,7 @@ import {Button, Text} from '@gravity-ui/uikit';
 import {Legend} from '../components/Legend/Legend';
 import cn from 'bem-cn-lite';
 import './LargeGraphInfo.scss';
-import {getQuerySingleProgress} from '../../../../store/selectors/query-tracker/query';
+import {selectQuerySingleProgress} from '../../../../store/selectors/query-tracker/query';
 import i18n from './i18n';
 
 const block = cn('yt-large-graph-info');
@@ -19,7 +19,7 @@ export function LargeGraphInfo({
     showGraph: React.Dispatch<React.SetStateAction<boolean>>;
     graph: ProcessedGraph;
 }) {
-    const {yql_progress: progress} = useSelector(getQuerySingleProgress);
+    const {yql_progress: progress} = useSelector(selectQuerySingleProgress);
     const [nodes] = React.useState(() => new DataSet<ProcessedNode>());
     const repaint = useUpdate();
 

--- a/packages/ui/src/ui/pages/query-tracker/Plan/NodeStages/NodeStages.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/NodeStages/NodeStages.tsx
@@ -5,7 +5,7 @@ import {type NodeState, type NodeStages as Stages} from '../models/plan';
 import cn from 'bem-cn-lite';
 
 import {useSelector} from '../../../../store/redux-hooks';
-import {getQueryItem} from '../../../../store/selectors/query-tracker/query';
+import {selectQueryItem} from '../../../../store/selectors/query-tracker/query';
 import {type QueryItem} from '../../../../types/query-tracker/api';
 import {isQueryCompleted} from '../../utils/query';
 import {duration, isOperationFinished} from '../utils';
@@ -35,7 +35,7 @@ interface NodeStagesProps {
     finishedAt?: string;
 }
 export default function NodeStages({stages = {}, state, finishedAt}: NodeStagesProps) {
-    const query = useSelector(getQueryItem);
+    const query = useSelector(selectQueryItem);
     const data = prepareData(stages, state, finishedAt, query);
     return (
         <div className={block()}>

--- a/packages/ui/src/ui/pages/query-tracker/Plan/Plan.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/Plan.tsx
@@ -13,7 +13,7 @@ import './Plan.scss';
 import {QueriesGraphLazy} from './GraphEditor';
 import {useSelector} from '../../../store/redux-hooks';
 import {getSettingsQueryTrackerNewGraphType} from '../../../store/selectors/settings/settings-ts';
-import {getProcessedGraph} from '../../../store/selectors/query-tracker/queryPlan';
+import {selectProcessedGraph} from '../../../store/selectors/query-tracker/queryPlan';
 import {type PlanView} from './PlanActions';
 
 const block = cn('plan');
@@ -26,7 +26,7 @@ interface PlanProps {
 }
 
 export default React.memo(function Plan({planView, isActive, className, prepareNode}: PlanProps) {
-    const graph = useSelector(getProcessedGraph);
+    const graph = useSelector(selectProcessedGraph);
     const newGraphType = useSelector(getSettingsQueryTrackerNewGraphType);
 
     const [showLargeGraph, setShowLargeGraph] = React.useState(false);

--- a/packages/ui/src/ui/pages/query-tracker/Plan/Timeline/Timeline.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/Timeline/Timeline.tsx
@@ -3,7 +3,7 @@ import {TimelineHeader} from './TimelineHeader';
 import {Flex} from '@gravity-ui/uikit';
 import {TimelineList} from './TimelineList';
 import {useSelector} from '../../../../store/redux-hooks';
-import {getProgressInterval} from '../../../../store/selectors/query-tracker/queryPlan';
+import {selectProgressInterval} from '../../../../store/selectors/query-tracker/queryPlan';
 import {useTimelineData} from './useTimelineData';
 import {useTimeline} from '@gravity-ui/timeline/react';
 import {TimelineBlock} from './TimelineBlock';
@@ -16,7 +16,7 @@ const b = block('yt-plan-timeline');
 type Interval = {from: number; to: number};
 
 export const Timeline: FC = () => {
-    const initialInterval = useSelector(getProgressInterval);
+    const initialInterval = useSelector(selectProgressInterval);
     const [interval, setInterval] = useState(initialInterval);
     const timelineData = useTimelineData();
 

--- a/packages/ui/src/ui/pages/query-tracker/Plan/Timeline/TimelineHeader.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/Timeline/TimelineHeader.tsx
@@ -4,7 +4,7 @@ import {type NodeState} from '../models/plan';
 import './TimelineHeader.scss';
 import cn from 'bem-cn-lite';
 import {useSelector} from '../../../../store/redux-hooks';
-import {getOperationNodesStates} from '../../../../store/selectors/query-tracker/queryPlan';
+import {selectOperationNodesStates} from '../../../../store/selectors/query-tracker/queryPlan';
 
 const block = cn('yt-timeline-header');
 
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export const TimelineHeader: FC<Props> = ({onStatusChange, onFilterChange}) => {
-    const states = useSelector(getOperationNodesStates);
+    const states = useSelector(selectOperationNodesStates);
 
     const handleStatusChange = (value: string[]) => {
         onStatusChange(value[0] as NodeState | undefined);

--- a/packages/ui/src/ui/pages/query-tracker/Plan/Timeline/useTimelineData.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/Timeline/useTimelineData.ts
@@ -3,8 +3,8 @@ import {useThemeValue} from '@gravity-ui/uikit';
 
 import {useSelector} from '../../../../store/redux-hooks';
 import {
-    getNodesWithProgress,
-    getQueryStartedAtMillis,
+    selectNodesWithProgress,
+    selectQueryStartedAtMillis,
 } from '../../../../store/selectors/query-tracker/queryPlan';
 import {useGraphColors} from '../GraphColors';
 import {type NodeState} from '../models/plan';
@@ -36,8 +36,8 @@ export function useTimelineData(): UseTimelineDataResult {
     const theme = useThemeValue();
     const colors = useGraphColors();
 
-    const nodes = useSelector(getNodesWithProgress);
-    const queryStartedAtMillis = useSelector(getQueryStartedAtMillis);
+    const nodes = useSelector(selectNodesWithProgress);
+    const queryStartedAtMillis = useSelector(selectQueryStartedAtMillis);
 
     const [expandedAxesSet, setExpandedAxesSet] = React.useState(new Set<string>());
     const [search, setSearch] = React.useState('');

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/EditQueryNameModal/EditQueryNameModal.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/EditQueryNameModal/EditQueryNameModal.tsx
@@ -7,7 +7,7 @@ import {type QueryItem} from '../../../../types/query-tracker/api';
 import {setQueryName} from '../../../../store/actions/query-tracker/api';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {updateQueryInList} from '../../../../store/actions/query-tracker/queriesList';
-import {getQueryDraft} from '../../../../store/selectors/query-tracker/query';
+import {selectQueryDraft} from '../../../../store/selectors/query-tracker/query';
 import {updateQueryDraft} from '../../../../store/actions/query-tracker/query';
 import i18n from './i18n';
 
@@ -22,7 +22,7 @@ interface FormValues {
 
 export default function EditQueryNameModal({query: {state, annotations, id}, className}: Props) {
     const dispatch = useDispatch();
-    const currentDraft = useSelector(getQueryDraft);
+    const currentDraft = useSelector(selectQueryDraft);
     const [error, setError] = useState<Error | undefined>(undefined);
     const [visible, setVisible] = useState(false);
 

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/index.tsx
@@ -3,10 +3,10 @@ import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import DataTable, {type Settings} from '@gravity-ui/react-data-table';
 import {type QueryItem} from '../../../../types/query-tracker/api';
 import {
-    getQueryListByDate,
-    getQueryListColumns,
-    hasQueriesListMore,
-    isQueriesListLoading,
+    selectHasQueriesListMore,
+    selectIsQueriesListLoading,
+    selectQueryListByDate,
+    selectQueryListColumns,
 } from '../../../../store/selectors/query-tracker/queriesList';
 import {DataTableYT} from '../../../../components/DataTableYT';
 import {useQueryNavigation} from '../../hooks/Query';
@@ -54,10 +54,10 @@ function QueriesHistoryListUpdater() {
 
 export function QueriesHistoryList() {
     const dispatch = useDispatch();
-    const itemsByDate = useSelector(getQueryListByDate);
-    const isLoading = useSelector(isQueriesListLoading);
-    const {columns} = useSelector(getQueryListColumns);
-    const hasMore = useSelector(hasQueriesListMore);
+    const itemsByDate = useSelector(selectQueryListByDate);
+    const isLoading = useSelector(selectIsQueriesListLoading);
+    const {columns} = useSelector(selectQueryListColumns);
+    const hasMore = useSelector(selectHasQueriesListMore);
     const [selectedId, goToQuery] = useQueryNavigation();
 
     const showPagination = hasMore && itemsByDate.length > 0;

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/FilterDropdown/FilterDropdown.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/FilterDropdown/FilterDropdown.tsx
@@ -8,7 +8,7 @@ import TrashBinIcon from '@gravity-ui/icons/svgs/trash-bin.svg';
 import {QueryStateFilter} from '../QueryStateFilter';
 import {QueryUserFilter} from '../QueryUserFilter';
 import {QueryDateFilter} from '../QueryDateFilter';
-import {hasCustomHistoryFilters} from '../../../../../store/selectors/query-tracker/queriesList';
+import {selectHasCustomHistoryFilters} from '../../../../../store/selectors/query-tracker/queriesList';
 import i18n from './i18n';
 
 const block = cn('yt-qt-filter-dropdown');
@@ -24,7 +24,7 @@ const Block: FC<PropsWithChildren<{title: string}>> = ({title, children}) => {
 
 export const FilterDropdown: FC = () => {
     const dispatch = useDispatch();
-    const changed = useSelector(hasCustomHistoryFilters);
+    const changed = useSelector(selectHasCustomHistoryFilters);
 
     const handleResetFilter = React.useCallback(() => {
         dispatch(resetFilter());

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryDateFilter/QueryDateFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryDateFilter/QueryDateFilter.tsx
@@ -1,6 +1,6 @@
 import React, {type FC, useMemo} from 'react';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
-import {getQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
+import {selectQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
 import {DatePicker} from '@gravity-ui/date-components';
 import {type DateTime, dateTimeParse} from '../../../../../utils/date-utils';
 import {Flex} from '@gravity-ui/uikit';
@@ -9,7 +9,7 @@ import i18n from './i18n';
 
 export const QueryDateFilter: FC = () => {
     const dispatch = useDispatch();
-    const {from, to} = useSelector(getQueriesFilters);
+    const {from, to} = useSelector(selectQueriesFilters);
 
     const setFilter = useMemo(
         () => ({

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryEngineFilter/QueryEngineFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryEngineFilter/QueryEngineFilter.tsx
@@ -3,7 +3,7 @@ import {Select} from '@gravity-ui/uikit';
 import {Engines} from '../../../../../types/query-tracker/api';
 import {type QueryEngine, QueryEnginesNames} from '../../../../../../shared/constants/engines';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
-import {getQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
+import {selectQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
 import {applyFilter} from '../../../../../store/actions/query-tracker/queriesList';
 import i18n from './i18n';
 
@@ -24,7 +24,7 @@ const getEnginesList = () => [
 
 export const QueryEngineFilter: FC = () => {
     const dispatch = useDispatch();
-    const {engine} = useSelector(getQueriesFilters);
+    const {engine} = useSelector(selectQueriesFilters);
 
     const onChangeEngineFilter = useCallback(
         (values: string[]) => {

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryFastUserFilter/QueryFastUserFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryFastUserFilter/QueryFastUserFilter.tsx
@@ -5,7 +5,7 @@ import {
 } from '../../../../../types/query-tracker/queryList';
 import {type ControlGroupOption, SegmentedRadioGroup} from '@gravity-ui/uikit';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
-import {getQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
+import {selectQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
 import {applyFilter} from '../../../../../store/actions/query-tracker/queriesList';
 import {selectCurrentUserName} from '../../../../../store/selectors/global';
 import i18n from './i18n';
@@ -23,7 +23,7 @@ const getAuthorFilter = (): ControlGroupOption[] => [
 
 export const QueryFastUserFilter: FC = () => {
     const dispatch = useDispatch();
-    const {user} = useSelector(getQueriesFilters);
+    const {user} = useSelector(selectQueriesFilters);
     const login = useSelector(selectCurrentUserName);
 
     const handleUserChange = (value: string) => {

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryStateFilter/QueryStateFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryStateFilter/QueryStateFilter.tsx
@@ -4,7 +4,7 @@ import {QueryStatus} from '../../../../../types/query-tracker';
 import hammer from '../../../../../common/hammer';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {applyFilter} from '../../../../../store/actions/query-tracker/queriesList';
-import {getQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
+import {selectQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
 import i18n from './i18n';
 
 const ALL_STATUS_KEY = '__all';
@@ -23,7 +23,7 @@ const getStatusesList = () => [
 
 export const QueryStateFilter: FC = () => {
     const dispatch = useDispatch();
-    const {state} = useSelector(getQueriesFilters);
+    const {state} = useSelector(selectQueriesFilters);
 
     const onChangeStatusFilter = useCallback(
         (values: string[]) => {

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryUserFilter/QueryUserFilter.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/QueryUserFilter/QueryUserFilter.tsx
@@ -3,7 +3,7 @@ import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {selectAllUserNames, selectCurrentUserName} from '../../../../../store/selectors/global';
 import {useAllUserNamesFiltered} from '../../../../../hooks/global';
 import {Select, type SelectOption} from '@gravity-ui/uikit';
-import {getQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
+import {selectQueriesFilters} from '../../../../../store/selectors/query-tracker/queriesList';
 import {QueriesListAuthorFilter} from '../../../../../types/query-tracker/queryList';
 import {applyFilter} from '../../../../../store/actions/query-tracker/queriesList';
 
@@ -14,7 +14,7 @@ export const QueryUserFilter: FC = () => {
     const dispatch = useDispatch();
     const userNames = useSelector(selectAllUserNames);
     const login = useSelector(selectCurrentUserName);
-    const {user} = useSelector(getQueriesFilters);
+    const {user} = useSelector(selectQueriesFilters);
 
     const values = useMemo<SelectOption[]>(() => {
         return [

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.tsx
@@ -13,10 +13,10 @@ import GearIcon from '@gravity-ui/icons/svgs/gear.svg';
 import ColumnSelector from '../../../../components/ColumnSelector/ColumnSelector';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
-    getQueriesFilters,
-    getQueriesListMode,
-    getQueryListColumns,
-    hasCustomHistoryFilters,
+    selectHasCustomHistoryFilters,
+    selectQueriesFilters,
+    selectQueriesListMode,
+    selectQueryListColumns,
 } from '../../../../store/selectors/query-tracker/queriesList';
 import {applyFilter} from '../../../../store/actions/query-tracker/queriesList';
 import {setSettingByKey} from '../../../../store/actions/settings';
@@ -33,10 +33,10 @@ type QueriesHistoryListFilterProps = {
 
 export function QueriesHistoryListFilter({className}: QueriesHistoryListFilterProps) {
     const dispatch = useDispatch();
-    const filter = useSelector(getQueriesFilters);
-    const filterViewMode = useSelector(getQueriesListMode);
-    const {allowedColumns} = useSelector(getQueryListColumns);
-    const customFilterChanged = useSelector(hasCustomHistoryFilters);
+    const filter = useSelector(selectQueriesFilters);
+    const filterViewMode = useSelector(selectQueriesListMode);
+    const {allowedColumns} = useSelector(selectQueryListColumns);
+    const customFilterChanged = useSelector(selectHasCustomHistoryFilters);
 
     const handleColumnChange = (selectedColumns: {
         items: Array<{checked: boolean; name: string}>;

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesTutorialList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesTutorialList/index.tsx
@@ -7,9 +7,9 @@ import tutorialIcon from '../../../../assets/img/svg/learn.svg';
 import './index.scss';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
-    getTutorialQueriesList,
-    hasQueriesListMore,
-    isQueriesListLoading,
+    selectHasQueriesListMore,
+    selectIsQueriesListLoading,
+    selectTutorialQueriesList,
 } from '../../../../store/selectors/query-tracker/queriesList';
 import {loadNextQueriesList} from '../../../../store/actions/query-tracker/queriesList';
 import {InfiniteScrollLoader} from '../../../../components/InfiniteScrollLoader';
@@ -32,9 +32,9 @@ function renderItem(item: QueryItem) {
 
 export function QueriesTutorialList({className}: {className: string}) {
     const dispatch = useDispatch();
-    const items = useSelector(getTutorialQueriesList);
-    const isLoading = useSelector(isQueriesListLoading);
-    const hasMore = useSelector(hasQueriesListMore);
+    const items = useSelector(selectTutorialQueriesList);
+    const isLoading = useSelector(selectIsQueriesListLoading);
+    const hasMore = useSelector(selectHasQueriesListMore);
 
     const [selectedId, goToQuery] = useQueryNavigation();
 

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/index.tsx
@@ -4,8 +4,8 @@ import {Tab, TabList, TabPanel, TabProvider} from '@gravity-ui/uikit';
 import {QueriesHistoryList} from './QueriesHistoryList';
 
 import {
-    getQueriesListMode,
-    getQueriesListTabs,
+    selectQueriesListMode,
+    selectQueriesListTabs,
 } from '../../../store/selectors/query-tracker/queriesList';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {DefaultQueriesListFilter, QueriesListMode} from '../../../types/query-tracker/queryList';
@@ -51,8 +51,8 @@ const TabContent: Record<QueriesListMode, React.ReactNode> = {
 
 export function QueriesList() {
     const dispatch = useDispatch();
-    const activeTab = useSelector(getQueriesListMode);
-    const tabsList = useSelector(getQueriesListTabs);
+    const activeTab = useSelector(selectQueriesListMode);
+    const tabsList = useSelector(selectQueriesListTabs);
     const isInitializedRef = useRef(false);
 
     useEffect(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryACO/useQueryACO.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryACO/useQueryACO.ts
@@ -1,8 +1,8 @@
 import {useCallback, useState} from 'react';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {
-    getCurrentDraftQueryACO,
-    getCurrentQueryACO,
+    selectCurrentDraftQueryACO,
+    selectCurrentQueryACO,
 } from '../../../store/selectors/query-tracker/query';
 import {
     getQueryACOOptions,
@@ -14,8 +14,8 @@ import {setDraftQueryACO, setQueryACO} from '../../../store/actions/query-tracke
 
 export const useQueryACO = () => {
     const dispatch = useDispatch();
-    const currentQueryACO = useSelector(getCurrentQueryACO);
-    const currentDraftQueryACO = useSelector(getCurrentDraftQueryACO);
+    const currentQueryACO = useSelector(selectCurrentQueryACO);
+    const currentDraftQueryACO = useSelector(selectCurrentDraftQueryACO);
     const selectOptions = useSelector(getQueryACOOptions);
     const isQueryTrackerInfoLoading = useSelector(isQueryTrackerInfoLoadingSelector);
     const trackerInfo = useSelector(selectQueryTrackerInfo);

--- a/packages/ui/src/ui/pages/query-tracker/QueryACO/useQueryACO.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryACO/useQueryACO.ts
@@ -5,8 +5,8 @@ import {
     selectCurrentQueryACO,
 } from '../../../store/selectors/query-tracker/query';
 import {
-    getQueryACOOptions,
-    isQueryTrackerInfoLoading as isQueryTrackerInfoLoadingSelector,
+    selectIsQueryTrackerInfoLoading,
+    selectQueryACOOptions,
     selectQueryTrackerInfo,
 } from '../../../store/selectors/query-tracker/queryAco';
 import {getQueryTrackerInfo} from '../../../store/actions/query-tracker/queryAco';
@@ -16,8 +16,8 @@ export const useQueryACO = () => {
     const dispatch = useDispatch();
     const currentQueryACO = useSelector(selectCurrentQueryACO);
     const currentDraftQueryACO = useSelector(selectCurrentDraftQueryACO);
-    const selectOptions = useSelector(getQueryACOOptions);
-    const isQueryTrackerInfoLoading = useSelector(isQueryTrackerInfoLoadingSelector);
+    const selectOptions = useSelector(selectQueryACOOptions);
+    const isQueryTrackerInfoLoading = useSelector(selectIsQueryTrackerInfoLoading);
     const trackerInfo = useSelector(selectQueryTrackerInfo);
     const [loading, setLoading] = useState(false);
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditor.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditor.tsx
@@ -2,7 +2,10 @@ import React, {type FC, useEffect, useState} from 'react';
 import block from 'bem-cn-lite';
 import {Loader} from '@gravity-ui/uikit';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
-import {isQueryExecuted, isQueryLoading} from '../../../store/selectors/query-tracker/query';
+import {
+    selectIsQueryExecuted,
+    selectIsQueryLoading,
+} from '../../../store/selectors/query-tracker/query';
 import FlexSplitPane from '../../../components/FlexSplitPane/FlexSplitPane';
 import './QueryEditor.scss';
 import {useCurrentQuery} from '../QueryResults/hooks/useCurrentQuery';
@@ -53,8 +56,8 @@ export const QueryEditor: FC<Props> = ({onStartQuery, showStatusInTitle, pathNav
         setResultViewMode('split');
     }, [query?.id]);
 
-    const isExecuted = useSelector(isQueryExecuted);
-    const isMainQueryLoading = useSelector(isQueryLoading);
+    const isExecuted = useSelector(selectIsQueryExecuted);
+    const isMainQueryLoading = useSelector(selectIsQueryLoading);
     const isLoading = isQueryTrackerInfoLoading || isMainQueryLoading;
 
     return (

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorMonaco.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorMonaco.tsx
@@ -3,12 +3,12 @@ import * as monaco from 'monaco-editor';
 import {useMonaco} from '../hooks/useMonaco';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {
-    getQueryDraftCluster,
-    getQueryEditorErrors,
-    getQueryEngine,
-    getQueryId,
-    getQueryText,
-    isQueryLoading,
+    selectIsQueryLoading,
+    selectQueryDraftCluster,
+    selectQueryEditorErrors,
+    selectQueryEngine,
+    selectQueryId,
+    selectQueryText,
 } from '../../../store/selectors/query-tracker/query';
 import {useMonacoQuerySuggestions} from '../querySuggestionsModule/useMonacoQuerySuggestions';
 import {updateQueryDraft} from '../../../store/actions/query-tracker/query';
@@ -44,12 +44,12 @@ export const QueryEditorMonaco: FC<Props> = ({pathNavigation = true}) => {
     const [changed, setChanged] = useState(false);
     const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
     const {setEditor} = useMonaco();
-    const id = useSelector(getQueryId);
-    const text = useSelector(getQueryText);
-    const cluster = useSelector(getQueryDraftCluster);
-    const engine = useSelector(getQueryEngine);
-    const editorErrors = useSelector(getQueryEditorErrors);
-    const loading = useSelector(isQueryLoading);
+    const id = useSelector(selectQueryId);
+    const text = useSelector(selectQueryText);
+    const cluster = useSelector(selectQueryDraftCluster);
+    const engine = useSelector(selectQueryEngine);
+    const editorErrors = useSelector(selectQueryEditorErrors);
+    const loading = useSelector(selectIsQueryLoading);
     const dispatch = useDispatch();
 
     const decorators = useRef<Decorators>({

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
@@ -9,7 +9,7 @@ import {
     selectQueryId,
     selectShouldPollCliqueWhenInactive,
 } from '../../../../store/selectors/query-tracker/query';
-import {isSupportedQtACO} from '../../../../store/selectors/query-tracker/queryAco';
+import {selectIsSupportedQtACO} from '../../../../store/selectors/query-tracker/queryAco';
 import {loadCliqueByCluster, runQuery} from '../../../../store/actions/query-tracker/query';
 import {Button, Flex, Icon, Text} from '@gravity-ui/uikit';
 import playIcon from '../../../../assets/img/svg/play.svg';
@@ -40,7 +40,7 @@ export const QueryEditorView = memo<Props>(function QueryEditorView({
     const engine = useSelector(selectQueryEngine);
     const queryCluster = useSelector(selectQueryDraftCluster);
     const shouldPollClique = useSelector(selectShouldPollCliqueWhenInactive);
-    const isACOSupported = useSelector(isSupportedQtACO);
+    const isACOSupported = useSelector(selectIsSupportedQtACO);
     const isRunButtonActive = useSelector(selectIsQueryButtonActive);
     const dispatch = useDispatch();
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
@@ -3,11 +3,11 @@ import type * as monaco from 'monaco-editor';
 import {useMonaco} from '../../hooks/useMonaco';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
-    getQueryDraftCluster,
-    getQueryEngine,
-    getQueryId,
-    isQueryButtonActive,
-    shouldPollCliqueWhenInactive,
+    selectIsQueryButtonActive,
+    selectQueryDraftCluster,
+    selectQueryEngine,
+    selectQueryId,
+    selectShouldPollCliqueWhenInactive,
 } from '../../../../store/selectors/query-tracker/query';
 import {isSupportedQtACO} from '../../../../store/selectors/query-tracker/queryAco';
 import {loadCliqueByCluster, runQuery} from '../../../../store/actions/query-tracker/query';
@@ -36,12 +36,12 @@ export const QueryEditorView = memo<Props>(function QueryEditorView({
 }) {
     const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
     const {setEditor} = useMonaco();
-    const id = useSelector(getQueryId);
-    const engine = useSelector(getQueryEngine);
-    const queryCluster = useSelector(getQueryDraftCluster);
-    const shouldPollClique = useSelector(shouldPollCliqueWhenInactive);
+    const id = useSelector(selectQueryId);
+    const engine = useSelector(selectQueryEngine);
+    const queryCluster = useSelector(selectQueryDraftCluster);
+    const shouldPollClique = useSelector(selectShouldPollCliqueWhenInactive);
     const isACOSupported = useSelector(isSupportedQtACO);
-    const isRunButtonActive = useSelector(isQueryButtonActive);
+    const isRunButtonActive = useSelector(selectIsQueryButtonActive);
     const dispatch = useDispatch();
 
     const runButtonDisabled = !isRunButtonActive;

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
@@ -87,7 +87,9 @@ export const QueryResultDownloadManager = React.memo(function QueryResultDownloa
     className,
 }: Props) {
     const cluster = useSelector(selectCluster);
-    const result = useSelector((state: RootState) => selectQueryResult(state, queryId, resultIndex));
+    const result = useSelector((state: RootState) =>
+        selectQueryResult(state, queryId, resultIndex),
+    );
     const dispatch = useDispatch();
     const startRow = result?.resultReady ? result?.page * result?.settings?.pageSize || 0 : 0;
     const allItems = useMemo(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
@@ -4,7 +4,7 @@ import React, {useMemo, useState} from 'react';
 import {selectCluster} from '../../../../store/selectors/global';
 import {DownloadManager} from '../../../navigation/content/Table/DownloadManager/DownloadManager';
 import {getDownloadQueryResultURL} from '../../../../store/actions/query-tracker/api';
-import {getQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
+import {selectQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
 import {type RootState} from '../../../../store/reducers';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {type FIX_MY_TYPE} from '../../../../../@types/types';
@@ -87,7 +87,7 @@ export const QueryResultDownloadManager = React.memo(function QueryResultDownloa
     className,
 }: Props) {
     const cluster = useSelector(selectCluster);
-    const result = useSelector((state: RootState) => getQueryResult(state, queryId, resultIndex));
+    const result = useSelector((state: RootState) => selectQueryResult(state, queryId, resultIndex));
     const dispatch = useDispatch();
     const startRow = result?.resultReady ? result?.page * result?.settings?.pageSize || 0 : 0;
     const allItems = useMemo(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/index.tsx
@@ -1,5 +1,5 @@
 import {Button, type ControlGroupOption, Icon, SegmentedRadioGroup} from '@gravity-ui/uikit';
-import {getQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
+import {selectQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
 import block from 'bem-cn-lite';
 import React, {useCallback} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
@@ -38,7 +38,7 @@ const getModeVariants = (): ControlGroupOption[] => [
 export function QueryResultActions({query, resultIndex}: Props) {
     const dispatch = useDispatch();
     const queryResult = useSelector((state: RootState) =>
-        getQueryResult(state, query.id, resultIndex),
+        selectQueryResult(state, query.id, resultIndex),
     );
 
     const handleTransposedChange = useCallback(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/ShareButton/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/ShareButton/index.tsx
@@ -5,7 +5,7 @@ import ChevronUpIcon from '@gravity-ui/icons/svgs/chevron-up.svg';
 import ChevronDownIcon from '@gravity-ui/icons/svgs/chevron-down.svg';
 import {
     SHARED_QUERY_ACO,
-    getCurrentQueryACO,
+    selectCurrentQueryACO,
 } from '../../../../store/selectors/query-tracker/query';
 import {toggleShareQuery} from '../../../../store/actions/query-tracker/query';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
@@ -23,7 +23,7 @@ export const ShareButton: FC = () => {
     const [sending, setSending] = useState(false);
     const [open, toggleDropdown] = useToggle(false);
     const showShareButton = useSelector(isSupportedShareQuery);
-    const queryAco = useSelector(getCurrentQueryACO);
+    const queryAco = useSelector(selectCurrentQueryACO);
     const isShared = queryAco.includes(SHARED_QUERY_ACO);
 
     const handleToggleQuery = useCallback(async () => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/ShareButton/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/ShareButton/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../store/selectors/query-tracker/query';
 import {toggleShareQuery} from '../../../../store/actions/query-tracker/query';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
-import {isSupportedShareQuery} from '../../../../store/selectors/query-tracker/queryAco';
+import {selectIsSupportedShareQuery} from '../../../../store/selectors/query-tracker/queryAco';
 import {useToggle} from 'react-use';
 import {toaster} from '../../../../utils/toaster';
 import './index.scss';
@@ -22,7 +22,7 @@ export const ShareButton: FC = () => {
     const dispatch = useDispatch();
     const [sending, setSending] = useState(false);
     const [open, toggleDropdown] = useToggle(false);
-    const showShareButton = useSelector(isSupportedShareQuery);
+    const showShareButton = useSelector(selectIsSupportedShareQuery);
     const queryAco = useSelector(selectCurrentQueryACO);
     const isShared = queryAco.includes(SHARED_QUERY_ACO);
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useCurrentQuery.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useCurrentQuery.ts
@@ -2,7 +2,7 @@ import {useContext, useEffect, useMemo} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {QueriesPoolingContext} from '../../hooks/QueriesPooling/context';
 
-import {getCurrentQuery} from '../../../../store/selectors/query-tracker/query';
+import {selectCurrentQuery} from '../../../../store/selectors/query-tracker/query';
 import {getDefaultQueryACO} from '../../../../store/selectors/query-tracker/queryAco';
 import {isQueryProgress} from '../../utils/query';
 import {type QueryItem} from '../../../../types/query-tracker/api';
@@ -11,7 +11,7 @@ import {UPDATE_QUERY_ITEM} from '../../../../store/reducers/query-tracker/query-
 import {updateQueryTabs} from '../../../../store/actions/query-tracker/queryTabs/queryTabs';
 
 export function useCurrentQuery() {
-    const query = useSelector(getCurrentQuery);
+    const query = useSelector(selectCurrentQuery);
     const defaultQueryACO = useSelector(getDefaultQueryACO);
     const pollingContext = useContext(QueriesPoolingContext);
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useCurrentQuery.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/hooks/useCurrentQuery.ts
@@ -3,7 +3,7 @@ import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {QueriesPoolingContext} from '../../hooks/QueriesPooling/context';
 
 import {selectCurrentQuery} from '../../../../store/selectors/query-tracker/query';
-import {getDefaultQueryACO} from '../../../../store/selectors/query-tracker/queryAco';
+import {selectDefaultQueryACO} from '../../../../store/selectors/query-tracker/queryAco';
 import {isQueryProgress} from '../../utils/query';
 import {type QueryItem} from '../../../../types/query-tracker/api';
 import {prepareQueryPlanIds} from '../../../../types/query-tracker/query';
@@ -12,7 +12,7 @@ import {updateQueryTabs} from '../../../../store/actions/query-tracker/queryTabs
 
 export function useCurrentQuery() {
     const query = useSelector(selectCurrentQuery);
-    const defaultQueryACO = useSelector(getDefaultQueryACO);
+    const defaultQueryACO = useSelector(selectDefaultQueryACO);
     const pollingContext = useContext(QueriesPoolingContext);
 
     const dispatch = useDispatch();

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/ResultPaginator/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/ResultPaginator/index.tsx
@@ -3,7 +3,7 @@ import block from 'bem-cn-lite';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {type RootState} from '../../../../store/reducers';
 import {Select, type SelectOption} from '@gravity-ui/uikit';
-import {getQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
+import {selectQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
 import SimplePagination from '../../../../components/Pagination/SimplePagination';
 import {
     applySettings,
@@ -48,7 +48,7 @@ function useQueryResultPagination(
         pageSize: 0,
     });
 
-    const result = useSelector((state: RootState) => getQueryResult(state, queryId, resultIndex));
+    const result = useSelector((state: RootState) => selectQueryResult(state, queryId, resultIndex));
 
     useEffect(() => {
         if (result?.resultReady) {

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/ResultPaginator/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/ResultPaginator/index.tsx
@@ -48,7 +48,9 @@ function useQueryResultPagination(
         pageSize: 0,
     });
 
-    const result = useSelector((state: RootState) => selectQueryResult(state, queryId, resultIndex));
+    const result = useSelector((state: RootState) =>
+        selectQueryResult(state, queryId, resultIndex),
+    );
 
     useEffect(() => {
         if (result?.resultReady) {

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLStatistics/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLStatistics/index.tsx
@@ -1,13 +1,13 @@
 import {useSelector} from '../../../../store/redux-hooks';
 import React from 'react';
 
-import {getProgressYQLStatistics} from '../../../../store/selectors/query-tracker/query';
+import {selectProgressYQLStatistics} from '../../../../store/selectors/query-tracker/query';
 import {StatisticTable, type StatisticTree} from '../../../../components/StatisticTable';
 
 import './index.scss';
 
 export function YQLStatisticsTable() {
-    const statistics = useSelector(getProgressYQLStatistics);
+    const statistics = useSelector(selectProgressYQLStatistics);
 
     if (!statistics) {
         return null;

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/index.tsx
@@ -10,8 +10,8 @@ import {
     onErrorTableCellPreview,
 } from '../../../types/navigation/table-cell-preview';
 import {
-    getQueryResult,
-    getQueryResultSettings,
+    selectQueryResult,
+    selectQueryResultSettings,
 } from '../../../store/selectors/query-tracker/queryResult';
 import {YTErrorBlock} from '../../../components/Error/Error';
 import {ResultsTable} from './ResultsTable';
@@ -88,10 +88,10 @@ function QueryReadyResultView({
 
 export const QueryResultsView = React.memo(
     function QueryResultsView({query, index}: {query: QueryItem; index: number}) {
-        const result = useSelector((state: RootState) => getQueryResult(state, query.id, index));
+        const result = useSelector((state: RootState) => selectQueryResult(state, query.id, index));
         const page = result?.page;
         const {pageSize} = useSelector((state: RootState) =>
-            getQueryResultSettings(state, query.id, index),
+            selectQueryResultSettings(state, query.id, index),
         );
         const engine = useSelector(selectQueryEngine);
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/index.tsx
@@ -31,7 +31,7 @@ import CancelHelper from '../../../utils/cancel-helper';
 import {injectQueryResults} from '../../../store/actions/query-tracker/queryResult';
 import i18n from './i18n';
 import {QueryFullResultList} from './QueryFullResultList';
-import {getQueryEngine} from '../../../store/selectors/query-tracker/query';
+import {selectQueryEngine} from '../../../store/selectors/query-tracker/query';
 import {type QueryEngine} from '../../../../shared/constants/engines';
 
 const b = block('query-result-table');
@@ -93,7 +93,7 @@ export const QueryResultsView = React.memo(
         const {pageSize} = useSelector((state: RootState) =>
             getQueryResultSettings(state, query.id, index),
         );
-        const engine = useSelector(getQueryEngine);
+        const engine = useSelector(selectQueryEngine);
 
         const {onShowPreview} = useShowPreviewHandler({
             queryId: query.id,

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/ChartLeftMenu/ChartLeftMenu.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsVisualization/components/ChartLeftMenu/ChartLeftMenu.tsx
@@ -7,7 +7,7 @@ import './ChartLeftMenu.scss';
 import cn from 'bem-cn-lite';
 import {ChartType} from '../../constants';
 import {ConfigWizard, Wizard} from '../Wizard';
-import {getQueryDraft} from '../../../../../store/selectors/query-tracker/query';
+import {selectQueryDraft} from '../../../../../store/selectors/query-tracker/query';
 import {saveQueryChartConfig} from '../../../../../store/actions/query-tracker/queryChart';
 import i18n from './i18n';
 
@@ -23,7 +23,7 @@ const b = cn('yt-chart-left-menu');
 export const ChartLeftMenu: FC = () => {
     const dispatch = useDispatch();
     const visualization = useSelector(selectCurrentChartVisualization);
-    const {id} = useSelector(getQueryDraft);
+    const {id} = useSelector(selectQueryDraft);
     const {type} = visualization;
 
     useEffect(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenButton/QueryTokenButton.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenButton/QueryTokenButton.tsx
@@ -5,12 +5,12 @@ import {QueryTokenDropdown} from './QueryTokenDropdown';
 import {useToggle} from 'react-use';
 import {PopupWithCloseButton} from '../../QuerySettingsButton/PopupWithCloseButton';
 import {useSelector} from '../../../../store/redux-hooks';
-import {getQuerySecrets} from '../../../../store/selectors/query-tracker/query';
+import {selectQuerySecrets} from '../../../../store/selectors/query-tracker/query';
 
 export const QueryTokenButton: FC = () => {
     const btnRef = useRef<HTMLButtonElement>(null);
     const [open, toggleOpen] = useToggle(false);
-    const haveSecrets = useSelector(getQuerySecrets).length > 0;
+    const haveSecrets = useSelector(selectQuerySecrets).length > 0;
 
     return (
         <>

--- a/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenButton/QueryTokenDropdown.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenButton/QueryTokenDropdown.tsx
@@ -7,7 +7,7 @@ import {getQueryTokens} from '../../../../store/selectors/settings/settings-quer
 import CircleQuestionIcon from '@gravity-ui/icons/svgs/circle-question.svg';
 import {updateQueryDraft} from '../../../../store/actions/query-tracker/query';
 import {type QuerySecret} from '../../../../types/query-tracker/api';
-import {getCurrentSecretIds} from '../../../../store/selectors/query-tracker/query';
+import {selectCurrentSecretIds} from '../../../../store/selectors/query-tracker/query';
 import i18n from './i18n';
 
 const block = cn('yt-qt-token-dropdown');
@@ -15,7 +15,7 @@ const block = cn('yt-qt-token-dropdown');
 export const QueryTokenDropdown: FC = () => {
     const dispatch = useDispatch();
     const tokens = useSelector(getQueryTokens);
-    const secretIds = useSelector(getCurrentSecretIds);
+    const secretIds = useSelector(selectCurrentSecretIds);
 
     const options = useMemo(() => {
         return tokens.map((token) => ({

--- a/packages/ui/src/ui/pages/query-tracker/QueryTracker/QueryTracker.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTracker/QueryTracker.tsx
@@ -14,8 +14,8 @@ import {
 import {usePreventUnload} from '../../../hooks/use-prevent-unload';
 import {useQueriesListSidebarToggle} from '../hooks/QueriesList';
 import {
-    getDirtySinceLastSubmit,
-    getQueryGetParams,
+    selectDirtySinceLastSubmit,
+    selectQueryGetParams,
 } from '../../../store/selectors/query-tracker/query';
 import {LazyQueriesList} from '../QueriesList/lazy';
 import {useQueryACO} from '../QueryACO/useQueryACO';
@@ -53,7 +53,7 @@ const minSize = 380; // see history list's cells size
 
 function QueryPageDraft() {
     const dispatch = useDispatch();
-    const routeParams = useSelector(getQueryGetParams);
+    const routeParams = useSelector(selectQueryGetParams);
     const cluster = useSelector(selectNavigationCluster);
     const favoriteEngine = useSelector(getLastUserChoiceQueryEngine) ?? QueryEngine.YQL;
 
@@ -113,7 +113,7 @@ function QueryPage(props: Props) {
 export default function QueryTracker({match}: Props) {
     const {isQueriesListSidebarVisible, toggleQueriesListSideBarToggle} =
         useQueriesListSidebarToggle();
-    const isQueryStateDirty = useSelector(getDirtySinceLastSubmit);
+    const isQueryStateDirty = useSelector(selectDirtySinceLastSubmit);
     const fileEditor = useSelector(selectFileEditor);
     usePreventUnload({shouldListen: isQueryStateDirty});
     const [sizes, setSize] = useState(initialSizes);

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerOpenButton/QueryTrackerOpenButton.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerOpenButton/QueryTrackerOpenButton.tsx
@@ -4,9 +4,9 @@ import Link from '../../../components/Link/Link';
 import Icon from '../../../components/Icon/Icon';
 import {createNewQueryUrl, createQueryUrl} from '../utils/navigation';
 import {
-    getQuery,
-    getQueryEngine,
-    isQueryDraftEditted,
+    selectIsQueryDraftEditted,
+    selectQuery,
+    selectQueryEngine,
 } from '../../../store/selectors/query-tracker/query';
 import {useSelector} from '../../../store/redux-hooks';
 import i18n from './i18n';
@@ -18,9 +18,9 @@ interface Props {
 }
 
 export function QueryTrackerOpenButton({className, cluster, path}: Props) {
-    const engine = useSelector(getQueryEngine);
-    const isEdited = useSelector(isQueryDraftEditted);
-    const queryId = useSelector(getQuery)?.id;
+    const engine = useSelector(selectQueryEngine);
+    const isEdited = useSelector(selectIsQueryDraftEditted);
+    const queryId = useSelector(selectQuery)?.id;
     let url = '';
     let buttonView: ButtonProps['view'];
     if (queryId && !isEdited) {

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryClusterSelector/QueryClusterSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryClusterSelector/QueryClusterSelector.tsx
@@ -7,7 +7,10 @@ import {getQueryTrackerInfoClusters} from '../../../../store/selectors/query-tra
 import {QuerySelector} from '../QuerySelector';
 import {QueryClusterItem, type Props as QueryClusterItemProps} from './QueryClusterItem';
 import {YT, isMultiClusterInstallation} from '../../../../config/yt-config';
-import {getClusterLoading, getQueryDraft} from '../../../../store/selectors/query-tracker/query';
+import {
+    selectClusterLoading,
+    selectQueryDraft,
+} from '../../../../store/selectors/query-tracker/query';
 import {getClusterList} from '../../../../store/selectors/slideoutMenu';
 import {setQueryCluster} from '../../../../store/actions/query-tracker/query';
 
@@ -18,9 +21,9 @@ type Props = {
 export const QueryClusterSelector: FC<Props> = ({className}) => {
     const dispatch = useDispatch();
     const infoClusters = useSelector(getQueryTrackerInfoClusters);
-    const loading = useSelector(getClusterLoading);
+    const loading = useSelector(selectClusterLoading);
     const clusters = useSelector(getClusterList);
-    const {settings} = useSelector(getQueryDraft);
+    const {settings} = useSelector(selectQueryDraft);
     const isMultiCluster = isMultiClusterInstallation();
 
     const handleOnChange = (clusterId: string) => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryClusterSelector/QueryClusterSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryClusterSelector/QueryClusterSelector.tsx
@@ -3,7 +3,7 @@ import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {Select} from '@gravity-ui/uikit';
 
 import {type ClusterConfig} from '../../../../../shared/yt-types';
-import {getQueryTrackerInfoClusters} from '../../../../store/selectors/query-tracker/queryAco';
+import {selectQueryTrackerInfoClusters} from '../../../../store/selectors/query-tracker/queryAco';
 import {QuerySelector} from '../QuerySelector';
 import {QueryClusterItem, type Props as QueryClusterItemProps} from './QueryClusterItem';
 import {YT, isMultiClusterInstallation} from '../../../../config/yt-config';
@@ -20,7 +20,7 @@ type Props = {
 
 export const QueryClusterSelector: FC<Props> = ({className}) => {
     const dispatch = useDispatch();
-    const infoClusters = useSelector(getQueryTrackerInfoClusters);
+    const infoClusters = useSelector(selectQueryTrackerInfoClusters);
     const loading = useSelector(selectClusterLoading);
     const clusters = useSelector(getClusterList);
     const {settings} = useSelector(selectQueryDraft);

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryClusterSelector/QueryClusterSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryClusterSelector/QueryClusterSelector.tsx
@@ -11,7 +11,7 @@ import {
     selectClusterLoading,
     selectQueryDraft,
 } from '../../../../store/selectors/query-tracker/query';
-import {getClusterList} from '../../../../store/selectors/slideoutMenu';
+import {selectClusterList} from '../../../../store/selectors/slideoutMenu';
 import {setQueryCluster} from '../../../../store/actions/query-tracker/query';
 
 type Props = {
@@ -22,7 +22,7 @@ export const QueryClusterSelector: FC<Props> = ({className}) => {
     const dispatch = useDispatch();
     const infoClusters = useSelector(selectQueryTrackerInfoClusters);
     const loading = useSelector(selectClusterLoading);
-    const clusters = useSelector(getClusterList);
+    const clusters = useSelector(selectClusterList);
     const {settings} = useSelector(selectQueryDraft);
     const isMultiCluster = isMultiClusterInstallation();
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/QueryEngineSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/QueryEngineSelector.tsx
@@ -1,12 +1,12 @@
 import React, {type FC, useCallback, useState} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
-    getClusterLoading,
-    getQueryEngine,
-    getQueryGetParams,
-    getSupportedEnginesOptions,
-    hasLoadedQueryItem,
-    isQueryDraftEditted,
+    selectClusterLoading,
+    selectHasLoadedQueryItem,
+    selectIsQueryDraftEditted,
+    selectQueryEngine,
+    selectQueryGetParams,
+    selectSupportedEnginesOptions,
 } from '../../../../store/selectors/query-tracker/query';
 import {
     createQueryFromTablePath,
@@ -30,12 +30,12 @@ type Props = {
 
 export const QueryEngineSelector: FC<Props> = ({isDesktop, className, onChange}) => {
     const dispatch = useDispatch();
-    const engine = useSelector(getQueryEngine);
-    const options = useSelector(getSupportedEnginesOptions);
-    const isEdited = useSelector(isQueryDraftEditted);
-    const hasLoadedQuery = useSelector(hasLoadedQueryItem);
-    const loading = useSelector(getClusterLoading);
-    const {cluster, path} = useSelector(getQueryGetParams);
+    const engine = useSelector(selectQueryEngine);
+    const options = useSelector(selectSupportedEnginesOptions);
+    const isEdited = useSelector(selectIsQueryDraftEditted);
+    const hasLoadedQuery = useSelector(selectHasLoadedQueryItem);
+    const loading = useSelector(selectClusterLoading);
+    const {cluster, path} = useSelector(selectQueryGetParams);
 
     const showPrompt = Boolean((isEdited || hasLoadedQuery) && cluster && path);
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
@@ -15,8 +15,8 @@ import {
 } from '../../../store/actions/query-tracker/query';
 import {Select} from '@gravity-ui/uikit';
 import {
-    getAvailableYql,
-    getEffectiveYqlVersion,
+    selectAvailableYql,
+    selectEffectiveYqlVersion,
 } from '../../../store/selectors/query-tracker/queryAco';
 import cn from 'bem-cn-lite';
 import './QuerySelectorsByEngine.scss';
@@ -28,8 +28,8 @@ export const QuerySelectorsByEngine: FC = () => {
     const cliqueMap = useSelector(selectCliqueMap);
     const cliqueLoading = useSelector(selectCliqueLoading);
     const {settings = {}, engine} = useSelector(selectQueryDraft);
-    const availableYql = useSelector(getAvailableYql);
-    const effectiveYqlVersion = useSelector(getEffectiveYqlVersion);
+    const availableYql = useSelector(selectAvailableYql);
+    const effectiveYqlVersion = useSelector(selectEffectiveYqlVersion);
     const currentCluster = settings?.cluster;
 
     const options = useMemo(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
@@ -3,9 +3,9 @@ import {QueryEngine} from '../../../../shared/constants/engines';
 import {QueryCliqueSelector} from './QueryCliqueSelector';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {
-    getCliqueLoading,
-    getCliqueMap,
-    getQueryDraft,
+    selectCliqueLoading,
+    selectCliqueMap,
+    selectQueryDraft,
 } from '../../../store/selectors/query-tracker/query';
 import {
     loadCliqueByCluster,
@@ -25,9 +25,9 @@ const block = cn('yt-query-selector-by-engine');
 
 export const QuerySelectorsByEngine: FC = () => {
     const dispatch = useDispatch();
-    const cliqueMap = useSelector(getCliqueMap);
-    const cliqueLoading = useSelector(getCliqueLoading);
-    const {settings = {}, engine} = useSelector(getQueryDraft);
+    const cliqueMap = useSelector(selectCliqueMap);
+    const cliqueLoading = useSelector(selectCliqueLoading);
+    const {settings = {}, engine} = useSelector(selectQueryDraft);
     const availableYql = useSelector(getAvailableYql);
     const effectiveYqlVersion = useSelector(getEffectiveYqlVersion);
     const currentCluster = settings?.cluster;

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/index.tsx
@@ -2,7 +2,7 @@ import React, {type FC, useCallback, useState} from 'react';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {RowWithName} from '../../../containers/AppNavigation/TopRowContent/SectionName';
 import {Page} from '../../../../shared/constants/settings';
-import {getQueryDraft} from '../../../store/selectors/query-tracker/query';
+import {selectQueryDraft} from '../../../store/selectors/query-tracker/query';
 import {
     resetQueryTracker,
     setQueryEngine,
@@ -34,7 +34,7 @@ const block = cn('query-tracker-top-row');
 const QueryTrackerTopRow: FC = () => {
     const dispatch = useDispatch();
     const isDesktop = useIsDesktop();
-    const {id, annotations, settings} = useSelector(getQueryDraft);
+    const {id, annotations, settings} = useSelector(selectQueryDraft);
     const [nameEdit, setNameEdit] = useState(false);
 
     const handleChangeEngine = useCallback(

--- a/packages/ui/src/ui/pages/query-tracker/QueryWidget/QueryMetaForm.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryWidget/QueryMetaForm.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react';
 import cn from 'bem-cn-lite';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
-import {getQueryDraft} from '../../../store/selectors/query-tracker/query';
+import {selectQueryDraft} from '../../../store/selectors/query-tracker/query';
 import {QuerySettingsButton} from '../QuerySettingsButton';
 import {QueryFilesButton} from '../QueryFilesButton';
 import {loadTablePromptToQuery, updateQueryDraft} from '../../../store/actions/query-tracker/query';
@@ -28,7 +28,7 @@ export function QueryMetaForm({
     onClickOnNewQueryButton: () => void;
 }) {
     const dispatch = useDispatch();
-    const draft = useSelector(getQueryDraft);
+    const draft = useSelector(selectQueryDraft);
 
     const onSettingsChange = useCallback(
         (settings: Record<string, string>) => dispatch(updateQueryDraft({settings})),

--- a/packages/ui/src/ui/pages/query-tracker/hooks/QueriesList/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/hooks/QueriesList/index.ts
@@ -1,11 +1,11 @@
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {setSettingByKey} from '../../../../store/actions/settings';
-import {getSettingQueryTrackerQueriesListSidebarVisibilityMode} from '../../../../store/selectors/query-tracker/settings';
+import {selectSettingQueryTrackerQueriesListSidebarVisibilityMode} from '../../../../store/selectors/query-tracker/settings';
 
 export const useQueriesListSidebarToggle = () => {
     const dispatch = useDispatch();
     const isQueriesListSidebarVisible = useSelector(
-        getSettingQueryTrackerQueriesListSidebarVisibilityMode,
+        selectSettingQueryTrackerQueriesListSidebarVisibilityMode,
     );
 
     const toggleQueriesListSideBarToggle = () => {

--- a/packages/ui/src/ui/pages/query-tracker/hooks/Query/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/hooks/Query/index.ts
@@ -5,12 +5,12 @@ import {createQueryUrl} from '../../utils/navigation';
 import {type QueryItem} from '../../../../types/query-tracker/api';
 import {selectCluster} from '../../../../store/selectors/global';
 import {getQuery} from '../../../../store/selectors/query-tracker/query';
-import {getQueriesListMode} from '../../../../store/selectors/query-tracker/queriesList';
+import {selectQueriesListMode} from '../../../../store/selectors/query-tracker/queriesList';
 
 export const useQueryNavigation = (): [QueryItem['id'] | undefined, (id: QueryItem) => void] => {
     const selectedItem = useSelector(getQuery);
     const cluster = useSelector(selectCluster);
-    const listMode = useSelector(getQueriesListMode);
+    const listMode = useSelector(selectQueriesListMode);
     const history = useHistory();
 
     const goToQuery = useCallback(

--- a/packages/ui/src/ui/pages/query-tracker/hooks/Query/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/hooks/Query/index.ts
@@ -4,11 +4,11 @@ import {useHistory} from 'react-router';
 import {createQueryUrl} from '../../utils/navigation';
 import {type QueryItem} from '../../../../types/query-tracker/api';
 import {selectCluster} from '../../../../store/selectors/global';
-import {getQuery} from '../../../../store/selectors/query-tracker/query';
+import {selectQuery} from '../../../../store/selectors/query-tracker/query';
 import {selectQueriesListMode} from '../../../../store/selectors/query-tracker/queriesList';
 
 export const useQueryNavigation = (): [QueryItem['id'] | undefined, (id: QueryItem) => void] => {
-    const selectedItem = useSelector(getQuery);
+    const selectedItem = useSelector(selectQuery);
     const cluster = useSelector(selectCluster);
     const listMode = useSelector(selectQueriesListMode);
     const history = useHistory();

--- a/packages/ui/src/ui/store/actions/ai/pageСontexts.ts
+++ b/packages/ui/src/ui/store/actions/ai/pageСontexts.ts
@@ -1,5 +1,5 @@
 import {type RootState} from '../../reducers';
-import {getQueryDraft, getQueryEngine} from '../../selectors/query-tracker/query';
+import {selectQueryDraft, selectQueryEngine} from '../../selectors/query-tracker/query';
 import {AGENT_MAP} from '../../../containers/AiChat/constants';
 import {selectPage} from '../../selectors/global';
 
@@ -11,10 +11,10 @@ export type PageContext = {
 };
 
 const getQueriesPageContext = (state: RootState): PageContext => {
-    const engine = getQueryEngine(state);
+    const engine = selectQueryEngine(state);
     const agent = engine ? AGENT_MAP[engine] : DEFAULT_AGENT;
 
-    const draft = getQueryDraft(state);
+    const draft = selectQueryDraft(state);
     const contextMessages: string[] = [];
 
     if (draft.query && draft.query.trim()) {

--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -18,8 +18,8 @@ import {
 import {type AnyAction} from 'redux';
 import {type QueryEngine} from '../../../../shared/constants/engines';
 import {
-    getLastSelectedACONamespaces,
     selectIsMultipleAco,
+    selectLastSelectedACONamespaces,
 } from '../../selectors/query-tracker/queryAco';
 import {setSettingByKey} from '../settings';
 import {type CancelTokenSource} from 'axios';
@@ -429,7 +429,7 @@ export function addACOToLastSelected(
 ): ThunkAction<Promise<any>, RootState, any, AnyAction> {
     return async (dispatch, getState) => {
         const state = getState();
-        const lastSelectedACONamespaces = getLastSelectedACONamespaces(state);
+        const lastSelectedACONamespaces = selectLastSelectedACONamespaces(state);
         const stage = selectEffectiveApiStage(state);
 
         await dispatch(

--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -25,7 +25,7 @@ import {setSettingByKey} from '../settings';
 import {type CancelTokenSource} from 'axios';
 import {JSONSerializer} from '../../../common/yt-api';
 import {createTablePrompt} from '../../../pages/query-tracker/Navigation/helpers/createTableSelect';
-import {getQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
+import {selectQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
 import {convertSettingsTypes} from '../../../utils/query-tracker/convertSettingsTypes';
 import {
     type DraftQuery,
@@ -96,7 +96,7 @@ export async function generateQueryFromTable(
     {cluster, path, defaultQueryACO}: {cluster: string; path: string; defaultQueryACO: string},
 ): Promise<DraftQuery | undefined> {
     const selectedCluster = getClusterConfigByName(cluster);
-    const {pageSize} = getQueryResultGlobalSettings();
+    const {pageSize} = selectQueryResultGlobalSettings();
 
     const node = await ytApiV3.get({
         parameters: {

--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -11,9 +11,9 @@ import {type RootState} from '../../reducers';
 import {makeDirectDownloadPath} from '../../../utils/navigation';
 import {UPDATE_QUERIES_LIST} from '../../reducers/query-tracker/query-tracker-contants';
 import {
-    getEffectiveApiStage,
-    getQueryAnnotations,
-    getQueryTrackerRequestOptions,
+    selectEffectiveApiStage,
+    selectQueryAnnotations,
+    selectQueryTrackerRequestOptions,
 } from '../../selectors/query-tracker/query';
 import {type AnyAction} from 'redux';
 import {type QueryEngine} from '../../../../shared/constants/engines';
@@ -151,7 +151,7 @@ export function loadQueriesList({
 }: QueriesListRequestParams): ThunkAction<Promise<QueriesListResponse>, RootState, any, any> {
     return async (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         return ytApiV4Id.listQueries(YTApiId.listQueries, {
             parameters: {
                 stage,
@@ -168,7 +168,7 @@ export function loadQueriesList({
 export function getQuery(query_id: string): ThunkAction<Promise<QueryItem>, RootState, any, any> {
     return (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         return ytApiV4Id.getQuery(YTApiId.getQuery, {
             parameters: {stage, ...makeGetQueryParams(query_id)},
             setup: {
@@ -186,7 +186,7 @@ export function startQuery(
     return async (_dispatch, getState) => {
         const state = getState();
         const isMultipleAco = selectIsMultipleAco(state);
-        const {stage, yqlAgentStage} = getQueryTrackerRequestOptions(state);
+        const {stage, yqlAgentStage} = selectQueryTrackerRequestOptions(state);
         const {
             query,
             engine,
@@ -227,7 +227,7 @@ export function abortQuery(params: {
 }): ThunkAction<Promise<void>, RootState, any, any> {
     return async (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         const {query_id, message} = params;
         return ytApiV4Id.abortQuery(YTApiId.abortQuery, {
             parameters: {
@@ -271,7 +271,7 @@ export function readQueryResults(
 ): ThunkAction<Promise<QueryResult>, RootState, any, any> {
     return async (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         const result = (await ytApiV4Id.readQueryResults(YTApiId.readQueryResults, {
             parameters: {
                 stage,
@@ -305,7 +305,7 @@ export function getDownloadQueryResultURL(
 ): ThunkAction<string, RootState, any, any> {
     return (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         const params = new URLSearchParams({
             query_id: queryId,
             result_index: resultIndex.toString(),
@@ -340,7 +340,7 @@ export function requestQueries(
 ): ThunkAction<Promise<QueryItem[]>, RootState, any, any> {
     return async (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         const requests: BatchSubRequest[] = ids.map((query_id) => ({
             command: 'get_query',
             parameters: {stage, ...makeGetQueryParams(query_id)},
@@ -368,7 +368,7 @@ export function getQueryResultMeta(
 ): ThunkAction<Promise<QueryResultMeta>, RootState, any, any> {
     return (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         return ytApiV4Id.getQueryResults(YTApiId.getQueryResults, {
             parameters: {stage, query_id, result_index},
             setup: {
@@ -385,7 +385,7 @@ export function getQueryResultMetaList(
 ): ThunkAction<Promise<BatchResultsItem<QueryResultMeta>[]>, RootState, any, any> {
     return async (_dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         const requests: BatchSubRequest[] = inds.map((ind) => ({
             command: 'get_query_result',
             parameters: {stage, query_id, result_index: ind},
@@ -407,7 +407,7 @@ export function setQueryName(
 ): ThunkAction<Promise<any>, RootState, any, AnyAction> {
     return async (dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
         await ytApiV4Id.alterQuery(YTApiId.alterQuery, {
             parameters: {
                 stage,
@@ -430,7 +430,7 @@ export function addACOToLastSelected(
     return async (dispatch, getState) => {
         const state = getState();
         const lastSelectedACONamespaces = getLastSelectedACONamespaces(state);
-        const stage = getEffectiveApiStage(state);
+        const stage = selectEffectiveApiStage(state);
 
         await dispatch(
             setSettingByKey(`qt-stage::${stage}::queryTracker::lastSelectedACOs`, [
@@ -453,8 +453,8 @@ export function updateACOQuery({
     return async (dispatch, getState) => {
         const state = getState();
         const isMultipleAco = selectIsMultipleAco(state);
-        const {stage} = getQueryTrackerRequestOptions(state);
-        const annotations = getQueryAnnotations(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
+        const annotations = selectQueryAnnotations(state);
         const chartConfig = state.queryTracker.queryChart.visualization;
 
         return ytApiV4Id
@@ -492,7 +492,7 @@ export function alterQueryChartConfig({
     return async (_dispatch, getState) => {
         const state = getState();
         const isMultipleAco = selectIsMultipleAco(state);
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
 
         return ytApiV4Id.alterQuery(YTApiId.alterQuery, {
             parameters: {

--- a/packages/ui/src/ui/store/actions/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queriesList.ts
@@ -3,11 +3,11 @@ import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {type RootState} from '../../reducers';
 import {loadQueriesList} from './api';
 import {
-    getQueriesFilters,
-    getQueriesList,
-    getQueriesListCursorParams,
-    getQueriesListFilterParams,
-    getQueriesListMode,
+    selectQueriesFilters,
+    selectQueriesList,
+    selectQueriesListCursorParams,
+    selectQueriesListFilterParams,
+    selectQueriesListMode,
 } from '../../selectors/query-tracker/queriesList';
 import {
     DefaultQueriesListFilter,
@@ -44,7 +44,7 @@ export const resetQueryList =
 export function requestQueriesList(silent = false): AsyncAction {
     return async (dispatch, getState) => {
         const state = getState();
-        const list = getQueriesList(state);
+        const list = selectQueriesList(state);
 
         if (!silent) {
             dispatch(setLoading(true));
@@ -54,8 +54,8 @@ export function requestQueriesList(silent = false): AsyncAction {
             const result = await wrapApiPromiseByToaster(
                 dispatch(
                     loadQueriesList({
-                        params: getQueriesListFilterParams(state),
-                        cursor: getQueriesListCursorParams(state),
+                        params: selectQueriesListFilterParams(state),
+                        cursor: selectQueriesListCursorParams(state),
                         limit: QUERIES_LIST_LIMIT,
                     }),
                 ),
@@ -93,7 +93,7 @@ export function requestQueriesList(silent = false): AsyncAction {
 export function loadNextQueriesList(direction = QueriesHistoryCursorDirection.PAST): AsyncAction {
     return (dispatch, getState) => {
         const state = getState();
-        const items = getQueriesList(state);
+        const items = selectQueriesList(state);
 
         const isFuture = direction === QueriesHistoryCursorDirection.FUTURE;
         const lastItem = items[isFuture ? 0 : items.length - 1];
@@ -113,8 +113,8 @@ export function loadNextQueriesList(direction = QueriesHistoryCursorDirection.PA
 export function resetFilter(): AsyncAction {
     return (dispatch, getState) => {
         const state = getState();
-        const listMode = getQueriesListMode(state);
-        const currentFilter = getQueriesFilters(state);
+        const listMode = selectQueriesListMode(state);
+        const currentFilter = selectQueriesFilters(state);
 
         dispatch(setFilter({...DefaultQueriesListFilter[listMode], filter: currentFilter.filter}));
         dispatch(requestQueriesList());
@@ -123,7 +123,7 @@ export function resetFilter(): AsyncAction {
 
 export function applyFilter(patch: QueriesListFilter): AsyncAction {
     return (dispatch, getState) => {
-        const filter = getQueriesFilters(getState());
+        const filter = selectQueriesFilters(getState());
 
         dispatch(setFilter({...filter, ...patch}));
         dispatch(resetQueryList(true));
@@ -147,7 +147,7 @@ export function applyListMode(listMode: QueriesListMode): AsyncAction {
 export function updateQueryInList(queryId: string, updates: Partial<QueryItem>): AsyncAction {
     return (dispatch, getState) => {
         const state = getState();
-        const items = getQueriesList(state);
+        const items = selectQueriesList(state);
 
         const updatedItems = items.map((item) =>
             item.id === queryId ? {...item, ...updates} : item,

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -77,7 +77,7 @@ import {RumMeasureTypes} from '../../../rum/rum-measure-types';
 import {type ClusterUiConfig} from '../../../../shared/yt-types';
 import {setSettingByKey} from '../settings';
 import {selectClusterConfigs} from '../../selectors/query-tracker/queryNavigation';
-import {getQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
+import {selectQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
 import {createTableSelect} from '../../../pages/query-tracker/Navigation/helpers/createTableSelect';
 import {
     type ResetQueryTabsAction,
@@ -186,7 +186,7 @@ export const loadTablePromptToQuery =
     ): AsyncAction =>
     async (dispatch, getState) => {
         const state = getState();
-        const {pageSize} = getQueryResultGlobalSettings();
+        const {pageSize} = selectQueryResultGlobalSettings();
         const clusters = selectClusterConfigs(state);
 
         const clusterConfig = clusters[cluster];

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -43,8 +43,8 @@ import {chytApiAction, spytApiAction} from '../../../utils/strawberryControllerA
 import guid from '../../../common/hammer/guid';
 import {getSettingQueryTrackerStage} from '../../selectors/settings/settings-ts';
 import {
-    getDefaultQueryACO,
-    getDefaultYqlVersion,
+    selectDefaultQueryACO,
+    selectDefaultYqlVersion,
     selectIsMultipleAco,
 } from '../../selectors/query-tracker/queryAco';
 import UIFactory from '../../../UIFactory';
@@ -125,7 +125,7 @@ export const setUserLastChoice =
         const lastPath = getLastUserChoiceQueryDiscoveryPath(state);
         const lastClique = getLastUserChoiceQueryChytClique(state);
         const lastVersion = getLastUserChoiceYqlVersion(state);
-        const defaultYqlVersion = getDefaultYqlVersion(state);
+        const defaultYqlVersion = selectDefaultYqlVersion(state);
 
         const newSettings = {...settings};
         if (clearProps) {
@@ -351,7 +351,7 @@ export function loadQuery(
             });
 
             query.files = query.files.map((file) => ({...file, id: guid()}));
-            const defaultQueryACO = getDefaultQueryACO(state);
+            const defaultQueryACO = selectDefaultQueryACO(state);
             const queryItem = prepareQueryPlanIds(query, defaultQueryACO);
 
             if (config?.dontReplaceQueryText) {
@@ -403,7 +403,7 @@ export function createQueryFromTablePath(
 
         try {
             const state = getState();
-            const defaultQueryACO = getDefaultQueryACO(state);
+            const defaultQueryACO = selectDefaultQueryACO(state);
             const draft = await wrapApiPromiseByToaster(
                 generateQueryFromTable(engine, {cluster, path, defaultQueryACO}),
                 {
@@ -447,7 +447,7 @@ export function createEmptyQuery(
     return (dispatch, getState) => {
         const state = getState();
         const lastEngine = getLastUserChoiceQueryEngine(state);
-        const defaultQueryACO = getDefaultQueryACO(state);
+        const defaultQueryACO = selectDefaultQueryACO(state);
 
         const initialEngine = engine || lastEngine || QueryEngine.YQL;
 
@@ -588,7 +588,7 @@ export const toggleShareQuery =
         const query = selectQuery(state);
         if (!query) return;
 
-        const defaultQueryACO = getDefaultQueryACO(state);
+        const defaultQueryACO = selectDefaultQueryACO(state);
         let aco = query.access_control_objects || [defaultQueryACO];
 
         if (aco.includes(SHARED_QUERY_ACO)) {

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -17,11 +17,11 @@ import {
 import {requestQueriesList} from './queriesList';
 import {
     SHARED_QUERY_ACO,
-    getCurrentQuery,
-    getQueryDraft,
-    getQueryDraftSettings,
-    getQueryEngine,
-    getQuery as selectQuery,
+    selectCurrentQuery,
+    selectQuery,
+    selectQueryDraft,
+    selectQueryDraftSettings,
+    selectQueryEngine,
 } from '../../selectors/query-tracker/query';
 import {getAppBrowserHistory} from '../../window-store';
 import {
@@ -108,7 +108,7 @@ const checkCliqueControllerIsSupported =
 export const setCurrentClusterToQuery = (): AsyncAction => async (dispatch, getState) => {
     const state = getState();
     const cluster = selectCluster(state);
-    const {settings, engine} = getQueryDraft(state);
+    const {settings, engine} = selectQueryDraft(state);
 
     if (settings && 'cluster' in settings) return;
 
@@ -120,8 +120,8 @@ export const setUserLastChoice =
     (clearProps?: boolean): AsyncAction =>
     (dispatch, getState) => {
         const state = getState();
-        const {settings} = getQueryDraft(state);
-        const engine = getQueryEngine(state);
+        const {settings} = selectQueryDraft(state);
+        const engine = selectQueryEngine(state);
         const lastPath = getLastUserChoiceQueryDiscoveryPath(state);
         const lastClique = getLastUserChoiceQueryChytClique(state);
         const lastVersion = getLastUserChoiceYqlVersion(state);
@@ -199,7 +199,7 @@ export const loadTablePromptToQuery =
 export const setQueryEngine =
     (engine: QueryEngine): AsyncAction =>
     (dispatch, getState) => {
-        const settings = getQueryDraftSettings(getState());
+        const settings = selectQueryDraftSettings(getState());
 
         const newSettings = {...settings};
         if (engine !== QueryEngine.SPYT) {
@@ -221,7 +221,7 @@ export const setQueryCluster =
     (clusterId: string): AsyncAction =>
     async (dispatch, getState) => {
         const state = getState();
-        const {settings = {}, engine} = getQueryDraft(state);
+        const {settings = {}, engine} = selectQueryDraft(state);
 
         try {
             dispatch({type: SET_QUERY_CLUSTER_LOADING, data: true});
@@ -245,7 +245,7 @@ export const setQueryCluster =
 export const setQueryClique =
     (alias: string): AsyncAction =>
     (dispatch, getState) => {
-        const settings = getQueryDraftSettings(getState());
+        const settings = selectQueryDraftSettings(getState());
 
         const newSettings = {...settings};
         if (!alias && 'clique' in newSettings) {
@@ -262,7 +262,7 @@ export const setQueryClique =
 export const setQueryYqlVersion =
     (version: string): AsyncAction =>
     (dispatch, getState) => {
-        const settings = getQueryDraftSettings(getState());
+        const settings = selectQueryDraftSettings(getState());
 
         dispatch(updateQueryDraft({settings: {...settings, yql_version: version}}));
         dispatch(
@@ -273,7 +273,7 @@ export const setQueryYqlVersion =
 export const setQueryPath =
     (newPath: string): AsyncAction =>
     (dispatch, getState) => {
-        const settings = getQueryDraftSettings(getState());
+        const settings = selectQueryDraftSettings(getState());
         dispatch(updateQueryDraft({settings: {...settings, discovery_group: newPath}}));
         dispatch(
             setSettingByKey(
@@ -477,7 +477,7 @@ export function runQuery(
 ): ThunkAction<any, RootState, any, SetQueryAction | SetDirtySubmit> {
     return async (dispatch, getState) => {
         const state = getState();
-        const query = getQueryDraft(state);
+        const query = selectQueryDraft(state);
 
         const newQuery = {...query};
         if ('access_control_objects' in newQuery) {
@@ -508,7 +508,7 @@ export function runQuery(
 export function abortCurrentQuery(): ThunkAction<any, RootState, any, SetQueryAction> {
     return async (dispatch, getState) => {
         const state = getState();
-        const currentQuery = getCurrentQuery(state);
+        const currentQuery = selectCurrentQuery(state);
         if (currentQuery) {
             await wrapApiPromiseByToaster(dispatch(abortQuery({query_id: currentQuery?.id})), {
                 toasterName: 'abort_query',

--- a/packages/ui/src/ui/store/actions/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryAco.ts
@@ -3,8 +3,8 @@ import {type ThunkAction} from 'redux-thunk';
 import {type AxiosError} from 'axios';
 import {YTApiId, ytApiV4Id} from '../../../rum/rum-wrap-api';
 import {
-    getEffectiveApiStage,
-    getQueryTrackerRequestOptions,
+    selectEffectiveApiStage,
+    selectQueryTrackerRequestOptions,
 } from '../../selectors/query-tracker/query';
 import {showErrorPopup} from '../../../utils/utils';
 import {QUERY_ACO_LOADING, type QueryACOActions} from '../../reducers/query-tracker/queryAco';
@@ -22,7 +22,7 @@ export const getQueryTrackerInfo = (): ThunkAction<
 > => {
     return (dispatch, getState) => {
         const state = getState();
-        const {stage} = getQueryTrackerRequestOptions(state);
+        const {stage} = selectQueryTrackerRequestOptions(state);
 
         dispatch({type: QUERY_ACO_LOADING.REQUEST});
 
@@ -80,7 +80,7 @@ export function setUserDefaultACO(
 ): ThunkAction<Promise<any>, RootState, any, AnyAction> {
     return async (dispatch, getState) => {
         const state = getState();
-        const stage = getEffectiveApiStage(state);
+        const stage = selectEffectiveApiStage(state);
 
         await dispatch(setSettingByKey(`qt-stage::${stage}::queryTracker::defaultACO`, aco));
     };

--- a/packages/ui/src/ui/store/actions/query-tracker/queryChart.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryChart.ts
@@ -4,10 +4,10 @@ import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {type ThunkAction} from 'redux-thunk';
 import {type Action} from 'redux';
 import {
-    getCurrentQueryACO,
-    getQueryAnnotations,
-    getQueryDraft,
-    getQueryItem,
+    selectCurrentQueryACO,
+    selectQueryAnnotations,
+    selectQueryDraft,
+    selectQueryItem,
 } from '../../selectors/query-tracker/query';
 import {selectCurrentUserName} from '../../selectors/global/username';
 import {
@@ -45,8 +45,8 @@ const saveChartConfig = (dispatch: AppDispatch, getState: () => RootState) => {
     const state = getState();
 
     const currentUser = selectCurrentUserName(state);
-    const queryItem = getQueryItem(state);
-    const {id} = getQueryDraft(state);
+    const queryItem = selectQueryItem(state);
+    const {id} = selectQueryDraft(state);
 
     if (!queryItem || currentUser !== queryItem.user || !id) {
         return;
@@ -54,8 +54,8 @@ const saveChartConfig = (dispatch: AppDispatch, getState: () => RootState) => {
 
     dispatch(setSaved(false));
 
-    const annotations = getQueryAnnotations(state);
-    const aco = getCurrentQueryACO(state);
+    const annotations = selectQueryAnnotations(state);
+    const aco = selectCurrentQueryACO(state);
     const chartConfig = selectChartVisualization(state);
 
     wrapApiPromiseByToaster(
@@ -183,7 +183,7 @@ const validateChartConfig = (config: any): config is Record<number, Visualizatio
 };
 
 export const loadVisualization = (): AsyncAction => (dispatch, getState) => {
-    const queryItem = getQueryItem(getState());
+    const queryItem = selectQueryItem(getState());
     const chartConfig = queryItem?.annotations?.chartConfig;
 
     dispatch(setResultIndex(0));
@@ -200,7 +200,7 @@ export const changeVisualizationResultIndex =
         const state = getState();
         const visualizations = selectChartVisualization(state);
         const results = selectQueryResults(state);
-        const {id} = getQueryDraft(state);
+        const {id} = selectQueryDraft(state);
 
         dispatch(setLoading(true));
 

--- a/packages/ui/src/ui/store/actions/query-tracker/queryFilesForm.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryFilesForm.ts
@@ -2,7 +2,7 @@ import {type QueryFile} from './api';
 import {type ThunkAction} from 'redux-thunk';
 import {type RootState} from '../../reducers';
 import {type Action} from 'redux';
-import {getQueryFiles} from '../../selectors/query-tracker/query';
+import {selectQueryFiles} from '../../selectors/query-tracker/query';
 import {updateQueryDraft} from './query';
 import {setDeletedFiles} from '../../reducers/query-tracker/queryFilesFormSlice';
 import {selectDeletedFiles} from '../../selectors/query-tracker/queryFilesForm';
@@ -21,7 +21,7 @@ export const changeQueryFile =
     (file: QueryFile): ThunkAction<void, RootState, undefined, Action> =>
     (dispatch, getState) => {
         const state = getState();
-        const files = getQueryFiles(state);
+        const files = selectQueryFiles(state);
         const index = files.findIndex((f) => f.id === file.id);
         if (index < 0) return;
 
@@ -36,7 +36,7 @@ export const restoreQueryFile =
     (dispatch, getState) => {
         const state = getState();
         const deletedFiles = selectDeletedFiles(state);
-        const files = getQueryFiles(state);
+        const files = selectQueryFiles(state);
 
         const data = findObjectByTitle<QueryFile>(deletedFiles, (file) => file.id === id);
         if (data === null) return;
@@ -61,7 +61,7 @@ export const deleteQueryFile =
     (dispatch, getState) => {
         const state = getState();
         const deletedFiles = selectDeletedFiles(state);
-        const files = getQueryFiles(state);
+        const files = selectQueryFiles(state);
 
         const data = findObjectByTitle<QueryFile>(files, (file) => file.id === id);
         if (data === null) return;

--- a/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
@@ -40,7 +40,7 @@ import {selectQueryDraft} from '../../selectors/query-tracker/query';
 import {getDefaultTableColumnLimit} from '../../selectors/settings';
 import {isYqlTypesEnabled} from '../../selectors/navigation/content/table';
 import {getClusterProxy, selectCurrentUserName} from '../../selectors/global';
-import {getQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
+import {selectQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
 import {getYsonSettingsDisableDecode} from '../../selectors/thor/unipika';
 import {QueriesListMode} from '../../../types/query-tracker/queryList';
 import {type ClusterConfig} from '../../../../shared/yt-types';
@@ -112,7 +112,7 @@ export const loadTableAttributesByPath =
     async (dispatch, getState) => {
         const state = getState();
         const clusterConfig = selectNavigationClusterConfig(state);
-        const {cellSize, pageSize} = getQueryResultGlobalSettings();
+        const {cellSize, pageSize} = selectQueryResultGlobalSettings();
         const defaultTableColumnLimit = getDefaultTableColumnLimit(state);
         const useYqlTypes = isYqlTypesEnabled(state);
         const login = selectCurrentUserName(state);

--- a/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
@@ -36,7 +36,7 @@ import {isTableNode} from '../../../utils/navigation/isTableNode';
 import {isFolderNode} from '../../../utils/navigation/isFolderNode';
 import {QueryEngine} from '../../../../shared/constants/engines';
 import {loadCliqueByCluster, loadTablePromptToQuery} from './query';
-import {getQueryDraft} from '../../selectors/query-tracker/query';
+import {selectQueryDraft} from '../../selectors/query-tracker/query';
 import {getDefaultTableColumnLimit} from '../../selectors/settings';
 import {isYqlTypesEnabled} from '../../selectors/navigation/content/table';
 import {getClusterProxy, selectCurrentUserName} from '../../selectors/global';
@@ -246,7 +246,7 @@ export const openPath =
     (path: string, clusterId: string | null): AsyncAction =>
     async (dispatch, getState) => {
         const state = getState();
-        const {settings} = getQueryDraft(state);
+        const {settings} = selectQueryDraft(state);
         const clusters = selectClusterConfigs(state);
         const currentClusterId = clusterId || settings?.cluster;
         if (!currentClusterId) return;

--- a/packages/ui/src/ui/store/actions/query-tracker/queryResult.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryResult.ts
@@ -11,9 +11,9 @@ import {
 } from './api';
 import {type Type, getSchemaDateType, parseV3Type} from '@ytsaurus/components';
 import {
-    getQueryResultGlobalSettings,
-    getQueryResultSettings,
-    hasQueryResult,
+    selectHasQueryResult,
+    selectQueryResultGlobalSettings,
+    selectQueryResultSettings,
 } from '../../selectors/query-tracker/queryResult';
 import {getClusterConfigByName, getClusterProxy} from '../../selectors/global';
 import {
@@ -94,7 +94,7 @@ export function loadQueryResult(
 ): ThunkAction<any, RootState, any, QueryResultsActions> {
     return async (dispatch, getState) => {
         const state = getState();
-        if (hasQueryResult(state, queryId, resultIndex)) {
+        if (selectHasQueryResult(state, queryId, resultIndex)) {
             return;
         }
         try {
@@ -121,7 +121,7 @@ export function loadQueryResult(
                     };
                 }) || [];
 
-            const settings = getQueryResultGlobalSettings();
+            const settings = selectQueryResultGlobalSettings();
             const result = await wrapApiPromiseByToaster(
                 dispatch(
                     readQueryResults(
@@ -219,7 +219,7 @@ export function updateQueryResult(
 ): ThunkAction<any, RootState, any, QueryResultsActions> {
     return async (dispatch, getState) => {
         try {
-            const settings = getQueryResultSettings(getState(), queryId, resultIndex);
+            const settings = selectQueryResultSettings(getState(), queryId, resultIndex);
             dispatch({
                 type: REQUEST_QUERY_RESULTS,
                 data: {queryId, index: resultIndex},
@@ -297,7 +297,7 @@ export function loadQueryResultsErrors(
 
         const inds: number[] = [];
         for (let ind = 0; ind < result_count; ind++) {
-            if (!hasQueryResult(state, query.id, ind)) inds.push(ind);
+            if (!selectHasQueryResult(state, query.id, ind)) inds.push(ind);
         }
 
         if (inds.length === 0) return;

--- a/packages/ui/src/ui/store/actions/query-tracker/queryTabs/queryTabs.tsx
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryTabs/queryTabs.tsx
@@ -12,7 +12,7 @@ import {CompletedStates, QueryStatus} from '../../../../types/query-tracker';
 import times_ from 'lodash/times';
 import find_ from 'lodash/find';
 import UIFactory from '../../../../UIFactory';
-import {getQuery} from '../../../selectors/query-tracker/query';
+import {selectQuery} from '../../../selectors/query-tracker/query';
 import {selectUserChangedQueryResultTab} from '../../../selectors/query-tracker/queryTabs';
 import {loadQueryResultsErrors} from '../queryResult';
 import i18n from './i18n';
@@ -21,7 +21,7 @@ type AsyncAction = ThunkAction<void, RootState, undefined, Action>;
 
 export const updateQueryTabs = (): AsyncAction => (dispatch, getState) => {
     const state = getState();
-    const query = getQuery(state);
+    const query = selectQuery(state);
     const userChangeTab = selectUserChangedQueryResultTab(state);
 
     if (!query) {

--- a/packages/ui/src/ui/store/actions/query-tracker/vcs.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/vcs.ts
@@ -21,7 +21,7 @@ import {
     setVcsTokensAvailability,
 } from '../../reducers/query-tracker/vcsSlice';
 import {selectVcs, selectVcsConfig} from '../../selectors/query-tracker/vcs';
-import {getQueryFiles} from '../../selectors/query-tracker/query';
+import {selectQueryFiles} from '../../selectors/query-tracker/query';
 import {updateQueryDraft} from './query';
 import guid from '../../../common/hammer/guid';
 import {selectFileEditor} from '../../selectors/query-tracker/queryFilesForm';
@@ -267,7 +267,7 @@ export const addFileToQuery =
         if (item.type !== 'file' || !repository || !branch) return;
 
         const editor = selectFileEditor(state);
-        const files = getQueryFiles(state);
+        const files = selectQueryFiles(state);
         const id = guid();
         dispatch(
             updateQueryDraft({

--- a/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
@@ -29,15 +29,12 @@ export const selectIsQueriesListLoading = (state: RootState) => state.queryTrack
 
 export const selectQueriesList = (state: RootState) => selectQueriesListState(state).items;
 
-export const selectHasQueriesListMore = (state: RootState) =>
-    selectQueriesListState(state).hasMore;
+export const selectHasQueriesListMore = (state: RootState) => selectQueriesListState(state).hasMore;
 
 export const selectQueriesFilters = (state: RootState) =>
     selectQueriesListState(state).filter || {};
-export const selectQueriesListMode = (state: RootState) =>
-    selectQueriesListState(state).listMode;
-export const selectQueriesListCursor = (state: RootState) =>
-    selectQueriesListState(state).cursor;
+export const selectQueriesListMode = (state: RootState) => selectQueriesListState(state).listMode;
+export const selectQueriesListCursor = (state: RootState) => selectQueriesListState(state).cursor;
 
 export const selectTutorialQueriesList = createSelector(
     [selectQueriesList, selectIsSupportedTutorials],

--- a/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
@@ -21,7 +21,7 @@ import {
     MyColumns,
     NameColumns,
 } from '../../../pages/query-tracker/QueriesList/QueriesHistoryList/columns';
-import {isSupportedTutorials} from './queryAco';
+import {selectIsSupportedTutorials} from './queryAco';
 
 export const selectQueriesListState = (state: RootState) => state.queryTracker.list;
 
@@ -40,7 +40,7 @@ export const selectQueriesListCursor = (state: RootState) =>
     selectQueriesListState(state).cursor;
 
 export const selectTutorialQueriesList = createSelector(
-    [selectQueriesList, isSupportedTutorials],
+    [selectQueriesList, selectIsSupportedTutorials],
     (listItems, supportsTutorials) => {
         return listItems.filter((item) =>
             supportsTutorials ? item?.is_tutorial : item?.annotations?.is_tutorial,
@@ -138,7 +138,7 @@ export function selectQueriesListFilterParams(state: RootState): QueriesListPara
         user = undefined;
     }
 
-    const supportsTutorials = isSupportedTutorials(state);
+    const supportsTutorials = selectIsSupportedTutorials(state);
 
     const params: QueriesListParams = {
         ...filter,

--- a/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
@@ -23,20 +23,24 @@ import {
 } from '../../../pages/query-tracker/QueriesList/QueriesHistoryList/columns';
 import {isSupportedTutorials} from './queryAco';
 
-export const getQueriesListState = (state: RootState) => state.queryTracker.list;
+export const selectQueriesListState = (state: RootState) => state.queryTracker.list;
 
-export const isQueriesListLoading = (state: RootState) => state.queryTracker.list.isLoading;
+export const selectIsQueriesListLoading = (state: RootState) => state.queryTracker.list.isLoading;
 
-export const getQueriesList = (state: RootState) => getQueriesListState(state).items;
+export const selectQueriesList = (state: RootState) => selectQueriesListState(state).items;
 
-export const hasQueriesListMore = (state: RootState) => getQueriesListState(state).hasMore;
+export const selectHasQueriesListMore = (state: RootState) =>
+    selectQueriesListState(state).hasMore;
 
-export const getQueriesFilters = (state: RootState) => getQueriesListState(state).filter || {};
-export const getQueriesListMode = (state: RootState) => getQueriesListState(state).listMode;
-export const getQueriesListCursor = (state: RootState) => getQueriesListState(state).cursor;
+export const selectQueriesFilters = (state: RootState) =>
+    selectQueriesListState(state).filter || {};
+export const selectQueriesListMode = (state: RootState) =>
+    selectQueriesListState(state).listMode;
+export const selectQueriesListCursor = (state: RootState) =>
+    selectQueriesListState(state).cursor;
 
-export const getTutorialQueriesList = createSelector(
-    [getQueriesList, isSupportedTutorials],
+export const selectTutorialQueriesList = createSelector(
+    [selectQueriesList, isSupportedTutorials],
     (listItems, supportsTutorials) => {
         return listItems.filter((item) =>
             supportsTutorials ? item?.is_tutorial : item?.annotations?.is_tutorial,
@@ -44,7 +48,7 @@ export const getTutorialQueriesList = createSelector(
     },
 );
 
-export const getQueryListByDate = createSelector([getQueriesList], (listItems) => {
+export const selectQueryListByDate = createSelector([selectQueriesList], (listItems) => {
     return Object.entries(
         groupBy_(listItems, (item) => moment(item.start_time).format('DD MMMM YYYY')),
     ).reduce<(QueryItem | {header: string})[]>((ret, [header, items]) => {
@@ -56,15 +60,15 @@ export const getQueryListByDate = createSelector([getQueriesList], (listItems) =
     }, []);
 });
 
-export const getQueriesListTabs = createSelector([selectIsVcsVisible], (vcsVisible) => {
+export const selectQueriesListTabs = createSelector([selectIsVcsVisible], (vcsVisible) => {
     const queriesListMode = Object.values(QueriesListMode);
     return vcsVisible
         ? queriesListMode
         : queriesListMode.filter((item) => item !== QueriesListMode.VCS);
 });
 
-export const getQueryListColumns = createSelector(
-    [getQueriesFilters, getQueryListHistoryColumns],
+export const selectQueryListColumns = createSelector(
+    [selectQueriesFilters, selectQueryListHistoryColumns],
     (filter, selectedColumns) => {
         const ALL_COLUMN_NAMES = intersectionBy_(AllColumns, MyColumns, 'name').map(
             (item) => item.name,
@@ -90,8 +94,8 @@ export const getQueryListColumns = createSelector(
     },
 );
 
-export const hasCustomHistoryFilters = createSelector(
-    [getQueriesFilters, getSettingsData],
+export const selectHasCustomHistoryFilters = createSelector(
+    [selectQueriesFilters, getSettingsData],
     (filter) => {
         const {from, to, state, user} = filter;
         const defaultFilter = DefaultQueriesListFilter[QueriesListMode.History];
@@ -105,12 +109,12 @@ export const hasCustomHistoryFilters = createSelector(
     },
 );
 
-export const getUncompletedItems = createSelector(getQueriesList, (items) => {
+export const selectUncompletedItems = createSelector(selectQueriesList, (items) => {
     return items.filter(isQueryProgress);
 });
 
-export const getQueriesListCursorParams = (state: RootState) => {
-    const cursor = getQueriesListCursor(state);
+export const selectQueriesListCursorParams = (state: RootState) => {
+    const cursor = selectQueriesListCursor(state);
     if (cursor) {
         return {cursor_time: cursor.cursorTime, cursor_direction: cursor.direction};
     }
@@ -118,10 +122,10 @@ export const getQueriesListCursorParams = (state: RootState) => {
     return undefined;
 };
 
-export function getQueriesListFilterParams(state: RootState): QueriesListParams {
-    const listMode = getQueriesListMode(state);
+export function selectQueriesListFilterParams(state: RootState): QueriesListParams {
+    const listMode = selectQueriesListMode(state);
     const filterParams = {
-        ...getQueriesFilters(state),
+        ...selectQueriesFilters(state),
         ...(QueriesListFilterPresets[listMode] || {}),
     };
     const {is_tutorial, from, to, state: queryState, ...filter} = filterParams;
@@ -155,6 +159,6 @@ export function getQueriesListFilterParams(state: RootState): QueriesListParams 
     return params;
 }
 
-export function getQueryListHistoryColumns(state: RootState) {
+export function selectQueryListHistoryColumns(state: RootState) {
     return getSettingsData(state)['global::queryTracker::history::Columns'];
 }

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -22,46 +22,50 @@ import {QueryEngine, QueryEnginesNames} from '../../../../shared/constants/engin
 import {selectClusterSupportedEngines} from '../global';
 
 const QT_STAGE = getQueryTrackerStage();
-const getState = (state: RootState) => state.queryTracker.query;
+const selectQueryState = (state: RootState) => state.queryTracker.query;
 
 export const DEFAULT_QUERY_ACO = 'nobody';
 export const SHARED_QUERY_ACO = 'everyone-share';
 
-export const getQuery = (state: RootState) => getState(state).queryItem;
-export const getQueryId = (state: RootState) => getState(state).queryItem?.id;
-export const getQueryAnnotations = (state: RootState) => getState(state).queryItem?.annotations;
-export const getQueryGetParams = (state: RootState) => getState(state).params;
-export const getQueryProgress = (state: RootState) => getQuery(state)?.progress;
+export const selectQuery = (state: RootState) => selectQueryState(state).queryItem;
+export const selectQueryId = (state: RootState) => selectQueryState(state).queryItem?.id;
+export const selectQueryAnnotations = (state: RootState) =>
+    selectQueryState(state).queryItem?.annotations;
+export const selectQueryGetParams = (state: RootState) => selectQueryState(state).params;
+export const selectQueryProgress = (state: RootState) => selectQuery(state)?.progress;
 
-export const getQueryDraft = (state: RootState) => getState(state).draft;
-export const getQueryDraftSettings = (state: RootState) => getState(state).draft.settings || {};
-export const getQueryDraftCluster = (state: RootState) => getQueryDraft(state).settings?.cluster;
+export const selectQueryDraft = (state: RootState) => selectQueryState(state).draft;
+export const selectQueryDraftSettings = (state: RootState) =>
+    selectQueryState(state).draft.settings || {};
+export const selectQueryDraftCluster = (state: RootState) =>
+    selectQueryDraft(state).settings?.cluster;
 
-export const getQueryFiles = (state: RootState) => getState(state).draft.files;
-export const getQuerySecrets = (state: RootState) => getState(state).draft.secrets;
+export const selectQueryFiles = (state: RootState) => selectQueryState(state).draft.files;
+export const selectQuerySecrets = (state: RootState) => selectQueryState(state).draft.secrets;
 
-export const getQueryText = (state: RootState) => getState(state).draft.query;
+export const selectQueryText = (state: RootState) => selectQueryState(state).draft.query;
 
-export const getQueryEngine = (state: RootState) => getState(state).draft.engine;
+export const selectQueryEngine = (state: RootState) => selectQueryState(state).draft.engine;
 
-export const isQueryLoading = (state: RootState) => getState(state).state === 'loading';
+export const selectIsQueryLoading = (state: RootState) =>
+    selectQueryState(state).state === 'loading';
 
-export const getCliqueMap = (state: RootState) => getState(state).cliqueMap;
-export const getCliqueLoading = (state: RootState) => getState(state).cliqueLoading;
-export const getClusterLoading = (state: RootState) => getState(state).clusterLoading;
+export const selectCliqueMap = (state: RootState) => selectQueryState(state).cliqueMap;
+export const selectCliqueLoading = (state: RootState) => selectQueryState(state).cliqueLoading;
+export const selectClusterLoading = (state: RootState) => selectQueryState(state).clusterLoading;
 
-export const getQueryItem = (state: RootState) => getState(state).queryItem;
+export const selectQueryItem = (state: RootState) => selectQueryState(state).queryItem;
 
-export const isQueryExecuted = (state: RootState): boolean => {
-    const queryItem = getQueryItem(state);
+export const selectIsQueryExecuted = (state: RootState): boolean => {
+    const queryItem = selectQueryItem(state);
     // TODO: Use real query's state
     return Boolean(queryItem?.id) && queryItem?.state !== QueryStatus.DRAFT;
 };
 
-export const getCurrentQuery = (state: RootState) => getState(state).queryItem;
+export const selectCurrentQuery = (state: RootState) => selectQueryState(state).queryItem;
 
-export const isQueryButtonActive = createSelector(
-    [getQueryEngine, getQueryDraftSettings, getCliqueMap],
+export const selectIsQueryButtonActive = createSelector(
+    [selectQueryEngine, selectQueryDraftSettings, selectCliqueMap],
     (engine, settings, cliqueMap) => {
         const isChyt = engine === QueryEngine.CHYT;
         if (!isChyt) return true;
@@ -80,8 +84,8 @@ export const isQueryButtonActive = createSelector(
     },
 );
 
-export const shouldPollCliqueWhenInactive = createSelector(
-    [getQueryEngine, getQueryDraftSettings, isQueryButtonActive],
+export const selectShouldPollCliqueWhenInactive = createSelector(
+    [selectQueryEngine, selectQueryDraftSettings, selectIsQueryButtonActive],
     (engine, settings, isRunButtonActive) => {
         return (
             engine === QueryEngine.CHYT &&
@@ -91,16 +95,19 @@ export const shouldPollCliqueWhenInactive = createSelector(
     },
 );
 
-export const isQueryDraftEditted = createSelector([getQuery, getQueryDraft], (query, draft) => {
-    return query?.query !== draft.query;
-});
+export const selectIsQueryDraftEditted = createSelector(
+    [selectQuery, selectQueryDraft],
+    (query, draft) => {
+        return query?.query !== draft.query;
+    },
+);
 
-export const hasLoadedQueryItem = (state: RootState) => {
-    const queryItem = getState(state).queryItem;
+export const selectHasLoadedQueryItem = (state: RootState) => {
+    const queryItem = selectQueryState(state).queryItem;
     return Boolean(queryItem?.id);
 };
 
-export const getSupportedEnginesOptions = createSelector(
+export const selectSupportedEnginesOptions = createSelector(
     [selectClusterSupportedEngines],
     (supportedEngines) => {
         const items = Object.entries(supportedEngines).filter(([_, supported]) => supported);
@@ -115,7 +122,7 @@ export const getSupportedEnginesOptions = createSelector(
     },
 );
 
-export const getQueryTrackerRequestOptions = createSelector(
+export const selectQueryTrackerRequestOptions = createSelector(
     [getSettingQueryTrackerStage, getSettingQueryTrackerYQLAgentStage],
     (stage, yqlAgentStage) => {
         const res: QTRequestOptions = {
@@ -126,7 +133,7 @@ export const getQueryTrackerRequestOptions = createSelector(
     },
 );
 
-export const getQueryEditorErrors = (state: RootState): QTEditorError[] => {
+export const selectQueryEditorErrors = (state: RootState): QTEditorError[] => {
     const res: QTEditorError[] = [];
     const collectQTEditorErrors = (error: YTError<{attributes?: object}>) => {
         if (isQTEditorError(error)) {
@@ -137,11 +144,11 @@ export const getQueryEditorErrors = (state: RootState): QTEditorError[] => {
         }
     };
 
-    const {error, id} = getState(state).draft;
+    const {error, id} = selectQueryState(state).draft;
     if (isYTError(error)) {
         collectQTEditorErrors(error);
     }
-    if (id && !isQueryDraftEditted(state)) {
+    if (id && !selectIsQueryDraftEditted(state)) {
         const results = getQueryResults(state, id);
         if (results) {
             forOwn_(results, (value) => {
@@ -151,7 +158,7 @@ export const getQueryEditorErrors = (state: RootState): QTEditorError[] => {
             });
         }
     }
-    const currentQuery = getCurrentQuery(state);
+    const currentQuery = selectCurrentQuery(state);
     if (currentQuery && currentQuery.error) {
         collectQTEditorErrors(currentQuery.error);
     }
@@ -159,10 +166,10 @@ export const getQueryEditorErrors = (state: RootState): QTEditorError[] => {
     return res;
 };
 
-export const getDirtySinceLastSubmit = (state: RootState) =>
+export const selectDirtySinceLastSubmit = (state: RootState) =>
     state.queryTracker.query.dirtySinceLastSubmit;
 
-export const getEffectiveApiStage = (state: RootState) => {
+export const selectEffectiveApiStage = (state: RootState) => {
     return state.queryTracker?.aco?.data?.query_tracker_stage ?? 'production';
 };
 
@@ -176,31 +183,31 @@ const getAco = (
     return state?.access_control_object ? [state?.access_control_object] : [defaultACO];
 };
 
-export const getCurrentQueryACO = (state: RootState) => {
+export const selectCurrentQueryACO = (state: RootState) => {
     const defaultACO = getDefaultQueryACO(state);
 
     return getAco(defaultACO, selectIsMultipleAco(state), state.queryTracker.query?.queryItem);
 };
 
-export const getCurrentDraftQueryACO = (state: RootState) => {
+export const selectCurrentDraftQueryACO = (state: RootState) => {
     const defaultACO = getDefaultQueryACO(state);
 
     return getAco(defaultACO, selectIsMultipleAco(state), state.queryTracker.query?.draft);
 };
 
-export const getQuerySingleProgress = createSelector([getQueryProgress], (progress) => {
+export const selectQuerySingleProgress = createSelector([selectQueryProgress], (progress) => {
     if (!isSingleProgress(progress)) return {};
     return progress;
 });
 
-export const getProgressYQLStatistics = (state: RootState) => {
-    const progress = getQueryProgress(state);
+export const selectProgressYQLStatistics = (state: RootState) => {
+    const progress = selectQueryProgress(state);
 
     if (!isSingleProgress(progress)) return undefined;
 
     return progress.yql_statistics;
 };
 
-export const getCurrentSecretIds = createSelector([getQuerySecrets], (secrets) => {
+export const selectCurrentSecretIds = createSelector([selectQuerySecrets], (secrets) => {
     return secrets.map((secret) => secret.id);
 });

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -17,7 +17,7 @@ import {type QTEditorError, isQTEditorError} from '../../../types/query-tracker/
 import {type YTError} from '../../../types';
 import {isYTError} from '../../../../shared/utils';
 import {getQueryResults} from './queryResult';
-import {getDefaultQueryACO, selectIsMultipleAco} from './queryAco';
+import {selectDefaultQueryACO, selectIsMultipleAco} from './queryAco';
 import {QueryEngine, QueryEnginesNames} from '../../../../shared/constants/engines';
 import {selectClusterSupportedEngines} from '../global';
 
@@ -184,13 +184,13 @@ const getAco = (
 };
 
 export const selectCurrentQueryACO = (state: RootState) => {
-    const defaultACO = getDefaultQueryACO(state);
+    const defaultACO = selectDefaultQueryACO(state);
 
     return getAco(defaultACO, selectIsMultipleAco(state), state.queryTracker.query?.queryItem);
 };
 
 export const selectCurrentDraftQueryACO = (state: RootState) => {
-    const defaultACO = getDefaultQueryACO(state);
+    const defaultACO = selectDefaultQueryACO(state);
 
     return getAco(defaultACO, selectIsMultipleAco(state), state.queryTracker.query?.draft);
 };

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -16,7 +16,7 @@ import {getQueryTrackerStage} from '../../../config';
 import {type QTEditorError, isQTEditorError} from '../../../types/query-tracker/editor';
 import {type YTError} from '../../../types';
 import {isYTError} from '../../../../shared/utils';
-import {getQueryResults} from './queryResult';
+import {selectQueryResults} from './queryResult';
 import {selectDefaultQueryACO, selectIsMultipleAco} from './queryAco';
 import {QueryEngine, QueryEnginesNames} from '../../../../shared/constants/engines';
 import {selectClusterSupportedEngines} from '../global';
@@ -149,7 +149,7 @@ export const selectQueryEditorErrors = (state: RootState): QTEditorError[] => {
         collectQTEditorErrors(error);
     }
     if (id && !selectIsQueryDraftEditted(state)) {
-        const results = getQueryResults(state, id);
+        const results = selectQueryResults(state, id);
         if (results) {
             forOwn_(results, (value) => {
                 if (value.state === 'error' && isYTError(value.error)) {

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
@@ -3,7 +3,7 @@ import {type SelectOption} from '@gravity-ui/uikit/build/esm/components/Select/t
 import {type RootState} from '../../reducers';
 import {getSettingsData} from '../settings/settings-base';
 import {createSelector} from 'reselect';
-import {DEFAULT_QUERY_ACO, SHARED_QUERY_ACO, getEffectiveApiStage} from './query';
+import {DEFAULT_QUERY_ACO, SHARED_QUERY_ACO, selectEffectiveApiStage} from './query';
 import {selectClusterUiConfig} from '../global';
 import {
     getAvailableYql,
@@ -20,7 +20,7 @@ export const getQueryTrackerInfoClusters = (state: RootState) =>
     state.queryTracker.aco.data.clusters;
 
 export const getLastSelectedACONamespaces = (state: RootState) => {
-    const stage = getEffectiveApiStage(state);
+    const stage = selectEffectiveApiStage(state);
 
     return getSettingsData(state)[`qt-stage::${stage}::queryTracker::lastSelectedACOs`] ?? [];
 };
@@ -67,13 +67,13 @@ export const isSupportedShareQuery = createSelector(
 
 export const getClusterDefaultQueryACO = (state: RootState) => {
     const queryTrackerDefaultACO = selectClusterUiConfig(state)?.query_tracker_default_aco;
-    const stage = getEffectiveApiStage(state);
+    const stage = selectEffectiveApiStage(state);
 
     return (queryTrackerDefaultACO && queryTrackerDefaultACO[stage]) || DEFAULT_QUERY_ACO;
 };
 
 export const getUserDefaultQueryACO = (state: RootState) => {
-    const stage = getEffectiveApiStage(state);
+    const stage = selectEffectiveApiStage(state);
 
     return getSettingsData(state)[`qt-stage::${stage}::queryTracker::defaultACO`];
 };

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
@@ -6,29 +6,29 @@ import {createSelector} from 'reselect';
 import {DEFAULT_QUERY_ACO, SHARED_QUERY_ACO, selectEffectiveApiStage} from './query';
 import {selectClusterUiConfig} from '../global';
 import {
-    getAvailableYql,
-    getDefaultYqlVersion,
+    selectAvailableYql,
+    selectDefaultYqlVersion,
     selectQueryTrackerInfo,
     selectSpytEnginesInfo,
 } from './queryTrackerEnginesInfo';
 
 const selectAcoState = (state: RootState) => state.queryTracker.aco;
 
-export {getAvailableYql, getDefaultYqlVersion, selectQueryTrackerInfo, selectSpytEnginesInfo};
+export {selectAvailableYql, selectDefaultYqlVersion, selectQueryTrackerInfo, selectSpytEnginesInfo};
 
-export const getQueryTrackerInfoClusters = (state: RootState) =>
+export const selectQueryTrackerInfoClusters = (state: RootState) =>
     state.queryTracker.aco.data.clusters;
 
-export const getLastSelectedACONamespaces = (state: RootState) => {
+export const selectLastSelectedACONamespaces = (state: RootState) => {
     const stage = selectEffectiveApiStage(state);
 
     return getSettingsData(state)[`qt-stage::${stage}::queryTracker::lastSelectedACOs`] ?? [];
 };
 
-export const getQueryACOOptions = (state: RootState): SelectOption[] => {
+export const selectQueryACOOptions = (state: RootState): SelectOption[] => {
     const aco = new Set(
         intersection_(
-            getLastSelectedACONamespaces(state),
+            selectLastSelectedACONamespaces(state),
             selectAcoState(state).data.access_control_objects,
         ).concat(selectAcoState(state).data.access_control_objects),
     );
@@ -36,48 +36,48 @@ export const getQueryACOOptions = (state: RootState): SelectOption[] => {
     return [...aco].map((text) => ({value: text, content: text}));
 };
 
-export const isSupportedQtACO = (state: RootState) =>
+export const selectIsSupportedQtACO = (state: RootState) =>
     selectAcoState(state).data.supported_features?.access_control;
 
 export const selectIsMultipleAco = (state: RootState) =>
     Boolean(selectAcoState(state).data.supported_features?.multiple_aco);
 
-export const isSupportedTutorials = (state: RootState) =>
+export const selectIsSupportedTutorials = (state: RootState) =>
     Boolean(selectAcoState(state).data.supported_features?.tutorials);
 
 export const selectAvailableAco = (state: RootState) =>
     selectAcoState(state).data.access_control_objects;
 
-export const isQueryTrackerInfoLoading = (state: RootState) => selectAcoState(state).loading;
+export const selectIsQueryTrackerInfoLoading = (state: RootState) => selectAcoState(state).loading;
 
-const getQueryDraftYqlVersion = (state: RootState) =>
+const selectQueryDraftYqlVersion = (state: RootState) =>
     state.queryTracker.query.draft.settings?.yql_version;
 
-export const getEffectiveYqlVersion = createSelector(
-    [getQueryDraftYqlVersion, getDefaultYqlVersion],
+export const selectEffectiveYqlVersion = createSelector(
+    [selectQueryDraftYqlVersion, selectDefaultYqlVersion],
     (draftVersion, defaultVersion) => draftVersion || defaultVersion,
 );
 
-export const isSupportedShareQuery = createSelector(
+export const selectIsSupportedShareQuery = createSelector(
     [selectIsMultipleAco, selectAvailableAco],
     (isMultipleAco, aco) => {
         return isMultipleAco && aco.includes(SHARED_QUERY_ACO);
     },
 );
 
-export const getClusterDefaultQueryACO = (state: RootState) => {
+export const selectClusterDefaultQueryACO = (state: RootState) => {
     const queryTrackerDefaultACO = selectClusterUiConfig(state)?.query_tracker_default_aco;
     const stage = selectEffectiveApiStage(state);
 
     return (queryTrackerDefaultACO && queryTrackerDefaultACO[stage]) || DEFAULT_QUERY_ACO;
 };
 
-export const getUserDefaultQueryACO = (state: RootState) => {
+export const selectUserDefaultQueryACO = (state: RootState) => {
     const stage = selectEffectiveApiStage(state);
 
     return getSettingsData(state)[`qt-stage::${stage}::queryTracker::defaultACO`];
 };
 
-export const getDefaultQueryACO = (state: RootState) => {
-    return getUserDefaultQueryACO(state) ?? getClusterDefaultQueryACO(state);
+export const selectDefaultQueryACO = (state: RootState) => {
+    return selectUserDefaultQueryACO(state) ?? selectClusterDefaultQueryACO(state);
 };

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryChart.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryChart.ts
@@ -1,6 +1,6 @@
 import {createSelector} from 'reselect';
 import {type RootState} from '../../reducers';
-import {getQueryResultsState} from './queryResult';
+import {selectQueryResultsState} from './queryResult';
 import {selectQueryDraft} from './query';
 import {type QueryResultReadyState} from '../../../types/query-tracker/queryResult';
 import {NumberTypes} from '../../../types/query-tracker/yqlTypes';
@@ -19,7 +19,7 @@ export const selectCurrentChartVisualization = createSelector(
 );
 
 export const selectQueryResults = createSelector(
-    [selectQueryDraft, getQueryResultsState],
+    [selectQueryDraft, selectQueryResultsState],
     ({id}, results) => {
         if (!id || !(id in results)) return [];
 

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryChart.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryChart.ts
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect';
 import {type RootState} from '../../reducers';
 import {getQueryResultsState} from './queryResult';
-import {getQueryDraft} from './query';
+import {selectQueryDraft} from './query';
 import {type QueryResultReadyState} from '../../../types/query-tracker/queryResult';
 import {NumberTypes} from '../../../types/query-tracker/yqlTypes';
 
@@ -19,7 +19,7 @@ export const selectCurrentChartVisualization = createSelector(
 );
 
 export const selectQueryResults = createSelector(
-    [getQueryDraft, getQueryResultsState],
+    [selectQueryDraft, getQueryResultsState],
     ({id}, results) => {
         if (!id || !(id in results)) return [];
 

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryFilesForm.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryFilesForm.ts
@@ -1,6 +1,6 @@
 import {type RootState} from '../../reducers';
 import {createSelector} from 'reselect';
-import {getQueryFiles} from './query';
+import {selectQueryFiles} from './query';
 import {type QueryFile} from '../../../types/query-tracker/api';
 
 export const selectAddForm = (state: RootState) => state.queryTracker.queryFilesModal.addForm;
@@ -9,7 +9,7 @@ export const selectDeletedFiles = (state: RootState) =>
     state.queryTracker.queryFilesModal.deletedFiles;
 
 export const selectFileEditorConfig = createSelector(
-    [selectFileEditor, getQueryFiles, selectDeletedFiles],
+    [selectFileEditor, selectQueryFiles, selectDeletedFiles],
     (fileEditor, files, deletedFiles) => {
         const fileArray = fileEditor.fileType === 'file' ? files : deletedFiles;
 
@@ -21,7 +21,7 @@ export const selectFileEditorConfig = createSelector(
 );
 
 export const selectQueryFilesButtonConfig = createSelector(
-    [getQueryFiles, selectDeletedFiles, selectAddForm],
+    [selectQueryFiles, selectDeletedFiles, selectAddForm],
     (files, deletedFiles, addForm) => {
         return {
             files,

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
@@ -1,6 +1,6 @@
 import {type RootState} from '../../reducers';
 import {createSelector} from 'reselect';
-import {getClusterList} from '../slideoutMenu';
+import {selectClusterList} from '../slideoutMenu';
 import {type NavigationNode} from '../../reducers/query-tracker/queryNavigationSlice';
 import {makeGetSetting} from '../settings';
 import {createNestedNS} from '../../../../shared/utils/settings';
@@ -8,7 +8,8 @@ import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
 
 export const selectNavigationCluster = (state: RootState) =>
     state.queryTracker.queryNavigation.cluster;
-export const selectLoading = (state: RootState) => state.queryTracker.queryNavigation.loading;
+export const selectIsQueryNavigationLoading = (state: RootState) =>
+    state.queryTracker.queryNavigation.loading;
 export const selectClusterConfigs = (state: RootState) => state.clustersMenu.clusters;
 export const selectNavigationError = (state: RootState) => state.queryTracker.queryNavigation.error;
 
@@ -62,7 +63,7 @@ export const selectTableWithFilter = createSelector(
 );
 
 export const selectClustersByFilter = createSelector(
-    [getClusterList, selectNavigationFilter],
+    [selectClusterList, selectNavigationFilter],
     (clusters, filter) => {
         if (!filter) return clusters;
 

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryPlan.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryPlan.ts
@@ -29,7 +29,7 @@ function getLabelWithStage(name: string, stages: NodeStages) {
     }
 }
 
-export const getProcessedGraph = createSelector(
+export const selectProcessedGraph = createSelector(
     [selectQuerySingleProgress],
     (progress): ProcessedGraph | undefined => {
         const plan = progress.yql_plan;
@@ -37,8 +37,8 @@ export const getProcessedGraph = createSelector(
     },
 );
 
-export const getNodesWithProgress = createSelector(
-    [getProcessedGraph, selectQuerySingleProgress],
+export const selectNodesWithProgress = createSelector(
+    [selectProcessedGraph, selectQuerySingleProgress],
     (graph, progress): ProcessedNode[] => {
         if (!graph) return [];
 
@@ -66,7 +66,7 @@ export const getNodesWithProgress = createSelector(
     },
 );
 
-export const getQueryStartedAtMillis = createSelector(
+export const selectQueryStartedAtMillis = createSelector(
     [selectQuerySingleProgress],
     (progress): number => {
         return reduce_(
@@ -81,7 +81,7 @@ export const getQueryStartedAtMillis = createSelector(
 );
 
 const RESERVE_TO_EVENT = 1_000;
-export const getProgressInterval = createSelector([getNodesWithProgress], (nodes) => {
+export const selectProgressInterval = createSelector([selectNodesWithProgress], (nodes) => {
     if (!nodes.length) return undefined;
 
     return nodes.reduce(
@@ -101,7 +101,7 @@ export const getProgressInterval = createSelector([getNodesWithProgress], (nodes
     );
 });
 
-export const getOperationNodesStates = createSelector([getNodesWithProgress], (nodes) => {
+export const selectOperationNodesStates = createSelector([selectNodesWithProgress], (nodes) => {
     const counts: Partial<Record<NodeState | 'NotStarted', number>> = {};
 
     nodes.forEach((node) => {

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryPlan.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryPlan.ts
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect';
 import reduce_ from 'lodash/reduce';
 import isEmpty_ from 'lodash/isEmpty';
-import {getQuerySingleProgress} from './query';
+import {selectQuerySingleProgress} from './query';
 import {
     type ProcessedGraph,
     type ProcessedNode,
@@ -30,7 +30,7 @@ function getLabelWithStage(name: string, stages: NodeStages) {
 }
 
 export const getProcessedGraph = createSelector(
-    [getQuerySingleProgress],
+    [selectQuerySingleProgress],
     (progress): ProcessedGraph | undefined => {
         const plan = progress.yql_plan;
         return plan ? preprocess(plan) : undefined;
@@ -38,7 +38,7 @@ export const getProcessedGraph = createSelector(
 );
 
 export const getNodesWithProgress = createSelector(
-    [getProcessedGraph, getQuerySingleProgress],
+    [getProcessedGraph, selectQuerySingleProgress],
     (graph, progress): ProcessedNode[] => {
         if (!graph) return [];
 
@@ -67,7 +67,7 @@ export const getNodesWithProgress = createSelector(
 );
 
 export const getQueryStartedAtMillis = createSelector(
-    [getQuerySingleProgress],
+    [selectQuerySingleProgress],
     (progress): number => {
         return reduce_(
             progress.yql_progress ?? {},

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryResult.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryResult.ts
@@ -9,7 +9,7 @@ import {
 
 export const selectQueryResultsState = (state: RootState) => state.queryTracker.results;
 
-export const getQueryResultGlobalSettings = (): QueryResultReadyState['settings'] => {
+export const selectQueryResultGlobalSettings = (): QueryResultReadyState['settings'] => {
     const settings = getSettingsInitialData();
 
     return {
@@ -21,7 +21,7 @@ export const getQueryResultGlobalSettings = (): QueryResultReadyState['settings'
     };
 };
 
-export const getQueryResults = (
+export const selectQueryResults = (
     state: RootState,
     queryId: string,
 ): Record<number, QueryResult> | undefined => {
@@ -29,42 +29,42 @@ export const getQueryResults = (
     return res;
 };
 
-export const getQueryResult = (
+export const selectQueryResult = (
     state: RootState,
     queryId: string,
     index: number,
 ): QueryResult | undefined => selectQueryResultsState(state)?.[queryId]?.[index];
 
-export const getQueryReadyResult = (
+export const selectQueryReadyResult = (
     state: RootState,
     queryId: string,
     index: number,
 ): QueryResultReadyState | undefined => {
-    const result = getQueryResult(state, queryId, index);
+    const result = selectQueryResult(state, queryId, index);
     if (result?.state === QueryResultState.Ready) {
         return result;
     }
     return undefined;
 };
 
-export const isQueryResultReady = (state: RootState, queryId: string, index: number): boolean => {
-    const result = getQueryResult(state, queryId, index);
+export const selectIsQueryResultReady = (state: RootState, queryId: string, index: number): boolean => {
+    const result = selectQueryResult(state, queryId, index);
     return Boolean(result?.resultReady);
 };
 
-export const hasQueryResult = (state: RootState, queryId: string, index: number) => {
-    return Boolean(getQueryResult(state, queryId, index));
+export const selectHasQueryResult = (state: RootState, queryId: string, index: number) => {
+    return Boolean(selectQueryResult(state, queryId, index));
 };
 
 /* Returns the result's settings or global settings */
-export const getQueryResultSettings = (
+export const selectQueryResultSettings = (
     state: RootState,
     queryId: string,
     index: number,
 ): QueryResultReadyState['settings'] => {
-    const result = getQueryResult(state, queryId, index);
+    const result = selectQueryResult(state, queryId, index);
     if (result?.state === QueryResultState.Ready) {
         return result.settings;
     }
-    return getQueryResultGlobalSettings();
+    return selectQueryResultGlobalSettings();
 };

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryResult.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryResult.ts
@@ -47,7 +47,11 @@ export const selectQueryReadyResult = (
     return undefined;
 };
 
-export const selectIsQueryResultReady = (state: RootState, queryId: string, index: number): boolean => {
+export const selectIsQueryResultReady = (
+    state: RootState,
+    queryId: string,
+    index: number,
+): boolean => {
     const result = selectQueryResult(state, queryId, index);
     return Boolean(result?.resultReady);
 };

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryResult.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryResult.ts
@@ -7,7 +7,7 @@ import {
     QueryResultState,
 } from '../../../types/query-tracker/queryResult';
 
-export const getQueryResultsState = (state: RootState) => state.queryTracker.results;
+export const selectQueryResultsState = (state: RootState) => state.queryTracker.results;
 
 export const getQueryResultGlobalSettings = (): QueryResultReadyState['settings'] => {
     const settings = getSettingsInitialData();
@@ -25,7 +25,7 @@ export const getQueryResults = (
     state: RootState,
     queryId: string,
 ): Record<number, QueryResult> | undefined => {
-    const res: Record<number, QueryResult> | undefined = getQueryResultsState(state)?.[queryId];
+    const res: Record<number, QueryResult> | undefined = selectQueryResultsState(state)?.[queryId];
     return res;
 };
 
@@ -33,7 +33,7 @@ export const getQueryResult = (
     state: RootState,
     queryId: string,
     index: number,
-): QueryResult | undefined => getQueryResultsState(state)?.[queryId]?.[index];
+): QueryResult | undefined => selectQueryResultsState(state)?.[queryId]?.[index];
 
 export const getQueryReadyResult = (
     state: RootState,

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryTabs.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryTabs.ts
@@ -1,6 +1,6 @@
 import {type RootState} from '../../reducers';
 import {createSelector} from 'reselect';
-import {getQueryId} from './query';
+import {selectQueryId} from './query';
 import {parseResultTabIndex} from '../../../pages/query-tracker/QueryResults/helpers/parseResultTabIndex';
 
 export const selectQueryResultTabs = (state: RootState) => state.queryTracker.tabs.tabs;
@@ -9,7 +9,7 @@ export const selectUserChangedQueryResultTab = (state: RootState) =>
     state.queryTracker.tabs.userChangeTab;
 
 export const selectActiveResultParams = createSelector(
-    [selectActiveQueryResultTab, getQueryId],
+    [selectActiveQueryResultTab, selectQueryId],
     (activeTabId, id) => {
         if (!id || !activeTabId?.includes('result')) return undefined;
 

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryTrackerEnginesInfo.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryTrackerEnginesInfo.ts
@@ -4,12 +4,12 @@ import {type RootState} from '../../reducers';
 
 export const selectQueryTrackerInfo = (state: RootState) => state.queryTracker.aco.data;
 
-export const getAvailableYql = createSelector([selectQueryTrackerInfo], (qtInfo) => {
+export const selectAvailableYql = createSelector([selectQueryTrackerInfo], (qtInfo) => {
     const versions = qtInfo?.engines_info?.yql?.available_yql_versions;
     return Array.isArray(versions) ? versions : [];
 });
 
-export const getDefaultYqlVersion = createSelector([selectQueryTrackerInfo], (qtInfo) => {
+export const selectDefaultYqlVersion = createSelector([selectQueryTrackerInfo], (qtInfo) => {
     return qtInfo?.engines_info?.yql?.default_yql_ui_version;
 });
 

--- a/packages/ui/src/ui/store/selectors/query-tracker/settings.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/settings.ts
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect';
 import {getSettingsData} from '../settings/settings-base';
 
-export const getSettingQueryTrackerQueriesListSidebarVisibilityMode = createSelector(
+export const selectSettingQueryTrackerQueriesListSidebarVisibilityMode = createSelector(
     getSettingsData,
     (settings) => Boolean(settings['global::queryTracker::queriesListSidebarVisibilityMode']),
 );

--- a/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
@@ -1,6 +1,6 @@
 import {createSelector} from 'reselect';
 import {getSettingsData} from './settings-base';
-import {getQueryDraft} from '../query-tracker/query';
+import {selectQueryDraft} from '../query-tracker/query';
 
 export const getQuerySuggestionsEnabled = createSelector(getSettingsData, (data) => {
     return data['global::queryTracker::suggestions'] || false;
@@ -11,21 +11,21 @@ export const getLastUserChoiceQueryEngine = createSelector([getSettingsData], (d
 });
 
 export const getLastUserChoiceQueryDiscoveryPath = createSelector(
-    [getSettingsData, getQueryDraft],
+    [getSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastDiscoveryPath`];
     },
 );
 
 export const getLastUserChoiceQueryChytClique = createSelector(
-    [getSettingsData, getQueryDraft],
+    [getSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastChytClique`];
     },
 );
 
 export const getLastUserChoiceYqlVersion = createSelector(
-    [getSettingsData, getQueryDraft],
+    [getSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastYqlVersion`];
     },

--- a/packages/ui/src/ui/store/selectors/slideoutMenu.ts
+++ b/packages/ui/src/ui/store/selectors/slideoutMenu.ts
@@ -76,7 +76,7 @@ const getRecentPagesInfoRaw = createSelector(
     },
 );
 
-export const getClusterList = createSelector([getRecentClustersInfo], (recentInfo) => {
+export const selectClusterList = createSelector([getRecentClustersInfo], (recentInfo) => {
     const {recent, rest} = recentInfo;
     return [...recent, ...rest];
 });


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Gcp7zbvz7aBf6D
<!-- nda-end --> ## Summary by Sourcery

Rename query tracker selectors to a consistent `select*` naming convention and update all usages across query-related actions, components, and selector modules.

Enhancements:
- Unify selector naming for query tracker, queries list, ACO, query results, query navigation, query plan, and related settings to improve readability and consistency.
- Adjust connected React components, hooks, and thunks to use the new selector names without changing behavior.