### PR TITLE
chore: minor fixes

### DIFF
--- a/packages/ui/src/ui/components/MarkdownLinePreview/MarkdownLinePreview.tsx
+++ b/packages/ui/src/ui/components/MarkdownLinePreview/MarkdownLinePreview.tsx
@@ -51,7 +51,6 @@ export function MarkdownLinePreview({text, title, className, allowHTML = false}:
                 <Modal
                     visible={visible}
                     title={title}
-                    onOutsideClick={hideModal}
                     onCancel={hideModal}
                     footer={false}
                     content={

--- a/packages/ui/src/ui/components/Modal/Modal.tsx
+++ b/packages/ui/src/ui/components/Modal/Modal.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import block from 'bem-cn-lite';
 
-import {ModalWrapper as ModalImpl} from '../ModalWrapper/ModalWrapper';
+import {ModalWrapper} from '../ModalWrapper/ModalWrapper';
 import Icon from '../Icon/Icon';
 
 import withHandledScrollBar from '../../hocs/components/Modal/withHandledScrollBar';
@@ -151,7 +151,7 @@ class Modal extends Component<ModalProps> {
     render() {
         const {visible, onOutsideClick, onTransitionInComplete, size, className} = this.props;
         return (
-            <ModalImpl
+            <ModalWrapper
                 open={visible}
                 onClose={onOutsideClick}
                 onTransitionInComplete={onTransitionInComplete}
@@ -162,7 +162,7 @@ class Modal extends Component<ModalProps> {
                     {this.renderErrors()}
                     {this.renderFooter()}
                 </div>
-            </ModalImpl>
+            </ModalWrapper>
         );
     }
 }

--- a/packages/ui/src/ui/components/Modal/Modal.tsx
+++ b/packages/ui/src/ui/components/Modal/Modal.tsx
@@ -30,7 +30,6 @@ interface ModalProps {
     content?: React.ReactNode;
     footer?: boolean;
     footerContent?: React.ReactNode;
-    onOutsideClick?: () => void;
     contentClassName?: string;
     onTransitionInComplete?: () => void;
 }
@@ -149,12 +148,16 @@ class Modal extends Component<ModalProps> {
     }
 
     render() {
-        const {visible, onOutsideClick, onTransitionInComplete, size, className} = this.props;
+        const {visible, onCancel, onTransitionInComplete, size, className} = this.props;
         return (
             <ModalWrapper
                 open={visible}
-                onClose={onOutsideClick}
                 onTransitionInComplete={onTransitionInComplete}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        onCancel();
+                    }
+                }}
             >
                 <div className={b('wrapper', {size}, className)}>
                     {this.renderHeader()}

--- a/packages/ui/src/ui/components/Modal/SimpleModal.tsx
+++ b/packages/ui/src/ui/components/Modal/SimpleModal.tsx
@@ -4,7 +4,7 @@ import block from 'bem-cn-lite';
 import Icon from '../Icon/Icon';
 
 import {Button, Loader} from '@gravity-ui/uikit';
-import {ModalWrapper as ModalImpl} from '../ModalWrapper/ModalWrapper';
+import {ModalWrapper} from '../ModalWrapper/ModalWrapper';
 
 import withHandledScrollBar from '../../hocs/components/Modal/withHandledScrollBar';
 
@@ -86,13 +86,13 @@ class SimpleModal extends Component<SimpleModalProps> {
         const {visible, onOutsideClick, size, className, wrapperClassName} = this.props;
         return (
             visible && (
-                <ModalImpl className={className} open={visible} onClose={onOutsideClick}>
+                <ModalWrapper className={className} open={visible} onClose={onOutsideClick}>
                     <div className={b('wrapper', {size}, wrapperClassName)}>
                         {this.renderHeader()}
                         {this.renderContent()}
                         {this.renderFooter()}
                     </div>
-                </ModalImpl>
+                </ModalWrapper>
             )
         );
     }

--- a/packages/ui/src/ui/components/Modal/SimpleModal.tsx
+++ b/packages/ui/src/ui/components/Modal/SimpleModal.tsx
@@ -21,7 +21,6 @@ interface SimpleModalProps {
     onCancel: () => void;
     children?: React.ReactNode;
     footerContent?: React.ReactNode;
-    onOutsideClick?: () => void;
     className?: string;
     wrapperClassName?: string;
 }
@@ -83,10 +82,18 @@ class SimpleModal extends Component<SimpleModalProps> {
     }
 
     render() {
-        const {visible, onOutsideClick, size, className, wrapperClassName} = this.props;
+        const {visible, onCancel, size, className, wrapperClassName} = this.props;
         return (
             visible && (
-                <ModalWrapper className={className} open={visible} onClose={onOutsideClick}>
+                <ModalWrapper
+                    className={className}
+                    open={visible}
+                    onOpenChange={(open) => {
+                        if (!open) {
+                            onCancel();
+                        }
+                    }}
+                >
                     <div className={b('wrapper', {size}, wrapperClassName)}>
                         {this.renderHeader()}
                         {this.renderContent()}

--- a/packages/ui/src/ui/containers/ACL/DeletePermissionModal/DeletePermissionModal.js
+++ b/packages/ui/src/ui/containers/ACL/DeletePermissionModal/DeletePermissionModal.js
@@ -84,7 +84,6 @@ export default class DeletePermissionModal extends Component {
                 confirmText={i18n('action_delete')}
                 onCancel={this.onClose}
                 title={i18n('title_delete-permissions')}
-                onOutsideClick={this.onClose}
                 isConfirmDisabled={this.checkConfirmDisabled}
                 content={
                     <div className={block()}>

--- a/packages/ui/src/ui/containers/ActionModal/ActionModal.js
+++ b/packages/ui/src/ui/containers/ActionModal/ActionModal.js
@@ -146,12 +146,7 @@ class ActionModal extends React.Component {
 
         if (status === MODAL_STATES.FAILED) {
             return (
-                <SimpleModal
-                    visible
-                    title={i18n('title_failure')}
-                    onCancel={this.dismissAction}
-                    onOutsideClick={this.dismissAction}
-                >
+                <SimpleModal visible title={i18n('title_failure')} onCancel={this.dismissAction}>
                     <p>{errorMessage}</p>
                     <YTErrorBlock error={error} />
                 </SimpleModal>
@@ -168,7 +163,6 @@ class ActionModal extends React.Component {
                     title={i18n('title_confirmation')}
                     confirmText={i18n('button_confirm')}
                     onCancel={this.dismissAction}
-                    onOutsideClick={this.dismissAction}
                     loading={status === MODAL_STATES.PENDING}
                     onConfirm={this.confirmAction}
                     content={

--- a/packages/ui/src/ui/containers/ManageTokens/ManageTokensModalContent/ManageTokensModalContent.tsx
+++ b/packages/ui/src/ui/containers/ManageTokens/ManageTokensModalContent/ManageTokensModalContent.tsx
@@ -162,7 +162,6 @@ const RevokeToken = (props: {handleClickRemoveToken: (index: number) => void; in
                 content="Are you sure you want to revoke the token? This action CANNOT be undone."
                 onCancel={handleCancel}
                 onConfirm={handleConfirm}
-                onOutsideClick={handleCancel}
                 visible={visible}
             />
         </>

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
@@ -752,7 +752,6 @@ class AccountsGeneralTab extends Component {
         return (
             editableAccount.name && (
                 <Modal
-                    onOutsideClick={closeEditorModal}
                     onCancel={closeEditorModal}
                     visible={showEditor}
                     content={<Editor account={editableAccount} />}

--- a/packages/ui/src/ui/pages/components/tabs/nodes/Version.js
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Version.js
@@ -50,7 +50,7 @@ class Version extends Component {
                 <Link theme="ghost" onClick={handleShow}>
                     View
                 </Link>
-                <SimpleModal visible={visible} onCancel={handleClose} onOutsideClick={handleClose}>
+                <SimpleModal visible={visible} onCancel={handleClose}>
                     <YTErrorBlock error={error} />
                 </SimpleModal>
             </div>

--- a/packages/ui/src/ui/pages/navigation/content/MapNode/MultipleActions.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/MapNode/MultipleActions.tsx
@@ -4,12 +4,16 @@ import isEmpty_ from 'lodash/isEmpty';
 import map_ from 'lodash/map';
 import some_ from 'lodash/some';
 
+import copyToClipboard from 'copy-to-clipboard';
+import {DropdownMenu, Icon as UIKitIcon} from '@gravity-ui/uikit';
+import {CircleQuestion} from '@gravity-ui/icons';
+
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import block from 'bem-cn-lite';
 
 import Icon from '../../../../components/Icon/Icon';
 import Button from '../../../../components/Button/Button';
-import {ClipboardButton} from '@ytsaurus/components';
+import {ClipboardButton, Tooltip} from '@ytsaurus/components';
 
 import {getPath} from '../../../../store/selectors/navigation';
 import {inTrash} from '../../../../utils/navigation/restore-object';
@@ -24,8 +28,6 @@ import {
     isSelected,
 } from '../../../../store/selectors/navigation/content/map-node';
 import {showNavigationAttributesEditor} from '../../../../store/actions/navigation/modals/attributes-editor';
-import {DropdownMenu} from '@gravity-ui/uikit';
-import copyToClipboard from 'copy-to-clipboard';
 import {
     showTableMergeModal,
     showTableSortModal,
@@ -39,6 +41,8 @@ import './MultipleActions.scss';
 
 const b = block('multiple-actions');
 
+const MAX_ITEMS_PER_REQUEST = 1000;
+
 export default function MultipleActions(props: {className?: string}) {
     const {className} = props;
 
@@ -46,7 +50,7 @@ export default function MultipleActions(props: {className?: string}) {
     const path = useSelector(getPath);
     const isOneSelected = useSelector(isSelected);
     const selectedNodes = useSelector(getSelectedNodes);
-    const isTooLarge = selectedNodes.length > 1000;
+    const isTooLarge = selectedNodes.length > MAX_ITEMS_PER_REQUEST;
 
     const dynTablesActions = useSelector(getSelectedNodesAllowedDynTablesActions);
 
@@ -58,11 +62,11 @@ export default function MultipleActions(props: {className?: string}) {
         dispatch(openDeleteModal(selectedNodes, true));
     }, [dispatch, selectedNodes]);
 
-    const allowModifyActions = !isOneSelected || isTooLarge;
+    const disableActions = !isOneSelected || isTooLarge;
 
     const dropdownButton = useMemo(
-        () => <Button disabled={allowModifyActions}>More actions</Button>,
-        [isOneSelected, isTooLarge],
+        () => <Button disabled={disableActions}>More actions</Button>,
+        [disableActions],
     );
 
     const restoreMoveCopy = useMemo(() => {
@@ -129,7 +133,7 @@ export default function MultipleActions(props: {className?: string}) {
                 },
             },
         ];
-    }, [selectedNodes]);
+    }, [selectedNodes, dispatch]);
 
     const editItem = useMemo(() => {
         return {
@@ -140,7 +144,7 @@ export default function MultipleActions(props: {className?: string}) {
                 dispatch(showNavigationAttributesEditor(paths));
             },
         };
-    }, [selectedNodes]);
+    }, [selectedNodes, dispatch]);
 
     const mergeSortSection = useMemo(() => {
         const allowSortMerge = !some_(selectedNodes, (node) => {
@@ -237,7 +241,7 @@ export default function MultipleActions(props: {className?: string}) {
             transferItem,
             dynTablesSection,
         ].filter((e) => e.length);
-    }, [restoreMoveCopy, editItem, mergeSortSection]);
+    }, [restoreMoveCopy, transferItem, dynTablesSection, editItem, mergeSortSection]);
 
     const onCopyPathClick = React.useCallback(() => {
         const res = map_(selectedNodes, 'path').join('\n');
@@ -250,16 +254,29 @@ export default function MultipleActions(props: {className?: string}) {
 
     return (
         <span className={b(null, className)}>
-            <span className={b('item')}>
-                <Button
-                    title="Delete selected nodes"
-                    disabled={allowModifyActions}
-                    onClick={handleDeleteClick}
+            {isTooLarge && (
+                <Tooltip
+                    className={b('item')}
+                    content={
+                        <span>
+                            It is not allowed to handle more than {MAX_ITEMS_PER_REQUEST} items per
+                            request. Use SHIFT+Click to select ranges.
+                        </span>
+                    }
+                    useFlex
                 >
+                    <span>Too many items selected</span>
+                    &nbsp;
+                    <UIKitIcon data={CircleQuestion} />
+                </Tooltip>
+            )}
+
+            {!isTooLarge && (
+                <Button title="Delete selected nodes" onClick={handleDeleteClick}>
                     <Icon awesome="trash-alt" />
                     &nbsp;Remove selected
                 </Button>
-            </span>
+            )}
 
             <span className={b('item')}>
                 <ClipboardButton
@@ -269,13 +286,11 @@ export default function MultipleActions(props: {className?: string}) {
                 />
             </span>
 
-            <span className={b('item')}>
-                <DropdownMenu
-                    disabled={allowModifyActions}
-                    switcher={dropdownButton}
-                    items={items}
-                />
-            </span>
+            {!disableActions && (
+                <span className={b('item')}>
+                    <DropdownMenu switcher={dropdownButton} items={items} />
+                </span>
+            )}
 
             <span className={b('item')}>
                 <ClickableText onClick={handleClearAll}>Clear all</ClickableText>

--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Consumers/UnregisterConsumerDialog.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Consumers/UnregisterConsumerDialog.tsx
@@ -32,7 +32,7 @@ export function UnregisterConsumerDialog() {
                     extras: {
                         children: (
                             <Text variant={'body-2'}>
-                                Are you shure you want to unregister consumer?
+                                Are you sure you want to unregister consumer?
                             </Text>
                         ),
                     },

--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Exports/ExportsEdit/ExportsEdit.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Exports/ExportsEdit/ExportsEdit.tsx
@@ -56,7 +56,7 @@ export function ExportsEdit({
                         extras: {
                             children: (
                                 <Text variant="body-2">
-                                    Are you shure you want to delete {prevConfig.export_name}?
+                                    Are you sure you want to delete {prevConfig.export_name}?
                                 </Text>
                             ),
                         },

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
@@ -458,7 +458,6 @@ class OperationJobsTable extends React.Component {
                 visible
                 onCancel={hideInputPaths}
                 loading={status === LOADING_STATUS.LOADING}
-                onOutsideClick={hideInputPaths}
                 title="Input paths"
             >
                 {content}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/DetailedJobsCounter/DetailedJobsCounter.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/DetailedJobsCounter/DetailedJobsCounter.js
@@ -95,7 +95,6 @@ class DetailedJobsCounter extends Component {
                 </Link>
                 {this.renderCount(type, primaryValue, secondaryValue)}
                 <Modal
-                    onOutsideClick={handleClose}
                     onCancel={handleClose}
                     content={modalContent}
                     visible={visible}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/FilterOverview/FilterOverview.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/FilterOverview/FilterOverview.js
@@ -43,7 +43,6 @@ function FilterOverview({type, filters, typedFilters, visible, handleShow, handl
             </Button>
 
             <Modal
-                onOutsideClick={handleClose}
                 onCancel={handleClose}
                 content={modalContent}
                 visible={visible}

--- a/packages/ui/src/ui/pages/query-tracker/NewQueryButton/NewQueryButton.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/NewQueryButton/NewQueryButton.tsx
@@ -19,7 +19,6 @@ export const NewQueryPromt = (props: {
             content={i18n('confirm_new-query')}
             onCancel={props.cancel}
             onConfirm={props.confirm}
-            onOutsideClick={props.cancel}
             visible={props.visible}
         />
     );

--- a/packages/ui/src/ui/pages/query-tracker/QueryMetaTable/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryMetaTable/index.tsx
@@ -95,7 +95,6 @@ export default function QueryMetaTable({query, className}: MetaTableProps) {
             <SimpleModal
                 visible={modalOpened}
                 disableBodyScrollLock
-                onOutsideClick={() => setModalOpened(false)}
                 onCancel={() => setModalOpened(false)}
             >
                 {selectedOption && <Yson value={selectedOption} settings={{}}></Yson>}

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/QueryEngineSelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QueryEngineSelector/QueryEngineSelector.tsx
@@ -107,7 +107,6 @@ export const QueryEngineSelector: FC<Props> = ({isDesktop, className, onChange})
                 visible={modalVisibility}
                 onCancel={handleClose}
                 onConfirm={handleConfirm}
-                onOutsideClick={handleClose}
             />
         </>
     );

--- a/packages/ui/src/ui/store/reducers/navigation/content/table/table.js
+++ b/packages/ui/src/ui/store/reducers/navigation/content/table/table.js
@@ -44,10 +44,6 @@ const ephemeralState = {
 
     nextOffsetValue: null,
     moveBackward: false,
-
-    // yql-kit
-    validColumns: [],
-    queryPreparing: false,
 };
 
 const persistedState = {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/pKRDC1hS7aZdWB
<!-- nda-end -->  ## Summary by Sourcery

Adjust multiple selection actions and modal behavior, and clean up minor UI issues across the app.

Bug Fixes:
- Fix spelling mistakes in confirmation dialog copy ("shure" → "sure").

Enhancements:
- Enforce a configurable maximum of 1000 items per multi-node action, showing a tooltip and disabling bulk actions when the limit is exceeded.
- Refine the multiple actions dropdown and delete button visibility/disabled state based on selection and size constraints.
- Switch modal components to use a unified wrapper with onOpenChange to trigger cancel behavior instead of relying on an onOutsideClick prop, and remove now-unused props and state fields.
- Tighten memoization dependencies in navigation actions to reflect all used values.

Chores:
- Remove obsolete table reducer fields related to yql-kit state and unused onOutsideClick wiring in modal usages.