### PR TITLE
test: add mockYTApi helper

### DIFF
--- a/packages/ui/tests/init-cluster-e2e.sh
+++ b/packages/ui/tests/init-cluster-e2e.sh
@@ -46,7 +46,6 @@ export E2E_DIR="$(date "+//tmp/e2e.%Y-%m-%d.%H:%M:%S.${E2E_SUFFIX}")"
 echo E2E_DIR=${E2E_DIR} >>./e2e-env.tmp
 
 yt create map_node ${E2E_DIR}
-yt set ${E2E_DIR}/@expiration_timeout 10000
 
 yt remove -f ${E2E_DIR}/root
 yt remove -f ${E2E_DIR}/locked
@@ -66,6 +65,8 @@ yt copy ${E2E_DIR}/file-types ${E2E_DIR}/locked
 
 yt lock --mode snapshot ${E2E_DIR}/locked --tx $(yt start-tx --timeout ${EXPIRATION_TIMEOUT})
 yt lock --mode shared ${E2E_DIR}/locked --tx $(yt start-tx --timeout ${EXPIRATION_TIMEOUT})
+
+yt set ${E2E_DIR}/@expiration_timeout 10000
 
 if [ "false" = "$(yt exists //sys/pool_trees/e2e)" ]; then
     yt create scheduler_pool_tree --attributes '{name=e2e;config={nodes_filter=e2e}}'

--- a/packages/ui/tests/package-lock.json
+++ b/packages/ui/tests/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "1.53.1"
+        "@playwright/test": "1.53.1",
+        "lodash": "^4.18.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -42,6 +43,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.53.1",

--- a/packages/ui/tests/package.json
+++ b/packages/ui/tests/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "1.53.1"
+    "@playwright/test": "1.53.1",
+    "lodash": "^4.18.1"
   }
 }

--- a/packages/ui/tests/screenshots/pages/navigation/navigation.table.base.screen.ts
+++ b/packages/ui/tests/screenshots/pages/navigation/navigation.table.base.screen.ts
@@ -2,6 +2,7 @@ import {expect, test} from '@playwright/test';
 import {E2E_DIR, MOCK_DATE, makeClusterUrl} from '../../../utils';
 import {replaceInnerHtml} from '../../../utils/dom';
 import {table} from '../../../widgets/TablePage';
+import {mockYTApi} from '../../../utils/network';
 
 test('Navigation: table - Content', async ({page}) => {
     await page.clock.install({time: MOCK_DATE});
@@ -68,7 +69,10 @@ test('Navigation: table - Schema', async ({page}) => {
 
 test('Navigation: table - Remount needed', async ({page}) => {
     await page.clock.install({time: MOCK_DATE});
+    await mockYTApi(page, 'navigationAttributes', [{output: {compression_ratio: {$value: "0.5819612345642"}}}]);
+
     await page.goto(makeClusterUrl(`navigation?path=${E2E_DIR}/dynamic-table`));
+
     await page.waitForLoadState('networkidle');
 
     page.locator('.data-table_theme_yt-internal').waitFor();

--- a/packages/ui/tests/utils/network.ts
+++ b/packages/ui/tests/utils/network.ts
@@ -1,0 +1,16 @@
+import {Page} from '@playwright/test';
+import merge from 'lodash/merge';
+
+export const mockYTApi = async (page: Page, ytApiId: string, patchToMerge: unknown) => {
+    await page.route(`**/api/yt/*/api/**`, async (route) => {
+        const {'x-custom-request-id': customApiId} = await route.request().allHeaders();
+        if (customApiId !== ytApiId) {
+            return await route.continue();
+        }
+
+        const response = await route.fetch();
+        const json = await response.json();
+
+        await route.fulfill({response, json: merge(json, patchToMerge)});
+    });
+};


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/xDtnRW7J7cLpGJ
<!-- nda-end -->     ## Summary by Sourcery

Introduce a reusable Playwright helper to mock YT API responses in UI tests and update an existing navigation screenshot test to use it.

New Features:
- Add a mockYTApi utility for Playwright tests to intercept YT API calls and merge custom patches into JSON responses.

Enhancements:
- Adjust E2E cluster initialization to set expiration timeout after creating and locking required nodes.
- Add lodash as a dev dependency to support deep merging in test utilities.

Tests:
- Update the navigation table remount screenshot test to use the YT API mocking helper for deterministic response data.