### PR TITLE
fix(SchemaTab): display correct value (without html-markup) in name column

### DIFF
--- a/packages/components/src/modules/NavigationTable/SchemaTab.tsx
+++ b/packages/components/src/modules/NavigationTable/SchemaTab.tsx
@@ -36,7 +36,7 @@ export const SchemaTab: FC<SchemaTabProps> = ({schema, filter, onFilterChange}) 
                                     size={16}
                                 />
                             )}{' '}
-                            {unipika.prettyprint(row.name, {asHTML: false, ...unipikaSettings})}
+                            {unipika.prettyprint(row.name, {...unipikaSettings, asHTML: false})}
                         </>
                     );
                 },


### PR DESCRIPTION
Fix the name column on the schema tab
<img width="742" height="245" alt="image" src="https://github.com/user-attachments/assets/c499a609-cb61-4305-a6d2-7afafce333a7" />

## Summary by Sourcery

Bug Fixes:
- Correct the schema tab name column rendering so values are shown without HTML markup.