### PR TITLE
feat(PrometheusDashboard): use //sys/interface_monitoring [YTFRONT-5802]

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -82,11 +82,11 @@ All application files in a resulting docker-image will be placed in /opt/app, so
 }
 ```
 
-- `GRAFANA_BASE_URL` - If defined enables links to specific dashbords when `YTCoreConfig.prometheusBaseUrl` is provided (the value is forwarded to `YTCoreConfig.uiSettings.grafanaBaseUrl`). By default the link is visible for all users, to control the visibility create `//sys/interface-monitoring/allow_grafana_url` node and add `use` permission for specific users/groups.
+- `GRAFANA_BASE_URL` - If defined enables links to specific dashbords when `YTCoreConfig.prometheusBaseUrl` is provided (the value is forwarded to `YTCoreConfig.uiSettings.grafanaBaseUrl`). By default the link is visible for all users, to control the visibility create `//sys/interface_monitoring/allow_grafana_url` node and add `use` permission for specific users/groups.
 
 ### Prometheus dashboards
 
-To activate monitoring ddashboards you have to provide PROMETHEUS_BASE_URL. Additionally you have to provide documents in `//sys/interface-monitoring/` with description of dashboards:
+To activate monitoring ddashboards you have to provide PROMETHEUS_BASE_URL. Additionally you have to provide documents in `//sys/interface_monitoring/` with description of dashboards:
 
 - Account: `master-accounts`
 - Tablet cell bundle: `bundle-ui-cpu`, `bundle-ui-disk`, `bundle-ui-efficiency`, `bundle-ui-lsm`, `bundle-ui-memory`, `bundle-ui-network`, `bundle-ui-resource`, `bundle-ui-rpc-proxy`, `bundle-ui-rpc-proxy-overview`, `bundle-ui-user-load`,

--- a/packages/ui/src/server/controllers/prometheus/prometheus.utils.ts
+++ b/packages/ui/src/server/controllers/prometheus/prometheus.utils.ts
@@ -112,7 +112,7 @@ export async function checkDashboardPermissions(
     permissions?.forEach(
         ({cluster: rawCluster = ytAuthCluster, path: rawPath, permission, ignorePaths}) => {
             // chartParams should contain only keys corresponding to items of `templating.list` of a dashboard description
-            // from //sys/interface-monitoring/*, so it is safe to use it for RegExp
+            // from //sys/interface_monitoring/*, so it is safe to use it for RegExp
             // eslint-disable-next-line security/detect-non-literal-regexp
             const keyToRegex = (key: string) => new RegExp(`\\$${key}`, 'g');
 

--- a/packages/ui/src/shared/prometheus/utils.ts
+++ b/packages/ui/src/shared/prometheus/utils.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 
 export function getDashboardPath(type: PrometheusDashboardType) {
-    return `//sys/interface-monitoring/${type}`;
+    return `//sys/interface_monitoring/${type}`;
 }
 
 export function makePanelId(item: {

--- a/packages/ui/src/ui/containers/PrometheusDashboard/PrometheusDashboard.tsx
+++ b/packages/ui/src/ui/containers/PrometheusDashboard/PrometheusDashboard.tsx
@@ -235,7 +235,7 @@ function useGrafanaUrlVisibility() {
         parameters: {
             requests: [
                 makeCheckPermissionBatchSubRequest({
-                    path: '//sys/interface-monitoring/allow_grafana_url',
+                    path: '//sys/interface_monitoring/allow_grafana_url',
                     user,
                     permission: 'use',
                 }),

--- a/packages/ui/src/ui/containers/PrometheusDashboard/i18n/en.json
+++ b/packages/ui/src/ui/containers/PrometheusDashboard/i18n/en.json
@@ -3,5 +3,5 @@
   "message_provide-required-parameters": "You have to provide all required parameters",
   "message_dashboard-not-exist": "is not exist",
   "message_provide-correct-dashboard": "You have to provide correct dashboard description, see expected parameters below:",
-  "message_check-permission-error": "Check `use` permission for //sys/interface-monitoring/allow_grafana_url"
+  "message_check-permission-error": "Check `use` permission for //sys/interface_monitoring/allow_grafana_url"
 }

--- a/packages/ui/tests/init-monitoring-e2e.sh
+++ b/packages/ui/tests/init-monitoring-e2e.sh
@@ -17,8 +17,8 @@ BASE_DIR=$(readlink -f $(dirname $0))
 pushd $(dirname $0)/data/monitoring/json
 ls | xargs -I {} bash -c "
     echo -n Creating document {}...;
-    yt create -r -i document //sys/interface-monitoring/{} >/dev/null && \
-    yt set --format json //sys/interface-monitoring/{} < {} && \
+    yt create -r -i document //sys/interface_monitoring/{} >/dev/null && \
+    yt set --format json //sys/interface_monitoring/{} < {} && \
     echo OK;
 "
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/7c-nmki_7d3MbT
<!-- nda-end -->## Summary by Sourcery

Update Prometheus dashboard configuration to use the //sys/interface_monitoring path consistently instead of //sys/interface-monitoring across UI code, tests, and documentation.

Enhancements:
- Align Prometheus dashboard paths in UI logic and permission checks to the //sys/interface_monitoring namespace.
- Adjust monitoring test setup scripts to create and populate dashboard documents under //sys/interface_monitoring.
- Update UI documentation to reference the new //sys/interface_monitoring location for monitoring documents and Grafana visibility control.