### PR TITLE
Hotfix v3.9.0

### DIFF
--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
@@ -99,7 +99,7 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
                                   required: true,
                                   extras: {
                                       placeholder: i18n('field_responsible-users-placeholder'),
-                                      allowedTypes: ['users'],
+                                      allowedTypes: ['users', 'groups'],
                                   },
                               },
                           ]

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
@@ -1,20 +1,20 @@
 import cn from 'bem-cn-lite';
 import React from 'react';
-import {ConnectedProps, connect} from 'react-redux';
-
-import {DialogField, FormApi, YTDFDialog} from '../../../../../components/Dialog';
-import {closeCreateModal} from '../../../../../store/actions/accounts/editor';
-import {loadEditedAccount} from '../../../../../store/actions/accounts/accounts';
-import {createAccountFromInfo} from '../../../../../utils/accounts/editor';
-import {selectCluster, selectCurrentUserName} from '../../../../../store/selectors/global';
-import {selectIsAdmin} from '../../../../../store/selectors/global/is-developer';
-import {getActiveAccount} from '../../../../../store/selectors/accounts/accounts';
-import {ROOT_ACCOUNT_NAME} from '../../../../../constants/accounts/accounts';
-
-import './AccountCreateDialog.scss';
-import {RootState} from '../../../../../store/reducers';
+import {type ConnectedProps, connect} from 'react-redux';
+import {type DialogField, type FormApi, YTDFDialog} from '../../../../../components/Dialog';
 import {isIdmAclAvailable} from '../../../../../config';
+import {ROOT_ACCOUNT_NAME} from '../../../../../constants/accounts/accounts';
+import {loadEditedAccount} from '../../../../../store/actions/accounts/accounts';
+import {closeCreateModal} from '../../../../../store/actions/accounts/editor';
+import {createAccountFromInfo} from '../../../../../store/actions/accounts/editor-ts';
+import {type RootState} from '../../../../../store/reducers';
+import {selectActiveAccount} from '../../../../../store/selectors/accounts/accounts';
+import {selectCurrentUserName} from '../../../../../store/selectors/global';
+import {selectIsAdmin} from '../../../../../store/selectors/global/is-developer';
 import {isAbcAllowed} from '../../../../../UIFactory';
+import {type ResponsibleType} from '../../../../../utils/acl/acl-types';
+import './AccountCreateDialog.scss';
+import i18n from './i18n';
 
 const block = cn('account-create-dialog');
 
@@ -22,7 +22,7 @@ interface FormValues {
     abcService?: {slug: string; id: number};
     account: string;
     parentAccount: string;
-    responsibles: Array<unknown>;
+    responsibles: Array<ResponsibleType>;
     createHome: boolean;
 }
 
@@ -41,7 +41,7 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
                 className={block()}
                 visible={visible}
                 onClose={this.onClose}
-                headerProps={{title: 'Create account'}}
+                headerProps={{title: i18n('title_create-account')}}
                 onAdd={this.onSubmit}
                 pristineSubmittable
                 initialValues={{
@@ -58,14 +58,14 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
                               {
                                   name: 'abcService',
                                   type: 'abc-control',
-                                  caption: 'Service in ABC',
+                                  caption: i18n('field_abc-service'),
                                   required: true,
                                   visibilityCondition: {
                                       when: 'parentAccount',
                                       isActive: isRootAccount,
                                   },
                                   extras: {
-                                      placeholder: 'Enter ABC service name',
+                                      placeholder: i18n('field_abc-service-placeholder'),
                                   },
                               },
                           ]
@@ -73,20 +73,20 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
                     {
                         name: 'account',
                         type: 'text',
-                        caption: 'Account name',
+                        caption: i18n('field_account-name'),
                         required: true,
                         extras: {
-                            placeholder: 'Enter account name',
+                            placeholder: i18n('field_account-name-placeholder'),
                             className: block('name'),
                         },
                     },
                     {
                         name: 'parentAccount',
                         type: 'accountsSuggest',
-                        caption: 'Parent account',
+                        caption: i18n('field_parent-account'),
                         required: true,
                         extras: {
-                            placeholder: 'Enter parent account name',
+                            placeholder: i18n('field_parent-account-placeholder'),
                             allowRootAccount: isAdmin,
                         },
                     },
@@ -95,10 +95,10 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
                               {
                                   name: 'responsibles',
                                   type: 'acl-subjects',
-                                  caption: 'Responsible users',
+                                  caption: i18n('field_responsible-users'),
                                   required: true,
                                   extras: {
-                                      placeholder: 'Enter name or login',
+                                      placeholder: i18n('field_responsible-users-placeholder'),
                                       allowedTypes: ['users'],
                                   },
                               },
@@ -109,7 +109,7 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
                               {
                                   name: 'createHome',
                                   type: 'tumbler' as const,
-                                  caption: 'Create home directory',
+                                  caption: i18n('field_create-home-directory'),
                               },
                           ]
                         : []),
@@ -119,13 +119,13 @@ class AccountCreateDialog extends React.Component<ConnectedProps<typeof connecto
     }
 
     onSubmit = (form: FormApi<FormValues>) => {
-        const {createAccountFromInfo, closeCreateModal, loadEditedAccount, cluster} = this.props;
+        const {createAccountFromInfo, closeCreateModal, loadEditedAccount} = this.props;
         const newAccountInfo = form.getState().values;
         if (!isRootAccount(newAccountInfo.parentAccount)) {
             newAccountInfo.abcService = undefined;
         }
 
-        return createAccountFromInfo(cluster, newAccountInfo).then(() => {
+        return createAccountFromInfo(newAccountInfo).then(() => {
             closeCreateModal();
             const {account} = newAccountInfo;
             loadEditedAccount(account);
@@ -143,10 +143,9 @@ const mapStateToProps = (state: RootState) => {
     } = state;
     return {
         currentUserName: selectCurrentUserName(state),
-        activeAccount: getActiveAccount(state),
+        activeAccount: selectActiveAccount(state),
         visible: editor.createModalVisible,
         newAccountInfo: editor.newAccountInfo as FormValues,
-        cluster: selectCluster(state),
         isAdmin: selectIsAdmin(state),
     };
 };

--- a/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
@@ -1,35 +1,32 @@
-import React, {useCallback, useMemo, useState} from 'react';
-import {useDispatch, useSelector} from '../../../../store/redux-hooks';
-
-import sortedIndexOf_ from 'lodash/sortedIndexOf';
 import isEmpty_ from 'lodash/isEmpty';
-
-import Link from '../../../../components/Link/Link';
-import {YTErrorBlock} from '../../../../components/Error/Error';
-import {FormApi, YTDFDialog} from '../../../../components/Dialog';
+import sortedIndexOf_ from 'lodash/sortedIndexOf';
+import React, {useCallback, useMemo, useState} from 'react';
 import Button from '../../../../components/Button/Button';
-
+import {type FormApi, YTDFDialog} from '../../../../components/Dialog';
+import {YTErrorBlock} from '../../../../components/Error/Error';
+import Link from '../../../../components/Link/Link';
+import {docsUrl, isIdmAclAvailable} from '../../../../config';
+import {uiSettings} from '../../../../config/ui-settings';
+import {SCHEDULING_CREATE_POOL_CANCELLED} from '../../../../constants/scheduling';
+import {
+    createPool,
+    fetchCreatePoolDialogTreeItems,
+} from '../../../../store/actions/scheduling/create-pool-dialog';
+import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {selectCurrentUserName} from '../../../../store/selectors/global';
+import {
+    getCreatePoolDialogError,
+    getCreatePoolDialogFlatTreeItems,
+} from '../../../../store/selectors/scheduling/create-pool-dialog';
 import {
     getIsRoot,
     getPool,
     getTree,
     getTreesSelectItems,
 } from '../../../../store/selectors/scheduling/scheduling';
-
-import {
-    createPool,
-    fetchCreatePoolDialogTreeItems,
-} from '../../../../store/actions/scheduling/create-pool-dialog';
-import {
-    getCreatePoolDialogError,
-    getCreatePoolDialogFlatTreeItems,
-} from '../../../../store/selectors/scheduling/create-pool-dialog';
-import {FIX_MY_TYPE} from '../../../../types';
-import {SCHEDULING_CREATE_POOL_CANCELLED} from '../../../../constants/scheduling';
-import {docsUrl, isIdmAclAvailable} from '../../../../config';
+import {type FIX_MY_TYPE} from '../../../../types';
 import UIFactory from '../../../../UIFactory';
-import {uiSettings} from '../../../../config/ui-settings';
+import {type ResponsibleType} from '../../../../utils/acl/acl-types';
 
 const allowRoot = !uiSettings.schedulingDenyRootAsParent;
 
@@ -59,7 +56,8 @@ interface FormValues {
     name: string;
     tree: string;
     parent: string;
-    responsible: {value: string; id: string | number; title: string};
+    responsible: Array<ResponsibleType>;
+    abcService: {value: string; id: number; title: string};
 }
 
 function CreatePoolDialog(props: {onClose: () => void}) {
@@ -84,7 +82,7 @@ function CreatePoolDialog(props: {onClose: () => void}) {
     const pool = useSelector(getPool);
 
     const handleCreateConfirm = useCallback(
-        (form: FormApi) => {
+        (form: FormApi<FormValues>) => {
             const {values} = form.getState();
             return dispatch(createPool(values));
         },

--- a/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
+++ b/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
@@ -1,15 +1,24 @@
 import update_ from 'lodash/update';
-
-import {RootState} from '../../../store/reducers';
-import {setAccountLimit} from '../../../utils/accounts/editor';
-import {ThunkAction} from 'redux-thunk';
-import {FIX_MY_TYPE} from '../../../types';
-
+import {type ThunkAction} from 'redux-thunk';
+import {type RootState} from '../../../store/reducers';
+import {type FIX_MY_TYPE} from '../../../types';
+import {
+    createAccount,
+    createAccountHome,
+    setAccountAbc,
+    setAccountLimit,
+} from '../../../utils/accounts/editor';
 // @ts-ignore
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 import {RESOURCES_LIMITS_PREFIX} from '../../../constants/accounts';
-import {accountsIncreaseEditCounter, loadEditedAccount} from './accounts';
+import {ROOT_ACCOUNT_NAME} from '../../../constants/accounts/accounts';
+import {IdmObjectType} from '../../../constants/acl';
+import {selectCluster} from '../../../store/selectors/global';
+import {updateAcl} from '../../../utils/acl/acl-api';
+import {type ResponsibleType} from '../../../utils/acl/acl-types';
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
+import {accountsIncreaseEditCounter, loadEditedAccount} from './accounts';
+import i18n from './i18n';
 
 export interface AccountQuotaParams {
     limit: number;
@@ -53,10 +62,53 @@ export function setAccountQuota(params: AccountQuotaParams): EditorAction {
         const toasterName = params.account + '_' + params.resourcePath;
         return wrapApiPromiseByToaster(setAccountQuotaImpl(params), {
             toasterName,
-            successContent: 'The quota is updated',
+            successContent: i18n('alert_quota-updated'),
         }).then(() => {
             dispatch(loadEditedAccount(params.account));
             dispatch(accountsIncreaseEditCounter());
+        });
+    };
+}
+
+function setResponsibleUsers(
+    users: Array<ResponsibleType>,
+    accountName: string,
+    inheritAcl: boolean,
+): EditorAction {
+    return (_dispatch, getState) => {
+        const path = accountName;
+        const cluster = selectCluster(getState());
+
+        return updateAcl(cluster, path, {
+            idmKind: IdmObjectType.ACCOUNT,
+            responsible: users,
+            inheritAcl,
+        });
+    };
+}
+
+export interface NewAccountInfo {
+    abcService?: {slug: string; id: number};
+    account: string;
+    parentAccount: string;
+    responsibles: Array<ResponsibleType>;
+    createHome: boolean;
+}
+
+export function createAccountFromInfo(newAccountInfo: NewAccountInfo): EditorAction {
+    return (dispatch) => {
+        const {abcService, account, parentAccount, responsibles, createHome} = newAccountInfo;
+
+        return createAccount(account, parentAccount).then(() => {
+            const {id, slug} = abcService || {};
+
+            return Promise.all([
+                setAccountAbc(account, id, slug).catch(() => {}),
+                createHome ? createAccountHome(account).catch(() => {}) : Promise.resolve(),
+                dispatch(
+                    setResponsibleUsers(responsibles, account, parentAccount !== ROOT_ACCOUNT_NAME),
+                ).catch(() => {}),
+            ]);
         });
     };
 }

--- a/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
+++ b/packages/ui/src/ui/store/actions/accounts/editor-ts.tsx
@@ -13,8 +13,8 @@ import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 import {RESOURCES_LIMITS_PREFIX} from '../../../constants/accounts';
 import {ROOT_ACCOUNT_NAME} from '../../../constants/accounts/accounts';
 import {IdmObjectType} from '../../../constants/acl';
-import {selectCluster} from '../../../store/selectors/global';
-import {updateAcl} from '../../../utils/acl/acl-api';
+import {updateAcl} from '../../../store/actions/acl';
+import UIFactory from '../../../UIFactory';
 import {type ResponsibleType} from '../../../utils/acl/acl-types';
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {accountsIncreaseEditCounter, loadEditedAccount} from './accounts';
@@ -75,15 +75,27 @@ function setResponsibleUsers(
     accountName: string,
     inheritAcl: boolean,
 ): EditorAction {
-    return (_dispatch, getState) => {
-        const path = accountName;
-        const cluster = selectCluster(getState());
+    return (dispatch) => {
+        if (!UIFactory.getAclApi().isAllowed) {
+            return Promise.resolve();
+        }
 
-        return updateAcl(cluster, path, {
-            idmKind: IdmObjectType.ACCOUNT,
-            responsible: users,
-            inheritAcl,
-        });
+        return Promise.all([
+            dispatch(
+                updateAcl({
+                    path: accountName,
+                    idmKind: IdmObjectType.ACCOUNT,
+                    values: {responsible: users},
+                }),
+            ),
+            dispatch(
+                updateAcl({
+                    path: accountName,
+                    idmKind: IdmObjectType.ACCOUNT,
+                    values: {inheritAcl},
+                }),
+            ),
+        ]);
     };
 }
 

--- a/packages/ui/src/ui/store/actions/acl.ts
+++ b/packages/ui/src/ui/store/actions/acl.ts
@@ -395,6 +395,7 @@ export function updateAcl(
                     version,
                     idmKind,
                     poolTree,
+                    name: path,
                 });
             })
             .then(() => {

--- a/packages/ui/src/ui/store/actions/scheduling/create-pool-dialog.tsx
+++ b/packages/ui/src/ui/store/actions/scheduling/create-pool-dialog.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
-import {ThunkAction} from 'redux-thunk';
-import {RootState} from '../../reducers';
-import {
-    CreatePoolDialogAction,
-    CreatePoolDialogState,
-} from '../../reducers/scheduling/create-pool-dialog';
+import {type ThunkAction} from 'redux-thunk';
 import {
     CREATE_POOL_DIALOG_TREE_CREATE_FAILURE,
     CREATE_POOL_DIALOG_TREE_ITEMS_SUCCESS,
 } from '../../../constants/scheduling';
+import {type RootState} from '../../reducers';
+import {
+    type CreatePoolDialogAction,
+    type CreatePoolDialogState,
+} from '../../reducers/scheduling/create-pool-dialog';
 // @ts-ignore
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
+import Link from '../../../components/Link/Link';
+import {createAdminReqTicketUrl} from '../../../config';
+import {IdmObjectType} from '../../../constants/acl';
+import {YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
+import {updateAcl} from '../../../store/actions/acl';
+import UIFactory from '../../../UIFactory';
+import {type ResponsibleType} from '../../../utils/acl/acl-types';
 import {prepareAbcService} from '../../../utils/scheduling';
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {loadSchedulingData} from './scheduling-ts';
-import {FIX_MY_TYPE} from '../../../types';
-import {selectCluster} from '../../selectors/global';
-import {updateAcl} from '../../../utils/acl/acl-api';
-import {IdmObjectType} from '../../../constants/acl';
-import Link from '../../../components/Link/Link';
-import {YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
-import {createAdminReqTicketUrl} from '../../../config';
 
-type CreatePoolDialogThunkAction<R = any> = ThunkAction<
+type CreatePoolDialogThunkAction<R = void> = ThunkAction<
     R,
     RootState,
     unknown,
@@ -42,19 +42,28 @@ export function fetchCreatePoolDialogTreeItems(currentTree: string): CreatePoolD
     };
 }
 
-export function createPool(values: FIX_MY_TYPE): CreatePoolDialogThunkAction {
-    return (dispatch, getState) => {
-        const {abcService} = values;
-        const cluster = selectCluster(getState()) as string;
-
+export function createPool({
+    name,
+    parent,
+    tree,
+    responsible,
+    abcService,
+}: {
+    name: string;
+    parent?: string;
+    tree: string;
+    responsible: Array<ResponsibleType>;
+    abcService: {value: string; title: string; id: number};
+}): CreatePoolDialogThunkAction {
+    return (dispatch) => {
         return wrapApiPromiseByToaster(
             yt.v3.create({
                 type: 'scheduler_pool',
                 attributes: Object.assign(
                     {
-                        name: values.name,
-                        parent_name: values.parent || undefined,
-                        pool_tree: values.tree,
+                        name,
+                        parent_name: parent || undefined,
+                        pool_tree: tree,
                     },
                     !abcService || !abcService.value
                         ? {}
@@ -64,26 +73,30 @@ export function createPool(values: FIX_MY_TYPE): CreatePoolDialogThunkAction {
                 ),
             }),
             {
-                toasterName: `create_${values.name}`,
-                successContent: `Successfully created ${values.name}. Please wait.`,
-                errorContent: `'${values.name}' pool creation failed`,
+                toasterName: `create_${name}`,
+                successContent: `Successfully created ${name}. Please wait.`,
+                errorContent: `'${name}' pool creation failed`,
                 timeout: 10000,
             },
         )
             .then(() => {
-                updateAcl(cluster, values.name, {
-                    idmKind: IdmObjectType.POOL,
-                    poolTree: values.tree,
-                    responsible: values.responsible,
-                });
+                return waitWhilePoolIsReady({name, tree}).then(() => {
+                    if (UIFactory.getAclApi().isAllowed) {
+                        dispatch(
+                            updateAcl({
+                                values: {responsible},
+                                path: name,
+                                idmKind: IdmObjectType.POOL,
+                            }),
+                        );
+                    }
 
-                return waitWhilePoolIsReady(values).then(() => {
                     dispatch(loadSchedulingData());
                 });
             })
             .catch((error) => {
                 if (error?.code === yt.codes.CANCELLED) {
-                    return;
+                    return undefined;
                 }
 
                 dispatch({

--- a/packages/ui/src/ui/utils/accounts/editor.js
+++ b/packages/ui/src/ui/utils/accounts/editor.js
@@ -2,56 +2,32 @@ import reduce_ from 'lodash/reduce';
 
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 
-import {ROOT_ACCOUNT_NAME} from '../../constants/accounts/accounts';
 import {EDITOR_TABS} from '../../constants/accounts/editor';
-import hammer from '../../common/hammer';
-import {IdmObjectType} from '../../constants/acl';
 import {showErrorPopup} from '../../utils/utils';
-import {updateAcl} from '../../utils/acl/acl-api';
 import {toaster} from '../toaster';
+import i18n from './i18n';
 
 const basePath = '//sys/accounts/';
 
 const ERROR_TOASTER_TIMEOUT = 10000;
 const SUCCESS_TOASTER_TIMEOUT = 5000;
 
-export function setResponsibleUsers(cluster, users, accountName, inheritAcl) {
-    const path = accountName;
-
-    return updateAcl(cluster, path, {
-        idmKind: IdmObjectType.ACCOUNT,
-        responsible: users,
-        inheritAcl,
-    });
-}
+const EDITOR_TAB_LABELS = {
+    [EDITOR_TABS.general]: () => i18n('value_general'),
+    [EDITOR_TABS.medium]: () => i18n('value_disk-space'),
+    [EDITOR_TABS.nodes]: () => i18n('value_nodes'),
+    [EDITOR_TABS.chunks]: () => i18n('value_chunks'),
+    [EDITOR_TABS.tablets]: () => i18n('value_tablets'),
+    [EDITOR_TABS.masterMemory]: () => i18n('value_master-memory'),
+    [EDITOR_TABS.delete]: () => i18n('value_delete'),
+};
 
 export function setAccountLimit(input, accountName, resourcePath) {
     const path = basePath + accountName + resourcePath;
     return yt.v3.set({path}, input);
 }
 
-export function createAccountFromInfo(cluster, newAccountInfo) {
-    return () => {
-        const {abcService, account, parentAccount, responsibles, createHome} = newAccountInfo;
-
-        return createAccount(account, parentAccount).then(() => {
-            const {id, slug} = abcService || {};
-
-            return Promise.all([
-                setAccountAbc(account, id, slug).catch(() => {}),
-                createHome ? createAccountHome(account).catch(() => {}) : Promise.resolve(),
-                setResponsibleUsers(
-                    cluster,
-                    responsibles,
-                    account,
-                    parentAccount !== ROOT_ACCOUNT_NAME,
-                ).catch(() => {}),
-            ]);
-        });
-    };
-}
-
-function createAccount(accountName, parentName) {
+export function createAccount(accountName, parentName) {
     return yt.v3
         .create({
             type: 'account',
@@ -65,7 +41,7 @@ function createAccount(accountName, parentName) {
                 name: 'create account',
                 timeout: SUCCESS_TOASTER_TIMEOUT,
                 theme: 'success',
-                title: `${accountName} successfully created`,
+                title: i18n('alert_account-created', {accountName}),
             });
             return d;
         })
@@ -74,9 +50,9 @@ function createAccount(accountName, parentName) {
                 name: 'create account',
                 timeout: ERROR_TOASTER_TIMEOUT,
                 theme: 'danger',
-                title: `Failed to create account ${accountName}`,
+                title: i18n('alert_create-account-failed', {accountName}),
                 content: err.message,
-                actions: [{label: ' view', onClick: () => showErrorPopup(err)}],
+                actions: [{label: i18n('action_view'), onClick: () => showErrorPopup(err)}],
             });
             return Promise.reject(err);
         });
@@ -90,7 +66,7 @@ export function setAccountParent(accountName, parentName) {
                 name: 'set parent for account',
                 timeout: SUCCESS_TOASTER_TIMEOUT,
                 theme: 'success',
-                title: `${accountName}'s Parent updated successfully`,
+                title: i18n('alert_account-parent-updated', {accountName}),
             });
             return d;
         })
@@ -99,9 +75,9 @@ export function setAccountParent(accountName, parentName) {
                 name: 'set parent for account',
                 timeout: ERROR_TOASTER_TIMEOUT,
                 theme: 'danger',
-                title: `Failed to set Parent for ${accountName}`,
+                title: i18n('alert_set-parent-failed', {accountName}),
                 content: err.message,
-                actions: [{label: ' view', onClick: () => showErrorPopup(err)}],
+                actions: [{label: i18n('action_view'), onClick: () => showErrorPopup(err)}],
             });
             return Promise.reject(err);
         });
@@ -118,7 +94,7 @@ export function setAccountAbc(accountName, abcId, abcSlug) {
                 name: 'account abc service',
                 timeout: SUCCESS_TOASTER_TIMEOUT,
                 theme: 'success',
-                title: `${accountName}'s ABC Service updated successfully`,
+                title: i18n('alert_account-abc-updated', {accountName}),
             });
             return d;
         })
@@ -127,9 +103,9 @@ export function setAccountAbc(accountName, abcId, abcSlug) {
                 name: 'account abc service',
                 timeout: ERROR_TOASTER_TIMEOUT,
                 theme: 'danger',
-                title: `Failed to set ABC for ${accountName}`,
+                title: i18n('alert_set-abc-failed', {accountName}),
                 content: err.message,
-                actions: [{label: ' view', onClick: () => showErrorPopup(err)}],
+                actions: [{label: i18n('action_view'), onClick: () => showErrorPopup(err)}],
             });
             return Promise.reject(err);
         });
@@ -157,7 +133,7 @@ export function createAccountHome(accountName) {
                         name: 'account create home',
                         timeout: SUCCESS_TOASTER_TIMEOUT,
                         theme: 'success',
-                        title: `${accountName}'s home directory created successfully`,
+                        title: i18n('alert_account-home-created', {accountName}),
                     });
                     return d;
                 });
@@ -167,9 +143,9 @@ export function createAccountHome(accountName) {
                 name: 'account create home',
                 timeout: ERROR_TOASTER_TIMEOUT,
                 theme: 'danger',
-                title: `Failed to create home for ${accountName}`,
+                title: i18n('alert_create-home-failed', {accountName}),
                 content: err.message,
-                actions: [{label: ' view', onClick: () => showErrorPopup(err)}],
+                actions: [{label: i18n('action_view'), onClick: () => showErrorPopup(err)}],
             });
             return Promise.reject(err);
         });
@@ -192,7 +168,9 @@ export const contentTabs = reduce_(
     (acc, value) => {
         acc.push({
             value,
-            text: hammer.format['ReadableField'](value),
+            get text() {
+                return EDITOR_TAB_LABELS[value]?.() ?? value;
+            },
             show: true,
         });
         return acc;

--- a/packages/ui/src/ui/utils/acl/acl-api.ts
+++ b/packages/ui/src/ui/utils/acl/acl-api.ts
@@ -62,15 +62,6 @@ export function getAcl({
     return api.getAcl({cluster, path, kind, poolTree, sysPath});
 }
 
-export function updateAcl(cluster: string, path: string, params: UpdateAclParams) {
-    const api = UIFactory.getAclApi();
-    if (!api.isAllowed) {
-        return Promise.resolve();
-    }
-
-    return api.updateAcl(cluster, path, params);
-}
-
 export const getResponsible = async ({
     cluster,
     path,

--- a/packages/ui/src/ui/utils/acl/acl-types.ts
+++ b/packages/ui/src/ui/utils/acl/acl-types.ts
@@ -274,4 +274,5 @@ export interface UpdateAclParams {
     version?: string;
     poolTree?: string;
     comment?: string;
+    name: string;
 }

--- a/packages/ui/src/ui/utils/acl/acl-types.ts
+++ b/packages/ui/src/ui/utils/acl/acl-types.ts
@@ -42,7 +42,7 @@ export interface GetGroupResponse {
 }
 
 export interface UpdateResponse {
-    status: RoleUpdateStatus | Array<RoleUpdateStatus>;
+    status: RoleUpdateStatus | Array<RoleUpdateStatus> | undefined;
 }
 
 export interface RoleUpdateStatus {


### PR DESCRIPTION
## Summary by Sourcery

Internationalize account and pool creation flows and centralize ACL responsibility updates through Redux actions and UIFactory-based ACL API checks.

New Features:
- Add typed Redux action for creating accounts that also configures ABC service, home directory, and responsible users.
- Allow specifying multiple responsible users and groups when creating accounts and scheduler pools.

Enhancements:
- Replace hardcoded English labels and toaster messages in account editor and account creation dialog with i18n-based strings.
- Refine pool creation flow to wait for pool readiness before updating ACL responsible metadata via centralized ACL action.
- Refactor account creation utilities to be reusable from Redux actions and expose editor tab labels through lazily evaluated i18n mappings.
- Update ACL update parameters and call sites to use centralized store action instead of direct util helper, including naming fields alignment.