### PR TITLE
feat(Navigation/Table): add rls-access meta table item [YTFRONT-5782]

### DIFF
--- a/packages/ui/src/ui/pages/navigation/content/Table/TableMeta/TableMeta.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/TableMeta/TableMeta.tsx
@@ -14,16 +14,19 @@ import {selectIsDynamic} from '../../../../../store/selectors/navigation/content
 import {
     selectAttributes,
     selectAttributesWithTypes,
+    selectPath,
+    selectTransaction,
 } from '../../../../../store/selectors/navigation';
 import {selectTabletErrorsBackgroundCount} from '../../../../../store/selectors/navigation/tabs/tablet-errors-background';
 import {type Props as AutomaticModeSwitchProps} from './AutomaticModeSwitch';
 
 import {type RootState} from '../../../../../store/reducers';
-import {selectCluster} from '../../../../../store/selectors/global';
+import {selectCluster, selectCurrentUserName} from '../../../../../store/selectors/global';
 
 import {UI_COLLAPSIBLE_SIZE} from '../../../../../constants/global';
 
 import './TableMeta.scss';
+import {useTableAccessMetaItem} from '../table-hooks/useTableAccessMetaItem';
 
 const block = cn('navigation-meta-table');
 
@@ -47,8 +50,14 @@ function TableMeta({
     const tabletErrorCount = useSelector(selectTabletErrorsBackgroundCount);
     const cluster = useSelector(selectCluster);
 
+    const path = useSelector(selectPath);
+    const transaction_id = useSelector(selectTransaction);
+    const user = useSelector(selectCurrentUserName);
+
+    const accessItem = useTableAccessMetaItem({path, transaction_id, user});
+
     const items = useMemo(() => {
-        return makeMetaItems({
+        const res = makeMetaItems({
             cluster,
             attributes,
             tableType,
@@ -58,7 +67,13 @@ function TableMeta({
             onEditEnableReplicatedTableTracker,
             navigationTableConfig: ytComponentsNavigationMetaConfig,
         });
+        if (accessItem) {
+            res[0].push(accessItem);
+        }
+
+        return res;
     }, [
+        accessItem,
         cluster,
         attributes,
         tableType,

--- a/packages/ui/src/ui/pages/navigation/content/Table/table-hooks/useTableAccessMetaItem.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/table-hooks/useTableAccessMetaItem.tsx
@@ -1,0 +1,73 @@
+import {Lock} from '@gravity-ui/icons';
+import {Flex} from '@gravity-ui/uikit';
+import {Tooltip} from '@ytsaurus/components';
+import compact_ from 'lodash/compact';
+import React from 'react';
+import HelpLink from '../../../../../components/HelpLink/HelpLink';
+import Label from '../../../../../components/Label';
+import {YTErrorInline} from '../../../../../containers/YTErrorInline/YTErrorInline';
+import {YTApiId} from '../../../../../rum/rum-wrap-api';
+import {useCheckPermissionQuery} from '../../../../../store/api/yt/checkPermissions';
+import {useGetQuery} from '../../../../../store/api/yt/get';
+import UIFactory from '../../../../../UIFactory';
+
+type UseTableAccessMetaItemParams = {
+    path: string;
+    user: string;
+    transaction_id?: string;
+};
+
+export function useTableAccessMetaItem({path, user, transaction_id}: UseTableAccessMetaItemParams) {
+    const fullReadPermission = useCheckPermissionQuery({
+        id: YTApiId.checkPermissions,
+        parameters: {
+            path,
+            transaction_id,
+            permission: 'full_read',
+            user,
+        },
+    });
+    const hasRls = useGetQuery<boolean>({
+        id: YTApiId.checkPermissions,
+        parameters: {transaction_id, path: `${path}/@has_row_level_ace`},
+    });
+
+    if (fullReadPermission.error || hasRls.error) {
+        const error = {
+            message: 'Failed to check row level access.',
+            inner_errors: compact_([fullReadPermission.error, hasRls.error]),
+        };
+        return {
+            key: 'access',
+            label: 'Access',
+            value: <YTErrorInline error={error} />,
+        };
+    }
+
+    const hasLimitedAccess = hasRls.data && fullReadPermission.data?.action === 'deny';
+    if (!hasLimitedAccess) {
+        return undefined;
+    }
+
+    return {
+        key: 'access',
+        label: 'Access',
+        value: (
+            <Label theme="warning">
+                <Flex gap={1} alignItems="center">
+                    <Lock />
+                    <Tooltip
+                        content={
+                            <>
+                                You can see subset of rows according to your subset of permissions.{' '}
+                                <HelpLink url={UIFactory.docsUrls['acl:row-level-security']} />,
+                            </>
+                        }
+                    >
+                        Limited
+                    </Tooltip>
+                </Flex>
+            </Label>
+        ),
+    };
+}

--- a/packages/ui/src/ui/playwright-components/playwright.config.ts
+++ b/packages/ui/src/ui/playwright-components/playwright.config.ts
@@ -45,7 +45,7 @@ const config: PlaywrightTestConfig = {
     */
     retries: process.env.CI ? 3 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 8 : undefined,
+    workers: process.env.CI ? 4 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter,
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/packages/ui/src/ui/store/api/yt/checkPermissions/endpoint.ts
+++ b/packages/ui/src/ui/store/api/yt/checkPermissions/endpoint.ts
@@ -1,4 +1,4 @@
-import {YTError} from '../../../../../@types/types';
+import {type YTError} from '../../../../../@types/types';
 import {type YTApiIdType} from '../../../../../shared/constants/yt-api-id';
 import {type CheckPermissionsParams} from '../../../../../shared/yt-types';
 import {ytApiV3Id} from '../../../../rum/rum-wrap-api';

--- a/packages/ui/src/ui/store/api/yt/checkPermissions/endpoint.ts
+++ b/packages/ui/src/ui/store/api/yt/checkPermissions/endpoint.ts
@@ -1,0 +1,18 @@
+import {YTError} from '../../../../../@types/types';
+import {type YTApiIdType} from '../../../../../shared/constants/yt-api-id';
+import {type CheckPermissionsParams} from '../../../../../shared/yt-types';
+import {ytApiV3Id} from '../../../../rum/rum-wrap-api';
+import {type YTEndpointApiArgs} from '../types';
+
+export type CheckPermissionParams = YTEndpointApiArgs<CheckPermissionsParams> & {
+    id: YTApiIdType;
+};
+
+export async function checkPermission({id, ...rest}: CheckPermissionParams) {
+    try {
+        const response: {action: 'allow' | 'deny'} = await ytApiV3Id.checkPermission(id, rest);
+        return {data: response};
+    } catch (error) {
+        return {error: error as YTError};
+    }
+}

--- a/packages/ui/src/ui/store/api/yt/checkPermissions/index.ts
+++ b/packages/ui/src/ui/store/api/yt/checkPermissions/index.ts
@@ -2,7 +2,7 @@ import {DEFAULT_UPDATER_TIMEOUT} from '../../../../hooks/use-updater';
 import {useSelector} from '../../../../store/redux-hooks';
 import {selectCluster} from '../../../../store/selectors/global/cluster';
 import {getUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
-import {OverrideDataType} from '../types';
+import {type OverrideDataType} from '../types';
 import {ytApi} from '../ytApi';
 import {type CheckPermissionParams, checkPermission} from './endpoint';
 

--- a/packages/ui/src/ui/store/api/yt/checkPermissions/index.ts
+++ b/packages/ui/src/ui/store/api/yt/checkPermissions/index.ts
@@ -1,0 +1,37 @@
+import {DEFAULT_UPDATER_TIMEOUT} from '../../../../hooks/use-updater';
+import {useSelector} from '../../../../store/redux-hooks';
+import {selectCluster} from '../../../../store/selectors/global/cluster';
+import {getUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
+import {OverrideDataType} from '../types';
+import {ytApi} from '../ytApi';
+import {type CheckPermissionParams, checkPermission} from './endpoint';
+
+const checkPermissionApi = ytApi.injectEndpoints({
+    endpoints: (build) => ({
+        checkPermissions: build.query({
+            queryFn: checkPermission,
+            providesTags: (_result, _error, params) => [params.id],
+        }),
+    }),
+});
+
+export function useCheckPermissionQuery(params: CheckPermissionParams) {
+    const useAutoRefresh = useSelector(getUseAutoRefresh);
+    const cluster = useSelector(selectCluster);
+
+    const options = {
+        pollingInterval: useAutoRefresh ? DEFAULT_UPDATER_TIMEOUT : undefined,
+        skipPollingIfUnfocused: true,
+    };
+
+    const customParams =
+        'setup' in params
+            ? params
+            : {
+                  ...params,
+                  cluster,
+              };
+
+    const res = checkPermissionApi.useCheckPermissionsQuery(customParams, options);
+    return res as OverrideDataType<typeof res, (typeof res)['data']>;
+}


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/DX_to51y7dd3YA
<!-- nda-end -->    ## Summary by Sourcery

Add navigation table metadata indicator for row-level access restrictions and wire it to permission checks via new YT checkPermissions API endpoint.

New Features:
- Display an 'Access' meta item in table metadata when row-level security limits a user's visible rows.
- Introduce a reusable hook to check table row-level security and surface corresponding status in the UI.

Enhancements:
- Add a YT checkPermissions API endpoint and React hook wrapper to query user access levels with auto-refresh support.
- Reduce CI Playwright workers on CI to lower parallelism for UI tests.