### PR TITLE
fix(Queries): settings in spyt connect [YTFRONT-5785]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettingsButton/QuerySettingsButton.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QuerySettingsButton/QuerySettingsButton/QuerySettingsButton.tsx
@@ -11,6 +11,8 @@ import {QueryEngine} from '../../../../../shared/constants/engines';
 import {QuerySettings} from '../QuerySettings';
 import {SpytSettings} from '../SpytSettings/SpytSettings';
 import {type DraftQuery} from '../../../../types/query-tracker/api';
+import {useSelector} from '../../../../store/redux-hooks';
+import {selectAvailableSpytConnect} from '../../../../store/selectors/query-tracker/queryTrackerEnginesInfo';
 
 const block = cn('query-settings-popup');
 
@@ -29,6 +31,7 @@ export const QuerySettingsButton: FC<Props> = ({
     popupClassName,
     onChange,
 }) => {
+    const availableSpytConnect = useSelector(selectAvailableSpytConnect);
     const [opened, toggleOpened] = useToggle(false);
     const ref = useRef(null);
 
@@ -41,6 +44,8 @@ export const QuerySettingsButton: FC<Props> = ({
         onChange(newSettings);
         toggleOpened();
     };
+
+    const showJsonSettingsModal = isSpyt && availableSpytConnect;
 
     return (
         <>
@@ -59,7 +64,7 @@ export const QuerySettingsButton: FC<Props> = ({
                 open={opened}
                 className={block(null, popupClassName)}
                 onClose={toggleOpened}
-                showCloseButton={!isSpyt}
+                showCloseButton={!showJsonSettingsModal}
             >
                 <div className={block('header')}>
                     <Text variant="subheader-3">{i18n('title_settings')} </Text>
@@ -69,7 +74,7 @@ export const QuerySettingsButton: FC<Props> = ({
                         </Text>
                     )}
                 </div>
-                {isSpyt ? (
+                {showJsonSettingsModal ? (
                     <SpytSettings
                         settings={settings}
                         onChange={handleSpytChange}

--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../store/selectors/query-tracker/queryAco';
 import cn from 'bem-cn-lite';
 import './QuerySelectorsByEngine.scss';
+import {selectAvailableSpytConnect} from '../../../store/selectors/query-tracker/queryTrackerEnginesInfo';
 
 const block = cn('yt-query-selector-by-engine');
 
@@ -30,6 +31,7 @@ export const QuerySelectorsByEngine: FC = () => {
     const {settings = {}, engine} = useSelector(selectQueryDraft);
     const availableYql = useSelector(selectAvailableYql);
     const effectiveYqlVersion = useSelector(selectEffectiveYqlVersion);
+    const hasSpytConnect = useSelector(selectAvailableSpytConnect);
     const currentCluster = settings?.cluster;
 
     const options = useMemo(() => {
@@ -70,6 +72,10 @@ export const QuerySelectorsByEngine: FC = () => {
                 onUpdate={handleYqlVersionChange}
             />
         );
+    }
+
+    if (engine === QueryEngine.SPYT && hasSpytConnect) {
+        return null;
     }
 
     if (engine === QueryEngine.CHYT || engine === QueryEngine.SPYT) {

--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -36,6 +36,7 @@ import {
     type QueryResult,
     type QueryResultMeta,
 } from '../../../types/query-tracker/api';
+import {selectAvailableSpytConnect} from '../../selectors/query-tracker/queryTrackerEnginesInfo';
 
 export function getQTApiSetup(): {proxy?: string} {
     const QT_CLUSTER = getQueryTrackerCluster();
@@ -189,6 +190,7 @@ export function startQuery(
         const state = getState();
         const isMultipleAco = selectIsMultipleAco(state);
         const {stage, yqlAgentStage} = selectQueryTrackerRequestOptions(state);
+        const hasSpytConnect = selectAvailableSpytConnect(state);
         const {
             query,
             engine,
@@ -200,7 +202,10 @@ export function startQuery(
             access_control_object,
         } = queryInstance;
 
-        const processedSettings = engine === 'spyt' ? convertSettingsTypes(settings) : settings;
+        const isSpyt = engine === 'spyt';
+
+        const processedSettings =
+            isSpyt && !hasSpytConnect ? convertSettingsTypes(settings) : settings;
 
         return ytApiV4Id.startQuery(YTApiId.startQuery, {
             parameters: {

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryTrackerEnginesInfo.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryTrackerEnginesInfo.ts
@@ -17,6 +17,10 @@ export const selectSpytEnginesInfo = (state: RootState) => {
     return selectQueryTrackerInfo(state)?.engines_info?.spyt;
 };
 
+export const selectAvailableSpytConnect = (state: RootState) => {
+    return Boolean(selectSpytEnginesInfo(state));
+};
+
 const selectQueryTrackerInfoLoaded = (state: RootState) => state.queryTracker.aco.loaded;
 
 export const selectSpytDefaultSettings = createSelector(


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/4ZTazZFf7cLVv5
<!-- nda-end -->  ## Summary by Sourcery

Adjust SPYT query settings behavior based on availability of SPYT Connect and expose a selector for this capability.

New Features:
- Introduce selector to detect availability of SPYT Connect and use it across query tracker UI.

Bug Fixes:
- Prevent type conversion of SPYT settings when SPYT Connect is available to preserve expected settings format.
- Hide cluster/engine selector UI for SPYT queries when SPYT Connect is enabled so the UI reflects the new connection mode.
- Show the JSON-based SPYT settings modal and adjust close button visibility only when SPYT Connect is present.