### PR TITLE
fix(server/configure-app): check clusterConfigPath,ytInterfaceSecret on start [YTFRONT-5764]

### DIFF
--- a/packages/ui/src/server/configs/e2e/local.ts
+++ b/packages/ui/src/server/configs/e2e/local.ts
@@ -2,6 +2,9 @@ import {type AppConfig} from '@gravity-ui/nodekit';
 import common from '../common';
 
 const e2eConfig: Partial<AppConfig> = {
+    ytInterfaceSecret: undefined,
+    clustersConfigPath: undefined,
+
     uiSettings: {
         defaultFontType: 'internal',
         newTableReplicasCount: 1,

--- a/packages/ui/src/server/configs/local.ts
+++ b/packages/ui/src/server/configs/local.ts
@@ -5,6 +5,7 @@ import {type AppConfig} from '@gravity-ui/nodekit';
 const localModeConfig: Partial<AppConfig> = {
     ytAuthAllowInsecure: true,
 
+    clustersConfigPath: undefined,
     ytInterfaceSecret: undefined,
 
     expressBodyParserJSONConfig: {

--- a/packages/ui/src/server/configure-app.ts
+++ b/packages/ui/src/server/configure-app.ts
@@ -5,6 +5,18 @@ import {rememberApp} from './ServerFactory';
 export function configureApp(app: ExpressKit) {
     rememberApp(app);
 
+    if (app.config.ytInterfaceSecret) {
+        // Check if file is loadable
+        // eslint-disable-next-line security/detect-non-literal-require
+        require(app.config.ytInterfaceSecret);
+    }
+
+    if (app.config.clustersConfigPath) {
+        // check if file is loadable
+        // eslint-disable-next-line security/detect-non-literal-require
+        require(app.config.clustersConfigPath);
+    }
+
     if (app.config.appDevMode) {
         const sourceMaps = require('source-map-support');
         sourceMaps.install();


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Vgr3Mv1L7awAFX
<!-- nda-end -->  ## Summary by Sourcery

Validate critical server configuration files on application startup to fail fast when they are missing or invalid.

Bug Fixes:
- Ensure the server checks that ytInterfaceSecret and clustersConfigPath files are loadable during startup to surface configuration issues early.

Enhancements:
- Explicitly define ytInterfaceSecret and clustersConfigPath as undefined in local and e2e local server configs to avoid accidental configuration leakage between environments.