### PR TITLE
fix(Flow/Messages): make body of dialog scrollable [YTFRONT-5780]

### DIFF
--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowGraphRenderer.scss
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowGraphRenderer.scss
@@ -41,5 +41,6 @@
 
     &__messages-body {
         min-width: 50vw;
+        overflow: auto;
     }
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/BHhpT_DS7d3rwT
<!-- nda-end --> ## Summary by Sourcery

Bug Fixes:
- Ensure the Flow messages dialog body can scroll when content exceeds the viewport width.