### PR TITLE
chore(ACL): fix for i18n [YTFRONT-5069]

### DIFF
--- a/packages/ui/src/ui/containers/ACL/RequestPermissions/RequestPermissions.tsx
+++ b/packages/ui/src/ui/containers/ACL/RequestPermissions/RequestPermissions.tsx
@@ -320,9 +320,9 @@ function RequestPermissions(props: Props) {
     }, [availableFields, requestPermissionsFields, aclMode]);
 
     const {
-        editAcl = 'Add ACL',
-        editColumnsAcl = 'Add columns ACL',
-        editRowsAcl = 'Add rows ACL',
+        editAcl = i18n('title_add-acl'),
+        editColumnsAcl = i18n('title_add-columns-acl'),
+        editRowsAcl = i18n('title_add-rows-acl'),
     } = buttonsTitle ?? {};
     let title = editAcl;
     switch (aclMode) {

--- a/packages/ui/src/ui/containers/ACL/RequestPermissions/i18n/en.json
+++ b/packages/ui/src/ui/containers/ACL/RequestPermissions/i18n/en.json
@@ -1,4 +1,7 @@
 {
+  "title_add-acl": "Add ACL",
+  "title_add-columns-acl": "Add columns ACL",
+  "title_add-rows-acl": "Add rows ACL",
   "field_cluster": "Cluster",
   "field_current_path": "Current path",
   "field_current_ui_effective_acl": "Current path",


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/wSV_dlRC7axJwL
<!-- nda-end -->## Summary by Sourcery

Use i18n keys for default ACL button titles in the RequestPermissions component instead of hardcoded English strings.