### PR TITLE
fix(ACL): pass `name` field to `updateAcl` [YTFRONT-5762]

### DIFF
--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
@@ -99,7 +99,7 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
                                   required: true,
                                   extras: {
                                       placeholder: i18n('field_responsible-users-placeholder'),
-                                      allowedTypes: ['users'],
+                                      allowedTypes: ['users', 'groups'],
                                   },
                               },
                           ]

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
@@ -1,22 +1,20 @@
 import cn from 'bem-cn-lite';
 import React from 'react';
 import {type ConnectedProps, connect} from 'react-redux';
-
-import i18n from './i18n';
-
 import {type DialogField, type FormApi, YTDFDialog} from '../../../../../components/Dialog';
-import {closeCreateModal} from '../../../../../store/actions/accounts/editor';
-import {loadEditedAccount} from '../../../../../store/actions/accounts/accounts';
-import {createAccountFromInfo} from '../../../../../utils/accounts/editor';
-import {selectCluster, selectCurrentUserName} from '../../../../../store/selectors/global';
-import {selectIsAdmin} from '../../../../../store/selectors/global/is-developer';
-import {selectActiveAccount} from '../../../../../store/selectors/accounts/accounts';
-import {ROOT_ACCOUNT_NAME} from '../../../../../constants/accounts/accounts';
-
-import './AccountCreateDialog.scss';
-import {type RootState} from '../../../../../store/reducers';
 import {isIdmAclAvailable} from '../../../../../config';
+import {ROOT_ACCOUNT_NAME} from '../../../../../constants/accounts/accounts';
+import {loadEditedAccount} from '../../../../../store/actions/accounts/accounts';
+import {closeCreateModal} from '../../../../../store/actions/accounts/editor';
+import {createAccountFromInfo} from '../../../../../store/actions/accounts/editor-ts';
+import {type RootState} from '../../../../../store/reducers';
+import {selectActiveAccount} from '../../../../../store/selectors/accounts/accounts';
+import {selectCurrentUserName} from '../../../../../store/selectors/global';
+import {selectIsAdmin} from '../../../../../store/selectors/global/is-developer';
 import {isAbcAllowed} from '../../../../../UIFactory';
+import {type ResponsibleType} from '../../../../../utils/acl/acl-types';
+import './AccountCreateDialog.scss';
+import i18n from './i18n';
 
 const block = cn('account-create-dialog');
 
@@ -24,7 +22,7 @@ interface FormValues {
     abcService?: {slug: string; id: number};
     account: string;
     parentAccount: string;
-    responsibles: Array<unknown>;
+    responsibles: Array<ResponsibleType>;
     createHome: boolean;
 }
 
@@ -121,13 +119,13 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
     }
 
     onSubmit = (form: FormApi<FormValues>) => {
-        const {createAccountFromInfo, closeCreateModal, loadEditedAccount, cluster} = this.props;
+        const {createAccountFromInfo, closeCreateModal, loadEditedAccount} = this.props;
         const newAccountInfo = form.getState().values;
         if (!isRootAccount(newAccountInfo.parentAccount)) {
             newAccountInfo.abcService = undefined;
         }
 
-        return createAccountFromInfo(cluster, newAccountInfo).then(() => {
+        return createAccountFromInfo(newAccountInfo).then(() => {
             closeCreateModal();
             const {account} = newAccountInfo;
             loadEditedAccount(account);
@@ -148,7 +146,6 @@ const mapStateToProps = (state: RootState) => {
         activeAccount: selectActiveAccount(state),
         visible: editor.createModalVisible,
         newAccountInfo: editor.newAccountInfo as FormValues,
-        cluster: selectCluster(state),
         isAdmin: selectIsAdmin(state),
     };
 };

--- a/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
@@ -1,35 +1,32 @@
-import React, {useCallback, useMemo, useState} from 'react';
-import {useDispatch, useSelector} from '../../../../store/redux-hooks';
-
-import sortedIndexOf_ from 'lodash/sortedIndexOf';
 import isEmpty_ from 'lodash/isEmpty';
-
-import Link from '../../../../components/Link/Link';
-import {YTErrorBlock} from '../../../../components/Error/Error';
-import {type FormApi, YTDFDialog} from '../../../../components/Dialog';
+import sortedIndexOf_ from 'lodash/sortedIndexOf';
+import React, {useCallback, useMemo, useState} from 'react';
 import Button from '../../../../components/Button/Button';
-
+import {type FormApi, YTDFDialog} from '../../../../components/Dialog';
+import {YTErrorBlock} from '../../../../components/Error/Error';
+import Link from '../../../../components/Link/Link';
+import {docsUrl, isIdmAclAvailable} from '../../../../config';
+import {uiSettings} from '../../../../config/ui-settings';
+import {SCHEDULING_CREATE_POOL_CANCELLED} from '../../../../constants/scheduling';
+import {
+    createPool,
+    fetchCreatePoolDialogTreeItems,
+} from '../../../../store/actions/scheduling/create-pool-dialog';
+import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {selectCurrentUserName} from '../../../../store/selectors/global';
+import {
+    getCreatePoolDialogError,
+    getCreatePoolDialogFlatTreeItems,
+} from '../../../../store/selectors/scheduling/create-pool-dialog';
 import {
     getIsRoot,
     getPool,
     getTree,
     getTreesSelectItems,
 } from '../../../../store/selectors/scheduling/scheduling';
-
-import {
-    createPool,
-    fetchCreatePoolDialogTreeItems,
-} from '../../../../store/actions/scheduling/create-pool-dialog';
-import {
-    getCreatePoolDialogError,
-    getCreatePoolDialogFlatTreeItems,
-} from '../../../../store/selectors/scheduling/create-pool-dialog';
 import {type FIX_MY_TYPE} from '../../../../types';
-import {SCHEDULING_CREATE_POOL_CANCELLED} from '../../../../constants/scheduling';
-import {docsUrl, isIdmAclAvailable} from '../../../../config';
 import UIFactory from '../../../../UIFactory';
-import {uiSettings} from '../../../../config/ui-settings';
+import {type ResponsibleType} from '../../../../utils/acl/acl-types';
 
 const allowRoot = !uiSettings.schedulingDenyRootAsParent;
 
@@ -59,7 +56,8 @@ interface FormValues {
     name: string;
     tree: string;
     parent: string;
-    responsible: {value: string; id: string | number; title: string};
+    responsible: Array<ResponsibleType>;
+    abcService: {value: string; id: number; title: string};
 }
 
 function CreatePoolDialog(props: {onClose: () => void}) {
@@ -84,7 +82,7 @@ function CreatePoolDialog(props: {onClose: () => void}) {
     const pool = useSelector(getPool);
 
     const handleCreateConfirm = useCallback(
-        (form: FormApi) => {
+        (form: FormApi<FormValues>) => {
             const {values} = form.getState();
             return dispatch(createPool(values));
         },

--- a/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
+++ b/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
@@ -13,8 +13,8 @@ import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 import {RESOURCES_LIMITS_PREFIX} from '../../../constants/accounts';
 import {ROOT_ACCOUNT_NAME} from '../../../constants/accounts/accounts';
 import {IdmObjectType} from '../../../constants/acl';
-import {selectCluster} from '../../../store/selectors/global';
-import {updateAcl} from '../../../utils/acl/acl-api';
+import {updateAcl} from '../../../store/actions/acl';
+import UIFactory from '../../../UIFactory';
 import {type ResponsibleType} from '../../../utils/acl/acl-types';
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {accountsIncreaseEditCounter, loadEditedAccount} from './accounts';
@@ -75,15 +75,27 @@ function setResponsibleUsers(
     accountName: string,
     inheritAcl: boolean,
 ): EditorAction {
-    return (_dispatch, getState) => {
-        const path = accountName;
-        const cluster = selectCluster(getState());
+    return (dispatch) => {
+        if (!UIFactory.getAclApi().isAllowed) {
+            return Promise.resolve();
+        }
 
-        return updateAcl(cluster, path, {
-            idmKind: IdmObjectType.ACCOUNT,
-            responsible: users,
-            inheritAcl,
-        });
+        return Promise.all([
+            dispatch(
+                updateAcl({
+                    path: accountName,
+                    idmKind: IdmObjectType.ACCOUNT,
+                    values: {responsible: users},
+                }),
+            ),
+            dispatch(
+                updateAcl({
+                    path: accountName,
+                    idmKind: IdmObjectType.ACCOUNT,
+                    values: {inheritAcl},
+                }),
+            ),
+        ]);
     };
 }
 

--- a/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
+++ b/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
@@ -1,15 +1,23 @@
 import update_ from 'lodash/update';
-
-import {type RootState} from '../../../store/reducers';
-import {setAccountLimit} from '../../../utils/accounts/editor';
 import {type ThunkAction} from 'redux-thunk';
+import {type RootState} from '../../../store/reducers';
 import {type FIX_MY_TYPE} from '../../../types';
-
+import {
+    createAccount,
+    createAccountHome,
+    setAccountAbc,
+    setAccountLimit,
+} from '../../../utils/accounts/editor';
 // @ts-ignore
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 import {RESOURCES_LIMITS_PREFIX} from '../../../constants/accounts';
-import {accountsIncreaseEditCounter, loadEditedAccount} from './accounts';
+import {ROOT_ACCOUNT_NAME} from '../../../constants/accounts/accounts';
+import {IdmObjectType} from '../../../constants/acl';
+import {selectCluster} from '../../../store/selectors/global';
+import {updateAcl} from '../../../utils/acl/acl-api';
+import {type ResponsibleType} from '../../../utils/acl/acl-types';
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
+import {accountsIncreaseEditCounter, loadEditedAccount} from './accounts';
 import i18n from './i18n';
 
 export interface AccountQuotaParams {
@@ -58,6 +66,49 @@ export function setAccountQuota(params: AccountQuotaParams): EditorAction {
         }).then(() => {
             dispatch(loadEditedAccount(params.account));
             dispatch(accountsIncreaseEditCounter());
+        });
+    };
+}
+
+function setResponsibleUsers(
+    users: Array<ResponsibleType>,
+    accountName: string,
+    inheritAcl: boolean,
+): EditorAction {
+    return (_dispatch, getState) => {
+        const path = accountName;
+        const cluster = selectCluster(getState());
+
+        return updateAcl(cluster, path, {
+            idmKind: IdmObjectType.ACCOUNT,
+            responsible: users,
+            inheritAcl,
+        });
+    };
+}
+
+export interface NewAccountInfo {
+    abcService?: {slug: string; id: number};
+    account: string;
+    parentAccount: string;
+    responsibles: Array<ResponsibleType>;
+    createHome: boolean;
+}
+
+export function createAccountFromInfo(newAccountInfo: NewAccountInfo): EditorAction {
+    return (dispatch) => {
+        const {abcService, account, parentAccount, responsibles, createHome} = newAccountInfo;
+
+        return createAccount(account, parentAccount).then(() => {
+            const {id, slug} = abcService || {};
+
+            return Promise.all([
+                setAccountAbc(account, id, slug).catch(() => {}),
+                createHome ? createAccountHome(account).catch(() => {}) : Promise.resolve(),
+                dispatch(
+                    setResponsibleUsers(responsibles, account, parentAccount !== ROOT_ACCOUNT_NAME),
+                ).catch(() => {}),
+            ]);
         });
     };
 }

--- a/packages/ui/src/ui/store/actions/acl.ts
+++ b/packages/ui/src/ui/store/actions/acl.ts
@@ -401,6 +401,7 @@ export function updateAcl(
                     version,
                     idmKind,
                     poolTree,
+                    name: path,
                 });
             })
             .then(() => {

--- a/packages/ui/src/ui/store/actions/scheduling/create-pool-dialog.tsx
+++ b/packages/ui/src/ui/store/actions/scheduling/create-pool-dialog.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
 import {type ThunkAction} from 'redux-thunk';
+import {
+    CREATE_POOL_DIALOG_TREE_CREATE_FAILURE,
+    CREATE_POOL_DIALOG_TREE_ITEMS_SUCCESS,
+} from '../../../constants/scheduling';
 import {type RootState} from '../../reducers';
 import {
     type CreatePoolDialogAction,
     type CreatePoolDialogState,
 } from '../../reducers/scheduling/create-pool-dialog';
-import {
-    CREATE_POOL_DIALOG_TREE_CREATE_FAILURE,
-    CREATE_POOL_DIALOG_TREE_ITEMS_SUCCESS,
-} from '../../../constants/scheduling';
 // @ts-ignore
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
+import Link from '../../../components/Link/Link';
+import {createAdminReqTicketUrl} from '../../../config';
+import {IdmObjectType} from '../../../constants/acl';
+import {YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
+import {updateAcl} from '../../../store/actions/acl';
+import UIFactory from '../../../UIFactory';
+import {type ResponsibleType} from '../../../utils/acl/acl-types';
 import {prepareAbcService} from '../../../utils/scheduling';
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {loadSchedulingData} from './scheduling-ts';
-import {type FIX_MY_TYPE} from '../../../types';
-import {selectCluster} from '../../selectors/global';
-import {updateAcl} from '../../../utils/acl/acl-api';
-import {IdmObjectType} from '../../../constants/acl';
-import Link from '../../../components/Link/Link';
-import {YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
-import {createAdminReqTicketUrl} from '../../../config';
 
-type CreatePoolDialogThunkAction<R = any> = ThunkAction<
+type CreatePoolDialogThunkAction<R = void> = ThunkAction<
     R,
     RootState,
     unknown,
@@ -42,19 +42,28 @@ export function fetchCreatePoolDialogTreeItems(currentTree: string): CreatePoolD
     };
 }
 
-export function createPool(values: FIX_MY_TYPE): CreatePoolDialogThunkAction {
-    return (dispatch, getState) => {
-        const {abcService} = values;
-        const cluster = selectCluster(getState()) as string;
-
+export function createPool({
+    name,
+    parent,
+    tree,
+    responsible,
+    abcService,
+}: {
+    name: string;
+    parent?: string;
+    tree: string;
+    responsible: Array<ResponsibleType>;
+    abcService: {value: string; title: string; id: number};
+}): CreatePoolDialogThunkAction {
+    return (dispatch) => {
         return wrapApiPromiseByToaster(
             yt.v3.create({
                 type: 'scheduler_pool',
                 attributes: Object.assign(
                     {
-                        name: values.name,
-                        parent_name: values.parent || undefined,
-                        pool_tree: values.tree,
+                        name,
+                        parent_name: parent || undefined,
+                        pool_tree: tree,
                     },
                     !abcService || !abcService.value
                         ? {}
@@ -64,26 +73,30 @@ export function createPool(values: FIX_MY_TYPE): CreatePoolDialogThunkAction {
                 ),
             }),
             {
-                toasterName: `create_${values.name}`,
-                successContent: `Successfully created ${values.name}. Please wait.`,
-                errorContent: `'${values.name}' pool creation failed`,
+                toasterName: `create_${name}`,
+                successContent: `Successfully created ${name}. Please wait.`,
+                errorContent: `'${name}' pool creation failed`,
                 timeout: 10000,
             },
         )
             .then(() => {
-                updateAcl(cluster, values.name, {
-                    idmKind: IdmObjectType.POOL,
-                    poolTree: values.tree,
-                    responsible: values.responsible,
-                });
+                return waitWhilePoolIsReady({name, tree}).then(() => {
+                    if (UIFactory.getAclApi().isAllowed) {
+                        dispatch(
+                            updateAcl({
+                                values: {responsible},
+                                path: name,
+                                idmKind: IdmObjectType.POOL,
+                            }),
+                        );
+                    }
 
-                return waitWhilePoolIsReady(values).then(() => {
                     dispatch(loadSchedulingData());
                 });
             })
             .catch((error) => {
                 if (error?.code === yt.codes.CANCELLED) {
-                    return;
+                    return undefined;
                 }
 
                 dispatch({

--- a/packages/ui/src/ui/utils/accounts/editor.js
+++ b/packages/ui/src/ui/utils/accounts/editor.js
@@ -2,11 +2,8 @@ import reduce_ from 'lodash/reduce';
 
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 
-import {ROOT_ACCOUNT_NAME} from '../../constants/accounts/accounts';
 import {EDITOR_TABS} from '../../constants/accounts/editor';
-import {IdmObjectType} from '../../constants/acl';
 import {showErrorPopup} from '../../utils/utils';
-import {updateAcl} from '../../utils/acl/acl-api';
 import {toaster} from '../toaster';
 import i18n from './i18n';
 
@@ -25,43 +22,12 @@ const EDITOR_TAB_LABELS = {
     [EDITOR_TABS.delete]: () => i18n('value_delete'),
 };
 
-export function setResponsibleUsers(cluster, users, accountName, inheritAcl) {
-    const path = accountName;
-
-    return updateAcl(cluster, path, {
-        idmKind: IdmObjectType.ACCOUNT,
-        responsible: users,
-        inheritAcl,
-    });
-}
-
 export function setAccountLimit(input, accountName, resourcePath) {
     const path = basePath + accountName + resourcePath;
     return yt.v3.set({path}, input);
 }
 
-export function createAccountFromInfo(cluster, newAccountInfo) {
-    return () => {
-        const {abcService, account, parentAccount, responsibles, createHome} = newAccountInfo;
-
-        return createAccount(account, parentAccount).then(() => {
-            const {id, slug} = abcService || {};
-
-            return Promise.all([
-                setAccountAbc(account, id, slug).catch(() => {}),
-                createHome ? createAccountHome(account).catch(() => {}) : Promise.resolve(),
-                setResponsibleUsers(
-                    cluster,
-                    responsibles,
-                    account,
-                    parentAccount !== ROOT_ACCOUNT_NAME,
-                ).catch(() => {}),
-            ]);
-        });
-    };
-}
-
-function createAccount(accountName, parentName) {
+export function createAccount(accountName, parentName) {
     return yt.v3
         .create({
             type: 'account',

--- a/packages/ui/src/ui/utils/acl/acl-api.ts
+++ b/packages/ui/src/ui/utils/acl/acl-api.ts
@@ -62,15 +62,6 @@ export function getAcl({
     return api.getAcl({cluster, path, kind, poolTree, sysPath});
 }
 
-export function updateAcl(cluster: string, path: string, params: UpdateAclParams) {
-    const api = UIFactory.getAclApi();
-    if (!api.isAllowed) {
-        return Promise.resolve();
-    }
-
-    return api.updateAcl(cluster, path, params);
-}
-
 export const getResponsible = async ({
     cluster,
     path,

--- a/packages/ui/src/ui/utils/acl/acl-types.ts
+++ b/packages/ui/src/ui/utils/acl/acl-types.ts
@@ -280,4 +280,5 @@ export interface UpdateAclParams {
     version?: string;
     poolTree?: string;
     comment?: string;
+    name: string;
 }

--- a/packages/ui/src/ui/utils/acl/acl-types.ts
+++ b/packages/ui/src/ui/utils/acl/acl-types.ts
@@ -42,7 +42,7 @@ export interface GetGroupResponse {
 }
 
 export interface UpdateResponse {
-    status: RoleUpdateStatus | Array<RoleUpdateStatus>;
+    status: RoleUpdateStatus | Array<RoleUpdateStatus> | undefined;
 }
 
 export interface RoleUpdateStatus {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/c68Wry-e7cFYUU
<!-- nda-end -->  ## Summary by Sourcery

Update ACL handling to pass object name and integrate responsible user assignment via Redux actions for accounts and pools.

New Features:
- Add Redux thunk to create accounts and set responsible users through the centralized ACL update action.
- Support specifying responsible users and ABC service when creating scheduling pools via the create pool dialog.

Bug Fixes:
- Ensure ACL updates include the name field when calling the ACL API to fix missing-name issues.

Enhancements:
- Refactor account and pool creation flows to use shared ACL update actions instead of direct ACL API calls.
- Strongly type create pool and account creation forms with explicit ResponsibleType and ABC service structures.