### PR TITLE
fix: update color palette [YTFRONT-4270]

### DIFF
--- a/packages/ui/src/ui/components/BundleMetaResourceProgress/BundleMetaResourceProgress.tsx
+++ b/packages/ui/src/ui/components/BundleMetaResourceProgress/BundleMetaResourceProgress.tsx
@@ -10,7 +10,8 @@ import {Progress, type ProgressProps} from '@gravity-ui/uikit';
 import {MetaTable, type MetaTableItem, Tooltip} from '@ytsaurus/components';
 import {ColorCircle} from '../../components/ColorCircle/ColorCircle';
 
-import {getProgressBarColorByIndex} from '../../constants/colors';
+// 1. Импортируем наш новый хук вместо старой функции
+import {useProgressBarColor} from '../../constants/colors';
 
 import {type CPULimits, type MemoryLimits} from '../../store/reducers/tablet_cell_bundles';
 
@@ -25,26 +26,47 @@ type ResourceProgress = {
     postfix?: string;
 };
 
-export function BundleMetaResourceProgress(
-    title: string,
-    {data, limit, resourceType, postfix = ''}: ResourceProgress,
-) {
-    const {props, text, commonTooltip} = getProgressData({data, limit, resourceType, postfix});
+// 2. Создаем внутренний React-компонент.
+// Именно здесь мы имеем право использовать хуки.
+function BundleMetaResourceProgressUI(props: ResourceProgress) {
+    const {data, limit, resourceType, postfix = ''} = props;
 
+    // Инициализируем хук генерации цветов
+    const getProgressBarColor = useProgressBarColor();
+
+    // Заворачиваем вычисления в useMemo для оптимизации (чтобы не пересчитывать при ререндерах)
+    const {progressProps, text, commonTooltip} = React.useMemo(() => {
+        return getProgressData(
+            {data, limit, resourceType, postfix},
+            getProgressBarColor, // передаем метод генерации цвета внутрь чистой функции
+        );
+    }, [data, limit, resourceType, postfix, getProgressBarColor]);
+
+    return (
+        <div className={block()}>
+            <Tooltip placement={'bottom'} content={commonTooltip}>
+                <Progress className={block('progress')} {...progressProps} text={text} />
+            </Tooltip>
+        </div>
+    );
+}
+
+// 3. Оригинальная функция-фабрика остается с той же сигнатурой,
+// чтобы не сломать родительский код.
+export function BundleMetaResourceProgress(title: string, params: ResourceProgress) {
     return {
         key: title,
-        value: (
-            <div className={block()}>
-                <Tooltip placement={'bottom'} content={commonTooltip}>
-                    <Progress className={block('progress')} {...props} text={text} />
-                </Tooltip>
-            </div>
-        ),
+        // Отрисовываем наш новый компонент
+        value: <BundleMetaResourceProgressUI {...params} />,
     };
 }
 
-function getProgressData({data, limit, resourceType, postfix}: ResourceProgress) {
-    const props: ProgressProps = {
+// 4. Добавляем функцию getProgressBarColor в аргументы
+function getProgressData(
+    {data, limit, resourceType, postfix}: ResourceProgress,
+    getProgressBarColor: (index: number) => string,
+) {
+    const progressProps: ProgressProps = {
         stack: [],
     };
 
@@ -56,8 +78,10 @@ function getProgressData({data, limit, resourceType, postfix}: ResourceProgress)
 
     forEach_(data, (value, name) => {
         const formattedValue = hammer.format[resourceType](value);
-        const color = getProgressBarColorByIndex(props.stack.length);
 
+        // Используем переданную функцию для получения цвета
+        const color = getProgressBarColor(progressProps.stack.length);
+        console.log(color);
         metaItems.push({
             key: name,
             label: (
@@ -70,7 +94,7 @@ function getProgressData({data, limit, resourceType, postfix}: ResourceProgress)
         });
         const fraction = (Number(value) / max) * 100;
 
-        props.stack.push({
+        progressProps.stack.push({
             color,
             value: fraction,
         });
@@ -78,5 +102,5 @@ function getProgressData({data, limit, resourceType, postfix}: ResourceProgress)
 
     const commonTooltip = <MetaTable items={metaItems} />;
 
-    return {props, text, commonTooltip};
+    return {progressProps, text, commonTooltip};
 }

--- a/packages/ui/src/ui/components/Histogram/HistogramChart.tsx
+++ b/packages/ui/src/ui/components/Histogram/HistogramChart.tsx
@@ -4,7 +4,7 @@ import {
     type RawSerieData,
     YTChartKitLazy,
     type YagrWidgetData,
-    getSerieColor,
+    useSerieColor,
 } from '../../components/YTChartKit';
 
 import formatLib from '../../common/hammer/format';
@@ -39,11 +39,17 @@ type X = number;
 type Y = number;
 
 function HistogramChart({className, pdf, ecdf, format, dataName, lineOnly}: HistogramChartProps) {
+    // 2. Инициализируем хук на верхнем уровне компонента
+    const getSerieColor = useSerieColor();
+
     const yagrData = React.useMemo(() => {
         const xFormat = format === 'Bytes' ? formatLib.Bytes : formatLib.Number;
+
+        // 3. Передаем функцию getSerieColor аргументом в хелперы
         const {timeline, graphs, step} = lineOnly
-            ? getLineOnlyData(pdf, ecdf)
-            : getColumnData(pdf, ecdf);
+            ? getLineOnlyData(pdf, ecdf, getSerieColor)
+            : getColumnData(pdf, ecdf, getSerieColor);
+
         const res: YagrWidgetData = {
             data: {
                 timeline,
@@ -110,7 +116,7 @@ function HistogramChart({className, pdf, ecdf, format, dataName, lineOnly}: Hist
             sources: {},
         };
         return res;
-    }, [pdf, ecdf, format, lineOnly]);
+    }, [pdf, ecdf, format, lineOnly, getSerieColor]); // 4. Добавляем getSerieColor в зависимости
 
     return (
         <div className={className}>
@@ -121,9 +127,11 @@ function HistogramChart({className, pdf, ecdf, format, dataName, lineOnly}: Hist
 
 export default React.memo(HistogramChart);
 
+// 5. Добавляем аргумент getSerieColor в сигнатуру функции
 function getColumnData(
     {buckets, min, bucketSize}: PDFData,
     {steps}: ECDFData,
+    getSerieColor: (index: number) => string,
 ): YagrWidgetData['data'] & {step: number} {
     const timeline = [min - 0.1 * bucketSize];
     const data: Array<number> = [undefined!];
@@ -162,12 +170,12 @@ function getColumnData(
             type: 'line' as const,
             data: lineData,
             scale: 'y1',
-            color: getSerieColor(1),
+            color: getSerieColor(1), // Используем переданную функцию
         },
         {
             type: 'column' as const,
             data,
-            color: getSerieColor(0),
+            color: getSerieColor(0), // Используем переданную функцию
             ...{
                 renderOptions: {
                     size: [1],
@@ -183,9 +191,11 @@ function getColumnData(
     };
 }
 
+// 6. Добавляем аргумент getSerieColor и сюда
 function getLineOnlyData(
     {min, buckets, bucketSize}: PDFData,
     {steps}: ECDFData,
+    getSerieColor: (index: number) => string,
 ): ReturnType<typeof getColumnData> {
     const timeline: Array<number> = [min - 0.1 * bucketSize];
     const data: Array<number> = [NaN];
@@ -202,7 +212,7 @@ function getLineOnlyData(
         {
             type: 'line' as const,
             data,
-            color: getSerieColor(1),
+            color: getSerieColor(1), // Используем переданную функцию
         },
     ];
 

--- a/packages/ui/src/ui/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/ui/src/ui/components/ProgressCircle/ProgressCircle.tsx
@@ -1,4 +1,5 @@
-import {getProgressBarColorByIndex} from '../../constants/colors';
+// 1. Импортируем наш новый хук вместо функции
+import {useProgressBarColor} from '../../constants/colors';
 import React from 'react';
 
 export type ProgressCircleProps = {
@@ -20,6 +21,9 @@ export type Stack = {
 };
 
 export function ProgressCircle({stack: rawStack, gap = 0, size, className}: ProgressCircleProps) {
+    // 2. Инициализируем хук генерации цветов
+    const getProgressBarColor = useProgressBarColor();
+
     const stack = rawStack.filter(({value}) => Math.abs(value) > 0);
     if (!stack.length) {
         return null;
@@ -67,7 +71,8 @@ export function ProgressCircle({stack: rawStack, gap = 0, size, className}: Prog
                             cx="50%"
                             cy="50%"
                             strokeDasharray={storkeDashArrays[index]}
-                            stroke={item.color ?? getProgressBarColorByIndex(index)}
+                            // 3. Используем функцию из хука
+                            stroke={item.color ?? getProgressBarColor(index)}
                             strokeWidth={strokeWidth}
                         />
                     );

--- a/packages/ui/src/ui/components/YTChartKit/index.tsx
+++ b/packages/ui/src/ui/components/YTChartKit/index.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import React, {useCallback} from 'react';
+// Импортируем чистую функцию и хук для получения текущего значения темы ('light' | 'dark')
+import {type ThemeType, generateColor, useThemeValue} from '@gravity-ui/uikit';
+
 export type {ChartKitProps, ChartKitWidget, ChartKitRef} from './YTChartKit';
 export type {RawSerieData, YagrWidgetData} from '@gravity-ui/chartkit/yagr';
 
@@ -9,21 +12,27 @@ export const YTChartKitLazy = withLazyLoading(
     React.lazy(async () => import(/* webpackChunkName: 'chart-kit' */ './YTChartKit')),
 ) as YTChartKitType;
 
-const COLORS = [
-    'rgb(77, 162, 241)',
-    'rgb(255, 61, 100)',
-    '#76a559',
-    '#6a72b8',
-    '#e98f27',
-    '#b67598',
-    '#ffdb80',
-    '#c6cb8e',
-    '#8dcaaf',
-    '#bee9ef',
-];
+/**
+ * Хук, возвращающий функцию генерации консистентных цветов для линий графиков
+ */
+export function useSerieColor() {
+    // 1. Получаем текущую тему из контекста Gravity UI
+    const theme = useThemeValue() as ThemeType;
 
-export function getSerieColor(serieIndex: number) {
-    return COLORS[serieIndex % COLORS.length];
+    return useCallback(
+        (serieIndex: number): string => {
+            // 2. Вызываем чистую функцию, передавая и seed, и theme
+            const {rgb} = generateColor({
+                seed: String(serieIndex),
+                theme,
+            });
+
+            // 3. Собираем валидную строку цвета. Yagr работает на Canvas,
+            // поэтому формат rgb(r, g, b) для него идеально подходит.
+            return `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
+        },
+        [theme], // Функция будет пересоздана (а графики перерисованы) при смене темы
+    );
 }
 
 export {YTChartKitPie} from './YTChartKitPie';

--- a/packages/ui/src/ui/components/YTHistogram/YTHistogram.tsx
+++ b/packages/ui/src/ui/components/YTHistogram/YTHistogram.tsx
@@ -6,7 +6,7 @@ import {
     type RawSerieData,
     YTChartKitLazy,
     type YagrWidgetData,
-    getSerieColor,
+    useSerieColor, // 1. Меняем импорт на хук
 } from '../../components/YTChartKit';
 import './YTHistogram.scss';
 
@@ -47,13 +47,16 @@ function YTHistogram({
     yFormat = format.Number,
     renderTooltip = renderDefaultTooltip,
 }: YTHistogramProps) {
+    // 2. Инициализируем хук
+    const getSerieColor = useSerieColor();
+
     const yagrData = React.useMemo(() => {
         const {timeline, serieData, step} = genYagrData(data);
         const graphs: Array<RawSerieData> = [
             {
                 type: 'column' as const,
                 data: yLogarithmic ? serieData.map((v) => (v === 0 ? NaN : v)) : (serieData as any),
-                color: getSerieColor(0),
+                color: getSerieColor(0), // Используем функцию из хука
                 formatter: yFormat,
                 ...{
                     renderOptions: {
@@ -110,7 +113,8 @@ function YTHistogram({
             },
         };
         return res;
-    }, [data, xLabel, yLabel, xFormat, yFormat, renderTooltip, yMin, yLogarithmic]);
+        // 3. Добавляем getSerieColor в зависимости, чтобы график реагировал на смену темы
+    }, [data, xLabel, yLabel, xFormat, yFormat, renderTooltip, yMin, yLogarithmic, getSerieColor]);
 
     return (
         <div className={block(null, className)}>

--- a/packages/ui/src/ui/constants/colors.ts
+++ b/packages/ui/src/ui/constants/colors.ts
@@ -14,3 +14,31 @@ export const STACKED_PROGRESS_BAR_COLORS = [
 export function getProgressBarColorByIndex(index: number, offset = 4) {
     return STACKED_PROGRESS_BAR_COLORS[(offset + index) % STACKED_PROGRESS_BAR_COLORS.length];
 }
+
+import {useCallback} from 'react';
+import {type ThemeType, generateColor, useThemeValue} from '@gravity-ui/uikit';
+
+/**
+ * Хук для генерации консистентных цветов прогресс-баров.
+ * Заменяет старый метод getProgressBarColorByIndex и хардкод STACKED_PROGRESS_BAR_COLORS.
+ */
+export function useProgressBarColor() {
+    // Получаем текущую тему (светлая/тёмная)
+    const theme = useThemeValue() as ThemeType;
+    return useCallback(
+        (index: number, offset = 4): string => {
+            // Чтобы сохранить логику смещения (offset),
+            // мы просто складываем индекс со смещением для формирования seed
+            const seed = String(index + offset);
+
+            const {rgb} = generateColor({
+                seed,
+                theme,
+            });
+
+            // Возвращаем валидную CSS-строку цвета
+            return `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
+        },
+        [theme],
+    );
+}

--- a/packages/ui/src/ui/containers/PrometheusDashboard/plugins/timeseries/timeseries.tsx
+++ b/packages/ui/src/ui/containers/PrometheusDashboard/plugins/timeseries/timeseries.tsx
@@ -13,7 +13,8 @@ import {YT} from '../../../../config/yt-config';
 
 import {IntersectionObserverContainer} from '../../../../components/IntersectionObserverContainer/IntersectionObserverContainer';
 
-import {YTChartKitLazy, getSerieColor} from '../../../../components/YTChartKit';
+// 1. Заменяем импорт
+import {YTChartKitLazy, useSerieColor} from '../../../../components/YTChartKit';
 import {type Yagr, type YagrWidgetData} from '@gravity-ui/chartkit/yagr';
 import {InlineError} from '../../../../components/InlineError/InlineError';
 import Loader from '../../../../components/Loader/Loader';
@@ -123,6 +124,9 @@ function useLoadQueriesData({
 }: Pick<PrometheusChartProps, 'data' | 'id'> & {pointCount?: number; from?: number; to?: number}) {
     // const [cancelHelper] = React.useState(new CancelHelper());
 
+    // 2. Инициализируем хук генерации цветов на верхнем уровне кастомного хука
+    const getSerieColor = useSerieColor();
+
     const {__ytDashboardType: dashboardType} = params;
 
     const {data, isLoading, error} = usePrometheusFetchQuery({
@@ -186,13 +190,16 @@ function useLoadQueriesData({
                     results,
                     {end, start, step},
                     params,
+                    getSerieColor, // 3. Передаем функцию как аргумент
                 ),
             };
-        }, [data, error, params, targets, title, fieldOverrides, isLoading]);
+            // 4. Обязательно добавляем getSerieColor в зависимости
+        }, [data, error, params, targets, title, fieldOverrides, isLoading, getSerieColor]);
 
     return chartData;
 }
 
+// 5. Расширяем сигнатуру функции для приема метода генерации цвета
 function makeYagrWidgetData(
     {
         title,
@@ -209,6 +216,7 @@ function makeYagrWidgetData(
     results: Array<QueryRangeData>,
     {end, start, step}: {end: number; start: number; step: number},
     params: Record<string, string | number>,
+    getSerieColor: (index: number) => string, // Принимаем функцию
 ): YagrWidgetData {
     const res: YagrWidgetData = {
         data: {graphs: [], timeline: []},
@@ -272,7 +280,7 @@ function makeYagrWidgetData(
                     : undefined,
                 data: new Array(timeline.length),
                 formatter: unit === 'bytes' ? format.Bytes : format.NumberSmart,
-                color: getSerieColor(res.data.graphs.length),
+                color: getSerieColor(res.data.graphs.length), // 6. Вызываем переданную функцию
             };
             if (!graph.name) {
                 const graphIndex = res.data.graphs.length;

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeBundlesTotal/NodeBundlesTotal.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeBundlesTotal/NodeBundlesTotal.tsx
@@ -16,10 +16,9 @@ import {
     selectNodeMemoryUsageTotalTableStatic,
     selectNodeMemoryUsageTotalTabletDynamic,
 } from '../../../../../store/selectors/components/node/memory';
-import {
-    STACKED_PROGRESS_BAR_COLORS,
-    getProgressBarColorByIndex,
-} from '../../../../../constants/colors';
+
+// 1. Меняем импорт на наш новый хук
+import {useProgressBarColor} from '../../../../../constants/colors';
 
 import './NodeBundlesTotal.scss';
 
@@ -63,11 +62,13 @@ function NodeBundlesTotal() {
     );
 }
 
-const COLORS: Partial<Record<keyof TabletDynamicTotalProps['data'], string>> = {
-    active: STACKED_PROGRESS_BAR_COLORS[4],
-    backing: STACKED_PROGRESS_BAR_COLORS[7],
-    other: STACKED_PROGRESS_BAR_COLORS[2],
-    passive: STACKED_PROGRESS_BAR_COLORS[0],
+// 2. Вместо хардкода готовых цветов, сохраняем нужные "индексы" (seed),
+// которые в оригинале соответствовали позициям в массиве (4, 7, 2, 0)
+const PREDEFINED_COLOR_INDICES: Partial<Record<keyof TabletDynamicTotalProps['data'], number>> = {
+    active: 4,
+    backing: 7,
+    other: 2,
+    passive: 0,
 };
 
 interface TabletDynamicTotalProps {
@@ -92,6 +93,9 @@ export function TabletDynamicTotal(props: TabletDynamicTotalProps) {
         limitTooltipTitle,
     } = props;
 
+    // 3. Инициализируем хук генерации цветов
+    const getProgressBarColor = useProgressBarColor();
+
     const {stack, text, content} = React.useMemo(() => {
         let usageSum = 0;
         const stack = map_(rest, (value, key) => {
@@ -113,7 +117,16 @@ export function TabletDynamicTotal(props: TabletDynamicTotalProps) {
                 <div className={block('progress-tooltip')}>
                     {map_(stack, (item, index) => {
                         const {key} = item;
-                        item.color = COLORS[key] ?? getProgressBarColorByIndex(index, 8);
+
+                        // 4. Проверяем, есть ли для этого ключа зарезервированный индекс
+                        const predefinedIndex = PREDEFINED_COLOR_INDICES[key];
+
+                        item.color =
+                            predefinedIndex !== undefined
+                                ? // Если есть - используем его со смещением 0 (чтобы получить оригинальный seed = 4, 7 и т.д.)
+                                  getProgressBarColor(predefinedIndex, 0)
+                                : // Если нет - используем фоллбэк из старой логики (index, 8)
+                                  getProgressBarColor(index, 8);
 
                         return (
                             <React.Fragment key={key}>
@@ -140,7 +153,8 @@ export function TabletDynamicTotal(props: TabletDynamicTotalProps) {
                 </div>
             ),
         };
-    }, [props.data]);
+        // 5. Добавляем getProgressBarColor и другие пропсы в зависимости useMemo
+    }, [props.data, hideLimit, limitTooltipTitle, getProgressBarColor]);
 
     return (
         <Tooltip content={content} className={className}>

--- a/packages/ui/src/ui/store/reducers/components/nodes/nodes/node.tsx
+++ b/packages/ui/src/ui/store/reducers/components/nodes/nodes/node.tsx
@@ -11,7 +11,10 @@ import without_ from 'lodash/without';
 
 import ypath from '../../../../../common/thor/ypath';
 import hammer from '../../../../../common/hammer';
-import {STACKED_PROGRESS_BAR_COLORS} from '../../../../../constants/colors';
+
+// 1. Импортируем чистую функцию генерации цвета
+import {generateColor} from '@gravity-ui/uikit';
+
 import {type FIX_MY_TYPE, type YTError} from '../../../../../types/index';
 import {computeProgress, progressText} from '../../../../../utils/progress';
 import {type MaintenanceRequestInfo} from '../../../../../store/actions/components/node-maintenance-modal';
@@ -94,10 +97,25 @@ export class Node {
         };
     }
 
+    // 2. Обновляем метод получения цвета
     static getColor(index: number) {
-        const colors = STACKED_PROGRESS_BAR_COLORS;
+        let theme: 'light' | 'dark' = 'light';
 
-        return colors[index % colors.length];
+        // Так как мы вне React-компонента, пытаемся определить тему из DOM-дерева.
+        // Gravity UI автоматически добавляет класс g-root_theme_dark при темной теме.
+        if (typeof document !== 'undefined') {
+            const isDark =
+                document.body.classList.contains('g-root_theme_dark') ||
+                document.documentElement.classList.contains('g-root_theme_dark') ||
+                document.body.classList.contains('yc-root_theme_dark');
+
+            if (isDark) {
+                theme = 'dark';
+            }
+        }
+
+        const {rgb} = generateColor({seed: String(index), theme});
+        return `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
     }
 
     alertCount?: number;
@@ -127,7 +145,10 @@ export class Node {
     lastSeenTime!: string;
     locations!: FIX_MY_TYPE[];
     memory: FIX_MY_TYPE;
-    memoryData?: Array<{color: string; name: string; value: number}>;
+
+    // 3. Добавляем опциональное поле colorIndex, чтобы в будущем облегчить рефакторинг UI
+    memoryData?: Array<{color: string; name: string; value: number; colorIndex?: number}>;
+
     memoryProgress!: number;
     memoryText!: string;
     memoryTotal!: {usage?: number; limit?: number};
@@ -356,6 +377,8 @@ export class Node {
         memory = map_(memory, (categoryData, index: number) => {
             memoryUsage += categoryData.rawData.used || 0;
             categoryData.color = Node.getColor(index);
+            // 4. Пробрасываем оригинальный индекс, чтобы в будущем перенести покраску в UI-слой
+            categoryData.colorIndex = index;
             return categoryData;
         });
 


### PR DESCRIPTION
## Summary by Sourcery

Adopt theme-aware, generated colors for charts and progress visuals to replace hardcoded palettes while preserving existing public APIs.

Bug Fixes:
- Ensure visual components correctly adapt their colors to the current light or dark theme instead of relying on static color lists.

Enhancements:
- Introduce hooks for generating theme-aware colors for chart series and progress bars and integrate them into existing chart, histogram, and progress components.
- Refactor bundle and tablet progress components to compute and memoize colorized stacks via injectable color generator functions for better reuse and performance.
- Update node model color computation to derive colors from generated theme-based values and propagate color indices for future UI refactors.