### PR TITLE
chore: fix acl responsible tooltip [YTFRONT-5774]

### DIFF
--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -47,7 +47,7 @@ function prepareApprovers(
             subjectType: subject.type === 'users' ? ('user' as const) : ('group' as const),
             groupInfo:
                 subject.type === 'groups'
-                    ? {name: subject.group_name, url: subject.url, group: undefined}
+                    ? {name: subject.group_name, url: subject.url, group: subject.group}
                     : undefined,
             action: undefined,
         };


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/5fjKYplC7cMYLK
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Ensure ACL responsible tooltip receives the underlying group object instead of leaving it undefined for group subjects.