### PR TITLE
chore: build ts with moduleResolution=bundler setting [YTFRONT-2241]

### DIFF
--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -1,8 +1,7 @@
 import type React from 'react';
 import {type Reducer} from 'redux';
 
-import {type DropdownMenuItem} from '@gravity-ui/uikit';
-import {type SVGIconData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
+import {type DropdownMenuItem, type IconData} from '@gravity-ui/uikit';
 
 import {type MetaTableItem} from '@ytsaurus/components';
 import {type LocationParameters, type PathParameters} from '../store/location';
@@ -61,7 +60,7 @@ export type UIFactoryRootPageInfo = HeaderItemOrPage & {
 export interface UIFactoryClusterPageInfo {
     title: string;
     pageId: string; // also used as urlMatch for <Route path={`/:cluster/${pageId}`} ... />
-    svgIcon?: SVGIconData;
+    svgIcon?: IconData;
     reducers?: Record<string, Reducer<any, any>>;
     reactComponent: React.ComponentType<any>; // used as component for <Route ... component={reactComponent} />
     topRowComponent?: React.ComponentType<any>; // used as component for <Route ... component={topRowComponent} />

--- a/packages/ui/src/ui/components/QueryStatus/index.tsx
+++ b/packages/ui/src/ui/components/QueryStatus/index.tsx
@@ -2,7 +2,7 @@ import {Icon, Spin} from '@gravity-ui/uikit';
 import React from 'react';
 import block from 'bem-cn-lite';
 import hammer from '../../common/hammer';
-import {type SVGIconData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
+import {type IconData} from '@gravity-ui/uikit';
 import {ProgressStatuses, QueryStatus} from '../../types/query-tracker';
 import CircleExclamationIcon from '@gravity-ui/icons/svgs/circle-exclamation.svg';
 import CircleCheckIcon from '@gravity-ui/icons/svgs/circle-check.svg';
@@ -18,7 +18,7 @@ type Props = {
     className?: string;
 };
 
-const STATUS_ICONS: Partial<Record<QueryStatus, SVGIconData>> = {
+const STATUS_ICONS: Partial<Record<QueryStatus, IconData>> = {
     [QueryStatus.DRAFT]: FileIcon,
     [QueryStatus.FAILED]: CircleExclamationIcon,
     [QueryStatus.ABORTED]: CircleStopIcon,

--- a/packages/ui/src/ui/components/YTGraph/canvas/YTGrapCanvasBlock.ts
+++ b/packages/ui/src/ui/components/YTGraph/canvas/YTGrapCanvasBlock.ts
@@ -2,7 +2,7 @@ import {CanvasBlock} from '@gravity-ui/graph';
 import {GRAPH_BACKGROUND_COLORS, GRAPH_COLORS} from '../constants';
 import {type YTGraphBlock} from '../types';
 import {svgDataToBase} from '../utils/iconToBase';
-import {type SVGIconSvgrData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
+import {type SVGIconSvgrData} from '../../../types/uikit';
 
 export const DEFAULT_PADDING = 10;
 

--- a/packages/ui/src/ui/components/YTGraph/config.tsx
+++ b/packages/ui/src/ui/components/YTGraph/config.tsx
@@ -7,12 +7,12 @@ import {
     ECanDrag,
     type TBlock,
     type TConnection,
+    type TGraphColors,
 } from '@gravity-ui/graph';
 
 import {type HookGraphParams, MultipointConnection, useElk} from '@gravity-ui/graph/react';
 
 import {type RecursivePartial} from '@gravity-ui/graph/build/utils/types/helpers';
-import {type TGraphColors} from '@gravity-ui/graph/build/graphConfig';
 
 import {getCssColor} from '../../utils/get-css-color';
 import {useMemoizedIfEqual} from '../../hooks';

--- a/packages/ui/src/ui/components/YTGraph/utils/iconToBase.tsx
+++ b/packages/ui/src/ui/components/YTGraph/utils/iconToBase.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import {renderToString} from 'react-dom/server';
+import {type SVGIconSvgrData} from '../../../types/uikit';
 import {GRAPH_COLORS} from '../constants';
-import {type SVGIconSvgrData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
 
 export function svgDataToBase(IconComponent: SVGIconSvgrData, color?: string) {
     return iconToBase(<IconComponent />, color);

--- a/packages/ui/src/ui/constants/slideoutMenu.ts
+++ b/packages/ui/src/ui/constants/slideoutMenu.ts
@@ -16,7 +16,7 @@ import pageQueries from '../assets/img/svg/page-query-tracker.svg';
 import pageChyt from '../assets/img/svg/page-chyt.svg';
 
 import {Page} from './index';
-import {type SVGIconData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
+import {type IconData} from '@gravity-ui/uikit';
 
 export const PAGES_WITH_ICONS = [
     {id: Page.ACCOUNTS, icon: accountsIcon},
@@ -47,7 +47,7 @@ export const PAGE_ICONS_BY_ID = PAGES_WITH_ICONS.reduce(
 
 export const emptyPageIcon = pageNoIcon;
 
-export function registerPageIcon(pageId: string, svgIcon: SVGIconData) {
+export function registerPageIcon(pageId: string, svgIcon: IconData) {
     if (PAGE_ICONS_BY_ID[pageId]) {
         throw new Error(`Icon for page '${pageId}' already registered`);
     }

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/types.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/types.ts
@@ -1,4 +1,4 @@
-import {type PluginWidgetProps} from '@gravity-ui/dashkit/build/esm';
+import {type PluginWidgetProps} from '@gravity-ui/dashkit';
 import {type ColumnSortByInfo} from '../../../../../pages/navigation/modals/TableMergeSortModal/TableSortByControl';
 
 export type AccountsWidgetData = {

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/types.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Operations/types.ts
@@ -1,4 +1,4 @@
-import {type PluginWidgetProps} from '@gravity-ui/dashkit/build/esm';
+import {type PluginWidgetProps} from '@gravity-ui/dashkit';
 
 export type Author = {
     value: string;

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/utils/mocks.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/utils/mocks.ts
@@ -1,4 +1,4 @@
-import {type PluginWidgetProps} from '@gravity-ui/dashkit/build/esm';
+import {type PluginWidgetProps} from '@gravity-ui/dashkit';
 
 export const baseWidgetProps: PluginWidgetProps = {
     params: {},

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/FlowGraph.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/FlowGraph.tsx
@@ -9,7 +9,7 @@ import ClockIcon from '@gravity-ui/icons/svgs/clock.svg';
 import FileCodeIcon from '@gravity-ui/icons/svgs/file-code.svg';
 import ReceiptIcon from '@gravity-ui/icons/svgs/receipt.svg';
 import {Flex} from '@gravity-ui/uikit';
-import {type SVGIconSvgrData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
+import {type SVGIconSvgrData} from '../../../../types/uikit';
 import cn from 'bem-cn-lite';
 import partition_ from 'lodash/partition';
 import React from 'react';

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/ComputationCanvas.ts
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/ComputationCanvas.ts
@@ -1,6 +1,6 @@
 import CpuIcon from '@gravity-ui/icons/svgs/cpu.svg';
 
-import {type TAnchor} from '@gravity-ui/graph/build';
+import {type TAnchor} from '@gravity-ui/graph';
 
 import format from '../../../../../common/hammer/format';
 import {

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowGraphRenderer.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowGraphRenderer.tsx
@@ -2,7 +2,7 @@ import cn from 'bem-cn-lite';
 import React from 'react';
 
 import {Dialog, Flex, Icon, Text} from '@gravity-ui/uikit';
-import {type SVGIconSvgrData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
+import {type IconData} from '@gravity-ui/uikit';
 
 import {type FlowMessageType, type FlowNodeStatusType} from '../../../../../../shared/yt-types';
 import format from '../../../../../common/hammer/format';
@@ -21,7 +21,7 @@ import './FlowGraphRenderer.scss';
 
 const block = cn('yt-flow-graph-renderer');
 
-export function FlowIcon({data}: {data?: SVGIconSvgrData}) {
+export function FlowIcon({data}: {data?: IconData}) {
     return !data ? null : (
         <Flex shrink={0}>
             <Icon className={block('icon')} data={data} />

--- a/packages/ui/src/ui/pages/navigation/Navigation/NavigationError/NavigationErrorImage.tsx
+++ b/packages/ui/src/ui/pages/navigation/Navigation/NavigationError/NavigationErrorImage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Icon} from '@gravity-ui/uikit';
 import {AccessDenied, NotFound} from '@gravity-ui/illustrations';
-import {type SVGIconData} from '@gravity-ui/uikit/build/esm/components/Icon/types';
+import {type IconData} from '@gravity-ui/uikit';
 
 import {type ErrorCode} from './helpers';
 
@@ -10,7 +10,7 @@ type Props = {
 };
 
 type ImageMap = {
-    [key in ErrorCode]: SVGIconData;
+    [key in ErrorCode]: IconData;
 };
 
 const ErrorImages: ImageMap = {

--- a/packages/ui/src/ui/pages/query-tracker/QueryACO/QueryACOSelect/hideSharedAco.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryACO/QueryACOSelect/hideSharedAco.ts
@@ -1,4 +1,4 @@
-import {type SelectOption} from '@gravity-ui/uikit/build/esm/components/Select/types';
+import {type SelectOption} from '@gravity-ui/uikit';
 import {SHARED_QUERY_ACO} from '../../../../store/selectors/query-tracker/query';
 
 export function hideSharedAco<T extends string | SelectOption>(aco: T[]): T[] {

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelector.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelector.tsx
@@ -1,7 +1,5 @@
 import React, {type ReactElement} from 'react';
-import {Select, type SelectProps, TextInput} from '@gravity-ui/uikit';
-import {type Option} from '@gravity-ui/uikit/build/esm/components/Select/tech-components';
-import {type SelectOption} from '@gravity-ui/uikit/build/esm/components/Select/types';
+import {Select, type SelectOption, type SelectProps, TextInput} from '@gravity-ui/uikit';
 import './QuerySelector.scss';
 import cn from 'bem-cn-lite';
 
@@ -12,7 +10,7 @@ type Props<T> = {
     items: T[];
     value?: string;
     onChange: (value: string) => void;
-    children: (items: T[]) => ReactElement<SelectOption<T>, typeof Option>[];
+    children: (items: T[]) => ReactElement<SelectOption<T>, typeof Select.Option>[];
 } & Omit<SelectProps, 'children' | 'onUpdate' | 'value'>;
 
 export const QuerySelector = <T,>({

--- a/packages/ui/src/ui/store/api/yt/types.ts
+++ b/packages/ui/src/ui/store/api/yt/types.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {type TypedUseQueryStateOptions} from '@reduxjs/toolkit/dist/query/react';
+import {type TypedUseQueryStateOptions} from '@reduxjs/toolkit/query/react';
 
 import {
     type BaseQueryFn,

--- a/packages/ui/src/ui/store/reducers/navigation/modals/delete-object.ts
+++ b/packages/ui/src/ui/store/reducers/navigation/modals/delete-object.ts
@@ -1,4 +1,4 @@
-import {type Action} from 'redux/dist/redux';
+import {type Action} from 'redux';
 import {
     CLOSE_DELETE_OBJECT_POPUP,
     DELETE_OBJECT,

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
@@ -1,5 +1,5 @@
 import intersection_ from 'lodash/intersection';
-import {type SelectOption} from '@gravity-ui/uikit/build/esm/components/Select/types';
+import {type SelectOption} from '@gravity-ui/uikit';
 import {type RootState} from '../../reducers';
 import {getSettingsData} from '../settings/settings-base';
 import {createSelector} from 'reselect';

--- a/packages/ui/src/ui/tsconfig.json
+++ b/packages/ui/src/ui/tsconfig.json
@@ -1,16 +1,17 @@
 {
   "extends": "../../tsconfig",
   "include": ["**/*", "@types/*"],
-  "exclude": ["../server/*", "../playwright-components/*"],
+  "exclude": ["../server/*", "./playwright-components/*"],
   "compilerOptions": {
     "declaration": true,
     "module": "ESNext",
+    "moduleResolution": "bundler",
     "target": "ES2018",
     "isolatedModules": true,
     "outDir": "../../dist/public/build",
     "baseUrl": ".",
     "paths": {
-      "*": ["../../node_modules/*"]
+      "@gravity-ui/graph/build/*": ["../../node_modules/@gravity-ui/graph/build/*"]
     },
     "jsx": "react",
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"]

--- a/packages/ui/src/ui/types/uikit/index.ts
+++ b/packages/ui/src/ui/types/uikit/index.ts
@@ -1,0 +1,4 @@
+import type React from 'react';
+import {type IconData} from '@gravity-ui/uikit';
+
+export type SVGIconSvgrData = Extract<IconData, React.FC<any>>;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Vk3eGyrG7aqu8i
<!-- nda-end -->

## Summary by Sourcery

Update UI package TypeScript configuration and UIKit-related typings to align with bundler-style module resolution.

Enhancements:
- Adjust UI tsconfig to use bundler module resolution, refine excluded paths, and narrow path mappings for graph imports.
- Switch UIKit and Dashkit imports to package-level entry points and centralize UIKit SVG icon typing in a local shared type helper.
- Simplify QuerySelector typings by referencing Select.Option directly in the children render prop signature.