### PR TITLE
Ytfront 5653 tables tablet thor settings

### DIFF
--- a/packages/ui/src/ui/containers/CellPreviewModal/CellPreviewModal.tsx
+++ b/packages/ui/src/ui/containers/CellPreviewModal/CellPreviewModal.tsx
@@ -18,8 +18,8 @@ import {ClipboardButton} from '@ytsaurus/components';
 import cn from 'bem-cn-lite';
 
 import {Yson} from '../../components/Yson/Yson';
-import {YTErrorBlock} from '../../containers/Block/Block';
-import {type YsonSettings, getPreviewCellYsonSettings} from '../../store/selectors/thor/unipika';
+import {YTErrorBlock} from '../../components/Error/Error';
+import {type YsonSettings, selectPreviewCellYsonSettings} from '../../store/selectors/thor/unipika';
 import {closeCellPreviewAndCancelRequest} from '../../store/actions/modals/cell-preview';
 import {isMediaTag} from '../../utils/yql-types';
 
@@ -37,7 +37,7 @@ export const CellPreviewModal: React.FC = () => {
     const noticeText = useSelector(selectCellPreviewNoticeText);
     const error = useSelector(selectErrorPreviewCellPath);
 
-    const unipikaSettings = useSelector(getPreviewCellYsonSettings);
+    const unipikaSettings = useSelector(selectPreviewCellYsonSettings);
 
     return (
         <SimpleModal

--- a/packages/ui/src/ui/containers/CellPreviewModal/CellPreviewModal.tsx
+++ b/packages/ui/src/ui/containers/CellPreviewModal/CellPreviewModal.tsx
@@ -18,7 +18,7 @@ import {ClipboardButton} from '@ytsaurus/components';
 import cn from 'bem-cn-lite';
 
 import {Yson} from '../../components/Yson/Yson';
-import {YTErrorBlock} from '../../components/Error/Error';
+import {YTErrorBlock} from '../../containers/Block/Block';
 import {type YsonSettings, selectPreviewCellYsonSettings} from '../../store/selectors/thor/unipika';
 import {closeCellPreviewAndCancelRequest} from '../../store/actions/modals/cell-preview';
 import {isMediaTag} from '../../utils/yql-types';

--- a/packages/ui/src/ui/containers/ErrorDetails/ErrorDetails.tsx
+++ b/packages/ui/src/ui/containers/ErrorDetails/ErrorDetails.tsx
@@ -20,7 +20,7 @@ import {unescapeSlashX} from '../../utils/utils';
 import FormattedText from '../../components/formatters/FormattedText';
 import {type UnipikaSettings} from '../../components/Yson/StructuredYson/StructuredYsonTypes';
 import {ErrorToClipboardButton} from '../../containers/ErrorToClipboardButton/ErrorToClipboardButton';
-import {getYsonSettingsErrorDetails} from '../../store/selectors/thor/unipika';
+import {selectYsonSettingsErrorDetails} from '../../store/selectors/thor/unipika';
 import {useSelector} from '../../store/redux-hooks';
 
 const b = block('elements-error-details');
@@ -37,7 +37,7 @@ type State = {
 };
 
 export default function ErrorDetails({error, ...props}: ErrorDetailsProps) {
-    const unipikaSettings = useSelector(getYsonSettingsErrorDetails);
+    const unipikaSettings = useSelector(selectYsonSettingsErrorDetails);
 
     const normalizedError = React.useMemo(() => {
         if (typeof error === 'string') {

--- a/packages/ui/src/ui/containers/ErrorYsonSettingsProvider/ErrorYsonSettingsProvider.tsx
+++ b/packages/ui/src/ui/containers/ErrorYsonSettingsProvider/ErrorYsonSettingsProvider.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {useSelector} from '../../store/redux-hooks';
 
 import {ErrorsYsonSettingsContext} from '../../hooks/useErrorYsonSettings';
-import {getErrorsYsonSettings} from '../../store/selectors/thor/unipika';
+import {selectErrorsYsonSettings} from '../../store/selectors/thor/unipika';
 
 export function ErrorYsonSettingsProvider({children}: {children: React.ReactNode}) {
-    const settings = useSelector(getErrorsYsonSettings);
+    const settings = useSelector(selectErrorsYsonSettings);
     return (
         <ErrorsYsonSettingsContext.Provider value={settings}>
             {children}

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
@@ -46,7 +46,7 @@ import {
     getContentModeOptions,
     makeReadableItems,
 } from '../../../../utils/accounts';
-import {getMediumList} from '../../../../store/selectors/thor';
+import {selectMediumList} from '../../../../store/selectors/thor';
 import {
     changeContentFilter,
     changeMediumFilter,
@@ -810,7 +810,7 @@ const makeMapStateToProps = () => {
 
             clusterUiConfig: selectClusterUiConfig(state),
 
-            mediumList: getMediumList(state),
+            mediumList: selectMediumList(state),
             accounts: accounts.accounts,
             contextViewTree,
             nameToAccountMap,

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/MediumContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/MediumContent.tsx
@@ -4,7 +4,7 @@ import cn from 'bem-cn-lite';
 import partition_ from 'lodash/partition';
 
 import {ClickableText} from '../../../../../../components/ClickableText/ClickableText';
-import {getMediumList} from '../../../../../../store/selectors/thor';
+import {selectMediumList} from '../../../../../../store/selectors/thor';
 
 import hammer from '../../../../../../common/hammer';
 import {type RootState} from '../../../../../../store/reducers';
@@ -85,7 +85,7 @@ class MediumContent extends Component<Props> {
 }
 
 const mapStateToProps = (state: RootState) => ({
-    mediumList: getMediumList(state),
+    mediumList: selectMediumList(state),
 });
 
 export default connect(mapStateToProps)(MediumContent);

--- a/packages/ui/src/ui/pages/accounts/tabs/monitor/AccountsMonitorPrometheus/AccountsMonitorPrometheus.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/monitor/AccountsMonitorPrometheus/AccountsMonitorPrometheus.tsx
@@ -8,7 +8,7 @@ import ypath from '../../../../../common/thor/ypath';
 
 import {PrometheusDashboardLazy} from '../../../../../containers/PrometheusDashboard/lazy';
 import {selectAccountsMapByName} from '../../../../../store/selectors/accounts/accounts-ts';
-import {getMediumList} from '../../../../../store/selectors/thor';
+import {selectMediumList} from '../../../../../store/selectors/thor';
 import {usePrometheusDashboardParams} from '../../../../../store/reducers/prometheusDashboard/prometheusDashboard-hooks';
 
 type LeftRightMedium = {
@@ -30,7 +30,7 @@ export function AccountsMonitorPrometheus({cluster, account}: {cluster: string; 
 }
 
 function useAccountMonitoringParams({cluster, account}: {cluster: string; account: string}) {
-    const mediumList: Array<string> = useSelector(getMediumList);
+    const mediumList: Array<string> = useSelector(selectMediumList);
     const accountData = useSelector(selectAccountsMapByName)[account];
 
     const {params: selection, setParams: setSelection} =

--- a/packages/ui/src/ui/pages/chyt/ChytPageClique/ChytPageCliqueSpeclet.tsx
+++ b/packages/ui/src/ui/pages/chyt/ChytPageClique/ChytPageCliqueSpeclet.tsx
@@ -22,7 +22,7 @@ import {
     selectChytOptionsDataAlias,
     selectChytOptionsError,
 } from '../../../store/selectors/chyt/options';
-import {getEditJsonYsonSettings} from '../../../store/selectors/thor/unipika';
+import {selectEditJsonYsonSettings} from '../../../store/selectors/thor/unipika';
 import {chytLoadCliqueSpeclet} from '../../../store/actions/chyt/speclet';
 import {chytEditOptions, chytLoadCliqueOptions} from '../../../store/actions/chyt/options';
 import {type ChytCliqueOptionsState} from '../../../store/reducers/chyt/options';
@@ -56,7 +56,7 @@ function useSpecletData({
     const specletData = useSelector(selectChytOptionsData);
     const dataAlias = useSelector(selectChytOptionsDataAlias);
     const error = useSelector(selectChytOptionsError);
-    const unipikaSettings = useSelector(getEditJsonYsonSettings);
+    const unipikaSettings = useSelector(selectEditJsonYsonSettings);
 
     return {alias, specletData, dataAlias, error, unipikaSettings};
 }

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeUnrecognizedOptions/NodeUnrecognizedOptions.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeUnrecognizedOptions/NodeUnrecognizedOptions.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../../../store/selectors/components/node/unrecognized-options';
 import {YTErrorBlock} from '../../../../../containers/Block/Block';
 import {YsonWithScroll} from '../../../../../components/Yson/YsonWithScroll';
-import {getNodeUnrecognizedOptionsYsonSettings} from '../../../../../store/selectors/thor/unipika';
+import {selectNodeUnrecognizedOptionsYsonSettings} from '../../../../../store/selectors/thor/unipika';
 import {YsonDownloadButton} from '../../../../../components/DownloadAttributesButton';
 
 export function NodeUnrecognizedOptions({host}: {host: string}) {
@@ -26,7 +26,7 @@ export function NodeUnrecognizedOptions({host}: {host: string}) {
     const data = useSelector(selectNodeUnrecognizedOptionsData);
     const error = useSelector(selectNodeUnrecognizedOptionsError);
 
-    const unipikaSettings = useSelector(getNodeUnrecognizedOptionsYsonSettings);
+    const unipikaSettings = useSelector(selectNodeUnrecognizedOptionsYsonSettings);
 
     return error ? (
         <YTErrorBlock error={error} />

--- a/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/NodesColumnHeader.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/NodesColumnHeader.tsx
@@ -7,7 +7,7 @@ import ColumnHeader, {
     type HasSortColumn,
 } from '../../../../../components/ColumnHeader/ColumnHeader';
 import {toggleColumnSortOrder} from '../../../../../store/actions/tables';
-import {getTables} from '../../../../../store/selectors/tables';
+import {selectTables} from '../../../../../store/selectors/tables';
 import {type NodesTableColumnNames} from '../../../../../pages/components/tabs/nodes/tables';
 import {oldSortStateToOrderType} from '../../../../../utils/sort-helpers';
 
@@ -15,7 +15,7 @@ export function NodesColumnHeader(
     props: HasSortColumn<NodesTableColumnNames> & Pick<ColumnHeaderProps, 'align'>,
 ) {
     const dispatch = useDispatch();
-    const sortState = useSelector(getTables)[COMPONENTS_NODES_TABLE_ID];
+    const sortState = useSelector(selectTables)[COMPONENTS_NODES_TABLE_ID];
     const order = oldSortStateToOrderType(sortState);
 
     const column = props.options?.find(({column}) => sortState.field === column);

--- a/packages/ui/src/ui/pages/components/tabs/nodes/SetupModal/SetupModal.js
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/SetupModal/SetupModal.js
@@ -26,7 +26,7 @@ import {FLAG_STATE, MEDIUM_COLS_PREFIX} from '../../../../../constants/component
 import {updateListWithAll} from '../../../../../utils';
 import {parseBytes} from '../../../../../utils/parse/parse-bytes';
 
-import {getMediumListNoCache} from '../../../../../store/selectors/thor';
+import {selectMediumListNoCache} from '../../../../../store/selectors/thor';
 import TagsFilter from './TagsFilter/TagsFilter';
 import {
     selectComponentNodesFiltersSetup,
@@ -813,7 +813,7 @@ export class SetupModal extends Component {
 const mapStateToProps = (state) => {
     return {
         setup: selectComponentNodesFiltersSetup(state),
-        mediumList: getMediumListNoCache(state),
+        mediumList: selectMediumListNoCache(state),
         nodeTags: selectComponentNodesTags(state),
         nodeRacks: selectComponentNodesRacks(state),
         nodeStates: COMPONENTS_AVAILABLE_STATES,

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/AccountsWidgetHeader/AccountsWidgetHeader.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/AccountsWidgetHeader/AccountsWidgetHeader.tsx
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
 import {WidgetHeader} from '../../../../../../pages/dashboard2/Dashboard/components/WidgetHeader/WidgetHeader';
-import {getMediumList} from '../../../../../../store/selectors/thor';
+import {selectMediumList} from '../../../../../../store/selectors/thor';
 import {type YTError} from '../../../../../../types';
 
 import {useAccountsWidget} from '../hooks/use-accounts-widget';
@@ -13,7 +13,7 @@ import i18n from '../i18n';
 export function AccountsWidgetHeader(props: AccountsWidgetProps) {
     const name = props?.data?.name;
     const {accounts, isLoading, userColumns} = useAccountsWidget(props);
-    const mediumList = useSelector(getMediumList);
+    const mediumList = useSelector(selectMediumList);
 
     const error = useMemo((): YTError | undefined => {
         if (!Array.isArray(userColumns)) {

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/settings/index.tsx
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Accounts/settings/index.tsx
@@ -1,11 +1,11 @@
 import {useSelector} from '../../../../../../store/redux-hooks';
 
-import {getMediumList} from '../../../../../../store/selectors/thor';
+import {selectMediumList} from '../../../../../../store/selectors/thor';
 
 import i18n from '../i18n';
 
 export function useAccountsSettings() {
-    const mediumList = useSelector(getMediumList);
+    const mediumList = useSelector(selectMediumList);
 
     return [
         {

--- a/packages/ui/src/ui/pages/flow/Flow/PipelineSpec/PipelineSpec.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/PipelineSpec/PipelineSpec.tsx
@@ -22,7 +22,7 @@ import {
     selectFlowStaticSpecError,
     selectFlowStaticSpecFirstLoading,
 } from '../../../../store/selectors/flow/specs';
-import {getFlowSpecYsonSettings} from '../../../../store/selectors/thor/unipika';
+import {selectFlowSpecYsonSettings} from '../../../../store/selectors/thor/unipika';
 import {type FlowSpecState} from '../../../../store/reducers/flow/specs';
 
 import {YsonDownloadButton} from '../../../../components/DownloadAttributesButton';
@@ -53,7 +53,7 @@ type PipelineSpecProps = {
 function PipelineSpec({path, data, error, name, onSave, allowForce}: PipelineSpecProps) {
     const [showEdit, setShowEdit] = React.useState(false);
 
-    const settings = useSelector(getFlowSpecYsonSettings);
+    const settings = useSelector(selectFlowSpecYsonSettings);
 
     return (
         <React.Fragment>

--- a/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
+++ b/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
@@ -18,7 +18,7 @@ import Label from '../../../components/Label';
 import {YsonWithScroll} from '../../../components/Yson/YsonWithScroll';
 import Tabs from '../../../components/Tabs/Tabs';
 
-import {getJobGeneralYsonSettings} from '../../../store/selectors/thor/unipika';
+import {selectJobGeneralYsonSettings} from '../../../store/selectors/thor/unipika';
 import {DEFAULT_TAB, Tab} from '../../../constants/job';
 import {type RootState} from '../../../store/reducers';
 import {Page} from '../../../constants/index';
@@ -47,7 +47,7 @@ const block = cn('job-general');
 export default function JobGeneral() {
     const cluster = useSelector(selectCluster);
     const match = useRouteMatch<RouteInfo>();
-    const settings = useSelector(getJobGeneralYsonSettings);
+    const settings = useSelector(selectJobGeneralYsonSettings);
     const job = useSelector(selectJob);
     const {loaded} = useSelector((state: RootState) => state.job.general);
 

--- a/packages/ui/src/ui/pages/job/tabs/Specification/Specification.tsx
+++ b/packages/ui/src/ui/pages/job/tabs/Specification/Specification.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../../store/actions/job/specification';
 
 import './Specification.scss';
-import {getJobSpecificationYsonSettings} from '../../../../store/selectors/thor/unipika';
+import {selectobSpecificationYsonSettings} from '../../../../store/selectors/thor/unipika';
 import {YsonDownloadButton} from '../../../../components/DownloadAttributesButton';
 import {selectJob} from '../../../../store/selectors/job/detail';
 
@@ -109,7 +109,7 @@ export default function Specification({className, jobID}: SpecificationProps) {
     }, [dispatch, jobID]);
 
     const initialLoading = loading && !loaded;
-    const settings = useSelector(getJobSpecificationYsonSettings);
+    const settings = useSelector(selectobSpecificationYsonSettings);
 
     return (
         <ErrorBoundary>

--- a/packages/ui/src/ui/pages/job/tabs/Specification/Specification.tsx
+++ b/packages/ui/src/ui/pages/job/tabs/Specification/Specification.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../../store/actions/job/specification';
 
 import './Specification.scss';
-import {selectobSpecificationYsonSettings} from '../../../../store/selectors/thor/unipika';
+import {selectJobSpecificationYsonSettings} from '../../../../store/selectors/thor/unipika';
 import {YsonDownloadButton} from '../../../../components/DownloadAttributesButton';
 import {selectJob} from '../../../../store/selectors/job/detail';
 
@@ -109,7 +109,7 @@ export default function Specification({className, jobID}: SpecificationProps) {
     }, [dispatch, jobID]);
 
     const initialLoading = loading && !loaded;
-    const settings = useSelector(selectobSpecificationYsonSettings);
+    const settings = useSelector(selectJobSpecificationYsonSettings);
 
     return (
         <ErrorBoundary>

--- a/packages/ui/src/ui/pages/navigation/content/MapNode/MapNode.js
+++ b/packages/ui/src/ui/pages/navigation/content/MapNode/MapNode.js
@@ -26,7 +26,7 @@ import MapNodesTable from './MapNodesTable';
 import {openCreateTableModal} from '../../../../store/actions/navigation/modals/create-table';
 import {selectPath, selectTransaction} from '../../../../store/selectors/navigation';
 import {selectNavigationPathAttributes} from '../../../../store/selectors/navigation/navigation';
-import {getMediumList} from '../../../../store/selectors/thor';
+import {selectMediumList} from '../../../../store/selectors/thor';
 import {
     selectContentMode,
     selectError,
@@ -161,7 +161,7 @@ function mapStateToProps(state) {
         contentMode: selectContentMode(state),
         filterState: selectFilterState(state),
         transaction: selectTransaction(state),
-        mediumList: getMediumList(state),
+        mediumList: selectMediumList(state),
         mediumType: selectMediumType(state),
         showCreateTableModal: selectIsCreateTableModalVisible(state),
         attributes: selectNavigationPathAttributes(state),

--- a/packages/ui/src/ui/pages/navigation/content/Table/Table.js
+++ b/packages/ui/src/ui/pages/navigation/content/Table/Table.js
@@ -42,7 +42,7 @@ import {
     selectYqlTypes,
 } from '../../../../store/selectors/navigation/content/table-ts';
 import {selectCluster} from '../../../../store/selectors/global';
-import {getTableYsonSettings} from '../../../../store/selectors/thor/unipika';
+import {selectTableYsonSettings} from '../../../../store/selectors/thor/unipika';
 import {useRumMeasureStop} from '../../../../rum/RumUiContext';
 import {useAppRumMeasureStart} from '../../../../rum/rum-app-measures';
 import {isFinalLoadingStatus} from '../../../../utils/utils';
@@ -210,7 +210,7 @@ function Table(props) {
 const mapStateToProps = (state) => {
     const {loading, loaded, error, errorData, isColumnSelectorOpen, isFullScreen} =
         state.navigation.content.table;
-    const settings = getTableYsonSettings(state);
+    const settings = selectTableYsonSettings(state);
     const {isSplit} = state.global.splitScreen;
 
     const path = selectPath(state);

--- a/packages/ui/src/ui/pages/navigation/modals/AttributesEditor.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/AttributesEditor.tsx
@@ -39,7 +39,7 @@ import {
     hideNavigationAttributesEditor,
     navigationSetNodeAttributes,
 } from '../../../store/actions/navigation/modals/attributes-editor';
-import {getMediumListNoCache} from '../../../store/selectors/thor';
+import {selectMediumListNoCache} from '../../../store/selectors/thor';
 
 import {selectCluster} from '../../../store/selectors/global';
 import {selectPath} from '../../../store/selectors/navigation';
@@ -100,7 +100,7 @@ function AttributesEditorLoaded() {
     const singleMode = !(paths?.length! > 1);
     const attributes = paths?.length === 1 ? attributesMap[paths[0]] : {};
 
-    const mediumList = useSelector(getMediumListNoCache);
+    const mediumList = useSelector(selectMediumListNoCache);
     const dispatch = useDispatch();
     const storeError = useSelector(selectNavigationAttributesEditorError);
 

--- a/packages/ui/src/ui/pages/navigation/tabs/TableMountConfig/TableMountConfig.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/TableMountConfig/TableMountConfig.tsx
@@ -4,7 +4,7 @@ import {useSelector} from '../../../../store/redux-hooks';
 import {selectNavigationTableMountConfig} from '../../../../store/selectors/navigation/content/table-mount-config';
 import {YTErrorBlock} from '../../../../containers/Block/Block';
 import {YsonWithScroll} from '../../../../components/Yson/YsonWithScroll';
-import {getNavigationMountConfigYsonSettings} from '../../../../store/selectors/thor/unipika';
+import {selectNavigationMountConfigYsonSettings} from '../../../../store/selectors/thor/unipika';
 import {YsonDownloadButton} from '../../../../components/DownloadAttributesButton';
 import {type UnipikaValue} from '../../../../components/Yson/StructuredYson/StructuredYsonTypes';
 import {pathToFileName} from '../../helpers/pathToFileName';
@@ -16,7 +16,7 @@ function TableMountConfig() {
     const {data, error} = useSelector(selectNavigationTableMountConfig);
     const path = useSelector(selectPath);
 
-    const settings = useSelector(getNavigationMountConfigYsonSettings);
+    const settings = useSelector(selectNavigationMountConfigYsonSettings);
 
     return (
         <div className={block('table-mount-config')}>

--- a/packages/ui/src/ui/pages/operations/OperationDetail/ExperimentAssignments/ExperimentAssignments.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/ExperimentAssignments/ExperimentAssignments.tsx
@@ -15,7 +15,7 @@ import {ClickableText} from '../../../../components/ClickableText/ClickableText'
 import {MetaTable} from '@ytsaurus/components';
 import StarTrackLink from '../../../../components/StarTrackLink/StarTrackLink';
 import {YsonWithScroll} from '../../../../components/Yson/YsonWithScroll';
-import {getOperationExperimentsYsonSettings} from '../../../../store/selectors/thor/unipika';
+import {selectOperationExperimentsYsonSettings} from '../../../../store/selectors/thor/unipika';
 import {UI_COLLAPSIBLE_SIZE} from '../../../../constants/global';
 import {YsonDownloadButton} from '../../../../components/DownloadAttributesButton';
 
@@ -62,7 +62,7 @@ function ExperimentAssignmentsItem(props: ItemProps) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {fraction: _fr, ...effect} = ypath.getValue(data, '/effect');
 
-    const settings = useSelector(getOperationExperimentsYsonSettings);
+    const settings = useSelector(selectOperationExperimentsYsonSettings);
 
     const toggleEffectVisibility = React.useCallback(() => {
         setEffectVisibility(!effectVisible);

--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -71,8 +71,8 @@ import {
     selectTotalJobWallTime,
 } from '../../../store/selectors/operations/statistics-v2';
 import {selectShowIncarnationsNext} from '../../../store/selectors/settings/operations';
-import {getCurrentCluster} from '../../../store/selectors/thor';
-import {getYsonSettingsDisableDecode} from '../../../store/selectors/thor/unipika';
+import {selectCurrentCluster} from '../../../store/selectors/thor';
+import {selectYsonSettingsDisableDecode} from '../../../store/selectors/thor/unipika';
 import {type OperationPool, type OperationStates} from '../selectors';
 import './OperationDetail.scss';
 import {JobsTimeline} from './tabs/JobsTimeline';
@@ -553,7 +553,7 @@ const mapStateToProps = (state: RootState, routerProps: RouteProps) => {
     const monitorTabVisible = Boolean(monitoringComponent) || Boolean(monitorTabUrlTemplate);
 
     return {
-        cluster: getCurrentCluster(state),
+        cluster: selectCurrentCluster(state),
         operation,
         errorData,
         loading,
@@ -575,7 +575,7 @@ const mapStateToProps = (state: RootState, routerProps: RouteProps) => {
         isGpuOperation: selectIsOperationInGpuTree(state),
         operationPerformanceUrlTemplate: selectOperationPerformanceUrlTemplate(state),
         operationEvents,
-        ysonSettings: getYsonSettingsDisableDecode(state),
+        ysonSettings: selectYsonSettingsDisableDecode(state),
         showIncarnationsNext: selectShowIncarnationsNext(state),
     };
 };

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/attributes/OperationAttributes.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/attributes/OperationAttributes.tsx
@@ -7,7 +7,7 @@ import {
     selectOperationTypedAttributes,
 } from '../../../../../store/selectors/operations/operation';
 import {YsonWithScroll} from '../../../../../components/Yson/YsonWithScroll';
-import {getYsonSettingsDisableDecode} from '../../../../../store/selectors/thor/unipika';
+import {selectYsonSettingsDisableDecode} from '../../../../../store/selectors/thor/unipika';
 import {useRumMeasureStop} from '../../../../../rum/RumUiContext';
 import {RumMeasureTypes} from '../../../../../rum/rum-measure-types';
 import {isFinalLoadingStatus} from '../../../../../utils/utils';
@@ -37,7 +37,7 @@ function useOperationAttributesRumMesures() {
 
 function OperationAttributes({className}: {className: string}) {
     const typedAttributes = useSelector(selectOperationTypedAttributes);
-    const settings = useSelector(getYsonSettingsDisableDecode);
+    const settings = useSelector(selectYsonSettingsDisableDecode);
     const id = useSelector(selectOperationId);
 
     useOperationAttributesRumMesures();

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Description.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Description.tsx
@@ -9,7 +9,7 @@ import CollapsableText from '../../../../../components/CollapsableText/Collapsab
 import {MetaTable} from '@ytsaurus/components';
 import {Yson} from '../../../../../components/Yson/Yson';
 import {canRenderAsMap} from './helpers/canRenderAsMap';
-import {getYsonSettingsDisableDecode} from '../../../../../store/selectors/thor/unipika';
+import {selectYsonSettingsDisableDecode} from '../../../../../store/selectors/thor/unipika';
 import {type DetailedOperationSelector} from '../../../selectors';
 
 type Props = {
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export const Description: FC<Props> = ({description}) => {
-    const settings = useSelector(getYsonSettingsDisableDecode);
+    const settings = useSelector(selectYsonSettingsDisableDecode);
 
     if (canRenderAsMap(description)) {
         const value = ypath.getValue(description);

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
@@ -10,7 +10,7 @@ import {
 import {selectQueryEngine} from '../../../../store/selectors/query-tracker/query';
 import {selectPageSize} from '../../../../store/selectors/navigation/content/table-ts';
 import {setFilter} from '../../../../store/reducers/query-tracker/queryNavigationSlice';
-import {getYsonSettingsDisableDecode} from '../../../../store/selectors/thor/unipika';
+import {selectYsonSettingsDisableDecode} from '../../../../store/selectors/thor/unipika';
 import {useMonaco} from '../../hooks/useMonaco';
 import {createTableSelect} from '../helpers/createTableSelect';
 import {insertTextWhereCursor} from '../helpers/insertTextWhereCursor';
@@ -19,7 +19,7 @@ import ErrorBoundary from '../../../../containers/ErrorBoundary/ErrorBoundary';
 
 export const NavigationTable: FC = () => {
     const dispatch = useDispatch();
-    const ysonSettings = useSelector(getYsonSettingsDisableDecode);
+    const ysonSettings = useSelector(selectYsonSettingsDisableDecode);
     const clusterConfig = useSelector(selectNavigationClusterConfig);
     const table = useSelector(selectNavigationTable);
     const engine = useSelector(selectQueryEngine);

--- a/packages/ui/src/ui/pages/system/Resources/Resources.js
+++ b/packages/ui/src/ui/pages/system/Resources/Resources.js
@@ -9,7 +9,7 @@ import {Progress} from '@gravity-ui/uikit';
 
 import {YTErrorBlock} from '../../../containers/Block/Block';
 import hammer from '../../../common/hammer';
-import {getMediumList} from '../../../store/selectors/thor';
+import {selectMediumList} from '../../../store/selectors/thor';
 import {loadSystemResources} from '../../../store/actions/system/resources';
 import {useDispatch} from '../../../store/redux-hooks';
 import {useUpdater} from '../../../hooks/use-updater';
@@ -174,7 +174,7 @@ function mapStateToProps(state) {
     return {
         resources,
         nodeAttributes,
-        mediumList: getMediumList(state),
+        mediumList: selectMediumList(state),
     };
 }
 

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.tsx
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.tsx
@@ -20,7 +20,7 @@ import Label, {type LabelTheme} from '../../../components/Label';
 import {Yson} from '../../../components/Yson/Yson';
 
 import {histogramItems} from '../../../utils/tablet/tablet';
-import {getActiveHistogram, selectHistogram} from '../../../store/selectors/tablet/tablet';
+import {selectActiveHistogram, selectHistogram} from '../../../store/selectors/tablet/tablet';
 import {changeActiveHistogram} from '../../../store/actions/tablet/tablet';
 import {Tab as NavigationTab} from '../../../constants/navigation';
 import {Page} from '../../../constants/index';
@@ -209,7 +209,7 @@ function Overview({id, block}: Props) {
     };
     const stateTheme: LabelTheme | undefined = stateThemeMap[state as string];
 
-    const activeHistogram = useSelector(getActiveHistogram);
+    const activeHistogram = useSelector(selectActiveHistogram);
     const histogram = useSelector(selectHistogram);
 
     const handleHistogramChange = useCallback(

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Partitions.js
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Partitions.js
@@ -18,8 +18,8 @@ import Label from '../../../components/Label';
 import {StickyContainer} from '../../../components/StickyContainer/StickyContainer';
 
 import {TABLET_PARTITIONS_TABLE_ID} from '../../../constants/tablet';
-import {tabletChangeContentMode} from '../../../store/actions/tablet/tablet';
-import {getPartitions} from '../../../store/selectors/tablet/tablet';
+import {changeContentMode} from '../../../store/actions/tablet/tablet';
+import {selectPartitions} from '../../../store/selectors/tablet/tablet';
 import {partitionsTableItems} from '../../../utils/tablet/table';
 import StoresDialog from './StoresDialog';
 
@@ -280,7 +280,7 @@ const mapDispatchToProps = {
 
 const mapStateToProps = (state) => {
     const {contentMode, tabletPath, unorderedDynamicTable} = state.tablet.tablet;
-    const partitions = getPartitions(state);
+    const partitions = selectPartitions(state);
 
     return {contentMode, tabletPath, partitions, unorderedDynamicTable};
 };

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Stores.js
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Stores.js
@@ -15,7 +15,7 @@ import LoadDataHandler from '../../../containers/LoadDataHandler/LoadDataHandler
 import {abortAndReset, loadStoresData} from '../../../store/actions/tablet/stores';
 import {TABLET_PARTITION_STORES_TABLE_ID} from '../../../constants/tablet';
 import {storesTableItems} from '../../../utils/tablet/table';
-import {getStores} from '../../../store/selectors/tablet/stores';
+import {selectStores} from '../../../store/selectors/tablet/stores';
 
 import i18n from './i18n';
 import './Stores.scss';
@@ -238,7 +238,7 @@ class Stores extends Component {
 
 const mapStateToProps = (state) => {
     const {loading, loaded, error, errorData} = state.tablet.stores;
-    const stores = getStores(state);
+    const stores = selectStores(state);
 
     return {loading, loaded, error, errorData, stores};
 };

--- a/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
@@ -41,7 +41,7 @@ import {selectDefaultTableColumnLimit} from '../../selectors/settings';
 import {selectIsYqlTypesEnabled} from '../../selectors/navigation/content/table';
 import {getClusterProxy, selectCurrentUserName} from '../../selectors/global';
 import {selectQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
-import {getYsonSettingsDisableDecode} from '../../selectors/thor/unipika';
+import {selectYsonSettingsDisableDecode} from '../../selectors/thor/unipika';
 import {QueriesListMode} from '../../../types/query-tracker/queryList';
 import {type ClusterConfig} from '../../../../shared/yt-types';
 import {type YTError} from '../../../../@types/types';
@@ -117,7 +117,7 @@ export const loadTableAttributesByPath =
         const defaultTableColumnLimit = selectDefaultTableColumnLimit(state);
         const useYqlTypes = selectIsYqlTypesEnabled(state);
         const login = selectCurrentUserName(state);
-        const ysonSettings = getYsonSettingsDisableDecode(state);
+        const ysonSettings = selectYsonSettingsDisableDecode(state);
 
         if (!clusterConfig) return;
 

--- a/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts-ts.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../constants/accounts/accounts';
 import hammer from '../../../common/hammer';
 import {type FIX_MY_TYPE} from '../../../types';
-import {getMediumListNoCache} from '../thor';
+import {selectMediumListNoCache} from '../thor';
 import ypath from '../../../common/thor/ypath';
 
 import {accountMemoryMediumToFieldName} from '../../../utils/accounts/accounts-selector';
@@ -187,7 +187,7 @@ function makeStaticConfigurationItem(
 }
 
 export const selectActiveAccountStaticConfiguration = createSelector(
-    [selectActiveAccount, selectAccountsTree, getMediumListNoCache],
+    [selectActiveAccount, selectAccountsTree, selectMediumListNoCache],
     (activeAccount, tree = {}, mediums = []) => {
         const item = tree[activeAccount];
         if (!item) {

--- a/packages/ui/src/ui/store/selectors/accounts/accounts.js
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts.js
@@ -7,7 +7,7 @@ import set_ from 'lodash/set';
 
 import {createSelector} from 'reselect';
 import {ACCOUNTS_TABLE_ID, ROOT_ACCOUNT_NAME} from '../../../constants/accounts/accounts';
-import {getTables} from '../../../store/selectors/tables';
+import {selectTables} from '../../../store/selectors/tables';
 import hammer from '../../../common/hammer';
 import ypath from '../../../common/thor/ypath';
 import {
@@ -27,7 +27,7 @@ export const selectUsableAccounts = (state) => state.accounts.accounts.usableAcc
 export const selectAccountsNameFilter = (state) => state.accounts.accounts.activeNameFilter;
 export const selectAccountsAbcServiceIdSlugFilter = (state) =>
     state.accounts.accounts.abcServiceFilter;
-export const selectAccountsSortInfo = (state) => getTables(state)[ACCOUNTS_TABLE_ID];
+export const selectAccountsSortInfo = (state) => selectTables(state)[ACCOUNTS_TABLE_ID];
 
 export const selectEditableAccount = (state) => state.accounts.accounts.editableAccount;
 

--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
@@ -11,7 +11,7 @@ import {type RootState} from '../../../../../store/reducers';
 import {AttributesByProperty} from '../../../../../store/reducers/components/nodes/nodes/node';
 import {selectCluster} from '../../../../../store/selectors/global';
 import {selectSelectedColumns} from '../../../../../store/selectors/settings';
-import {getMediumListNoCache} from '../../../../../store/selectors/thor';
+import {selectMediumListNoCache} from '../../../../../store/selectors/thor';
 import {type ValueOf} from '../../../../../types';
 import {createMediumsPredicates} from '../../../../../utils/components/nodes/setup';
 import {

--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
@@ -43,7 +43,7 @@ const selectComponentsNodesNodeTypeRaw = (state: RootState) =>
 const selectCustomColumns = (state: RootState) => selectSelectedColumns(state) || defaultColumns;
 
 const selectMediumsPredicates = createSelector(
-    [selectComponentNodesFiltersSetup, getMediumListNoCache],
+    [selectComponentNodesFiltersSetup, selectMediumListNoCache],
     createMediumsPredicates,
 );
 
@@ -80,7 +80,7 @@ const selectFilteredNodes = createSelector(
 );
 
 export const selectVisibleNodes = createSelector(
-    [selectFilteredNodes, selectSortState, getMediumListNoCache, selectCluster],
+    [selectFilteredNodes, selectSortState, selectMediumListNoCache, selectCluster],
     (nodes, sortState, mediumList, cluster) => {
         return hammer.utils.sort(
             nodes.map((n) => ({...n, cluster})),
@@ -91,7 +91,7 @@ export const selectVisibleNodes = createSelector(
 );
 
 export const selectComponentNodesTableProps = createSelector(
-    [getMediumListNoCache],
+    [selectMediumListNoCache],
     getNodeTablesProps,
 );
 

--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/predicates.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/predicates.ts
@@ -19,7 +19,7 @@ import {
     groupFilterInitialState,
 } from '../../../../../store/reducers/components/nodes/setup/setup';
 import {MEDIUM_COLS_PREFIX} from '../../../../../constants/components/nodes/nodes';
-import {getMediumListNoCache} from '../../../../../store/selectors/thor';
+import {selectMediumListNoCache} from '../../../../../store/selectors/thor';
 import {type ValueOf} from '../../../../../types';
 import {type Node} from '../../../../reducers/components/nodes/nodes/node';
 import {isRangeFilterDefined} from '../../../../../utils/components/nodes/setup';
@@ -74,7 +74,7 @@ export const selectComponentNodesFilterStatePredicate = createSelector(
 );
 
 export const selectComponentNodesFiltersSetup = createSelector(
-    [selectSetupFiltersRaw, getMediumListNoCache],
+    [selectSetupFiltersRaw, selectMediumListNoCache],
     (setup, mediumList) => {
         const mediumDefaults = reduce_(
             mediumList,

--- a/packages/ui/src/ui/store/selectors/navigation/content/transaction-map.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/transaction-map.js
@@ -5,7 +5,7 @@ import {NAVIGATION_TRANSACTION_MAP_TABLE_ID} from '../../../../constants/navigat
 import {calculateLoadingStatus} from '../../../../utils/utils';
 
 const getRawTransactions = (state) => state.navigation.content.transactionMap.transactions;
-const getSortState = (state) => state.tables[NAVIGATION_TRANSACTION_MAP_TABLE_ID];
+const selectSortState = (state) => state.tables[NAVIGATION_TRANSACTION_MAP_TABLE_ID];
 const getFilter = (state) => state.navigation.content.transactionMap.filter;
 
 const selectFilteredTransactions = createSelector(
@@ -19,7 +19,7 @@ const selectFilteredTransactions = createSelector(
 );
 
 export const selectTransactions = createSelector(
-    [selectFilteredTransactions, getSortState],
+    [selectFilteredTransactions, selectSortState],
     (filteredTransactions, sortState) =>
         hammer.utils.sort(filteredTransactions, sortState, tableItems),
 );

--- a/packages/ui/src/ui/store/selectors/tables.ts
+++ b/packages/ui/src/ui/store/selectors/tables.ts
@@ -1,4 +1,4 @@
 import {type RootState} from '../../store/reducers';
 import {initialState} from '../../store/reducers/tables';
 
-export const getTables = (state: RootState) => state.tables || initialState;
+export const selectTables = (state: RootState) => state.tables || initialState;

--- a/packages/ui/src/ui/store/selectors/tablet/stores.js
+++ b/packages/ui/src/ui/store/selectors/tablet/stores.js
@@ -3,9 +3,10 @@ import {createSelector} from 'reselect';
 import {storesTableItems} from '../../../utils/tablet/table';
 import {TABLET_PARTITION_STORES_TABLE_ID} from '../../../constants/tablet';
 
-const getRawStores = (state) => state.tablet.stores.stores;
-const getSortState = (state) => state.tables[TABLET_PARTITION_STORES_TABLE_ID];
+const selectRawStores = (state) => state.tablet.stores.stores;
+const selectSortState = (state) => state.tables[TABLET_PARTITION_STORES_TABLE_ID];
 
-export const getStores = createSelector([getRawStores, getSortState], (stores, sortState) =>
-    hammer.utils.sort(stores, sortState, storesTableItems),
+export const selectStores = createSelector(
+    [selectRawStores, selectSortState],
+    (stores, sortState) => hammer.utils.sort(stores, sortState, storesTableItems),
 );

--- a/packages/ui/src/ui/store/selectors/tablet/tablet.js
+++ b/packages/ui/src/ui/store/selectors/tablet/tablet.js
@@ -7,16 +7,16 @@ import {histogramItems} from '../../../utils/tablet/tablet';
 import {partitionsTableItems} from '../../../utils/tablet/table';
 import {TABLET_PARTITIONS_TABLE_ID} from '../../../constants/tablet';
 
-const getRawPartitions = (state) => state.tablet.tablet.partitions;
-const getSortState = (state) => state.tables[TABLET_PARTITIONS_TABLE_ID];
-export const getActiveHistogram = (state) => state.tablet.tablet.activeHistogram;
+const selectRawPartitions = (state) => state.tablet.tablet.partitions;
+const selectSortState = (state) => state.tables[TABLET_PARTITIONS_TABLE_ID];
+export const selectActiveHistogram = (state) => state.tablet.tablet.activeHistogram;
 
-export const getSortedPartitions = createSelector(
-    [getRawPartitions, getSortState],
+export const selectSortedPartitions = createSelector(
+    [selectRawPartitions, selectSortState],
     (partitions, sortState) => hammer.utils.sort(partitions, sortState, partitionsTableItems),
 );
 
-export const getPartitions = createSelector(getSortedPartitions, (sortedPartitions) => {
+export const selectPartitions = createSelector(selectSortedPartitions, (sortedPartitions) => {
     const aggregation = hammer.aggregation.prepare(sortedPartitions, [
         {name: 'stores', type: 'concat-array'},
         {name: 'storeCount', type: 'sum'},
@@ -31,7 +31,7 @@ export const getPartitions = createSelector(getSortedPartitions, (sortedPartitio
     return [aggregation, ...sortedPartitions];
 });
 
-const selectHistograms = createSelector(getRawPartitions, (partitions) =>
+const selectHistograms = createSelector(selectRawPartitions, (partitions) =>
     mapValues_(histogramItems, (settings, key) => {
         const partitionsWithoutEden = partitions.slice(1);
 
@@ -47,6 +47,6 @@ const selectHistograms = createSelector(getRawPartitions, (partitions) =>
 );
 
 export const selectHistogram = createSelector(
-    [selectHistograms, getActiveHistogram],
+    [selectHistograms, selectActiveHistogram],
     (histograms, activeHistogram) => histograms[activeHistogram],
 );

--- a/packages/ui/src/ui/store/selectors/thor/index.js
+++ b/packages/ui/src/ui/store/selectors/thor/index.js
@@ -4,13 +4,13 @@ import {createSelector} from 'reselect';
 import hammer from '../../../common/hammer';
 import {MediumType} from '../../../constants/index';
 
-export const getMediumList = createSelector(
+export const selectMediumList = createSelector(
     (state) => state.global.mediumList,
     (data) => hammer.utils.sortInPredefinedOrder([MediumType.DEFAULT], [...data]),
 );
 
-export const getMediumListNoCache = createSelector([getMediumList], (mediums) =>
+export const selectMediumListNoCache = createSelector([selectMediumList], (mediums) =>
     filter_(mediums, (item) => item !== 'cache'),
 );
 
-export const getCurrentCluster = (state) => state.global.cluster;
+export const selectCurrentCluster = (state) => state.global.cluster;

--- a/packages/ui/src/ui/store/selectors/thor/unipika.ts
+++ b/packages/ui/src/ui/store/selectors/thor/unipika.ts
@@ -53,7 +53,7 @@ const selectYsonSettings = createSelector(
 
 export const selectJobGeneralYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const selectobSpecificationYsonSettings = createSelector([selectYsonSettings], clone_);
+export const selectJobSpecificationYsonSettings = createSelector([selectYsonSettings], clone_);
 
 export const selectTableYsonSettings = createSelector([selectYsonSettings], clone_);
 
@@ -65,7 +65,10 @@ export const selectNavigationMountConfigYsonSettings = createSelector([selectYso
 
 export const selectEditJsonYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const selectNodeUnrecognizedOptionsYsonSettings = createSelector([selectYsonSettings], clone_);
+export const selectNodeUnrecognizedOptionsYsonSettings = createSelector(
+    [selectYsonSettings],
+    clone_,
+);
 
 export const selectPreviewCellYsonSettings = createSelector([selectYsonSettings], clone_);
 
@@ -77,4 +80,4 @@ export const selectYsonSettingsDisableDecode = createSelector([selectYsonSetting
     return {...settings, decodeUTF8: false};
 });
 
-export const getYsonSettingsErrorDetails = createSelector([getYsonSettings], clone_);
+export const selectYsonSettingsErrorDetails = createSelector([selectYsonSettings], clone_);

--- a/packages/ui/src/ui/store/selectors/thor/unipika.ts
+++ b/packages/ui/src/ui/store/selectors/thor/unipika.ts
@@ -24,7 +24,7 @@ export interface YsonSettings {
  * unipika.format && unipika.foramtRaw mix different properties into settings-object.
  * So, to minimize side-effects each UI-component should use his-own copy of settings-object.
  */
-const getYsonSettings = createSelector(
+const selectYsonSettings = createSelector(
     [
         selectFormat,
         selectShowDecoded,
@@ -51,29 +51,29 @@ const getYsonSettings = createSelector(
     },
 );
 
-export const getJobGeneralYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectJobGeneralYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getJobSpecificationYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectobSpecificationYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getTableYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectTableYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getOperationAttributesYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectOperationAttributesYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getOperationExperimentsYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectOperationExperimentsYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getNavigationMountConfigYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectNavigationMountConfigYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getEditJsonYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectEditJsonYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getNodeUnrecognizedOptionsYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectNodeUnrecognizedOptionsYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getPreviewCellYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectPreviewCellYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getFlowSpecYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectFlowSpecYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getErrorsYsonSettings = createSelector([getYsonSettings], clone_);
+export const selectErrorsYsonSettings = createSelector([selectYsonSettings], clone_);
 
-export const getYsonSettingsDisableDecode = createSelector([getYsonSettings], (settings) => {
+export const selectYsonSettingsDisableDecode = createSelector([selectYsonSettings], (settings) => {
     return {...settings, decodeUTF8: false};
 });
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/vAYoq8Ji7dKHJN
<!-- nda-end -->         ## Summary by Sourcery

Align selector naming with a unified `select*` convention across the UI store and update all consumers accordingly, along with minor formatting cleanup in shared math utilities.

Enhancements:
- Rename various Redux selector helpers (tables, thor/unipika, tablet, tablet stores, thor medium/cluster, settings, nodes, accounts, navigation transactions, etc.) to the `select*` naming convention and propagate these changes to all call sites.
- Standardize code style and indentation in the shared math utilities module without changing behavior.