### PR TITLE
chore(Settings): replace SettingName.DEVELOPMENT.YQL_TYPES by 'global::development::yqlTypes' [YTFRONT-5513]

### DIFF
--- a/packages/ui/src/shared/constants/settings.ts
+++ b/packages/ui/src/shared/constants/settings.ts
@@ -51,7 +51,6 @@ export const SettingName = {
     },
     DEVELOPMENT: {
         REDIRECT_TO_BETA: 'redirectToBetaV2',
-        YQL_TYPES: 'yqlTypes',
         REGULAR_USER_UI: 'regularUserUI',
     },
     MENU: {

--- a/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
@@ -450,15 +450,10 @@ function useSettings(cluster: string, isAdmin: boolean): Array<SettingsPage> {
             tableIcon,
             compact_([
                 makeItem(
-                    SettingName.DEVELOPMENT.YQL_TYPES,
+                    'global::development::yqlTypes',
                     i18n('field_yql-v3-types'),
                     'top',
-                    <SettingsMenuItem
-                        settingName={SettingName.DEVELOPMENT.YQL_TYPES}
-                        settingNS={NAMESPACES.DEVELOPMENT}
-                        qa="settings_yql-v3-types"
-                        oneLine
-                    />,
+                    <BooleanSettingItem settingKey="global::development::yqlTypes" oneLine />,
                 ),
                 makeItem(
                     SettingName.NAVIGATION.ROWS_PER_TABLE_PAGE,

--- a/packages/ui/tests/screenshots/pages/navigation/navigation.table.base.screen.ts
+++ b/packages/ui/tests/screenshots/pages/navigation/navigation.table.base.screen.ts
@@ -202,7 +202,7 @@ test('Navigation: yql-v3-types', async ({page}) => {
     await test.step('Diable yql-v3-types', async () => {
         await table(page).settingsToggleVisibility();
         await table(page).settingsShowByName('YQL V3 types');
-        await table(page).setCheckboxValue('settings_yql-v3-types', false);
+        await table(page).setCheckboxValue('global::development::yqlTypes', false);
         await table(page).settingsToggleVisibility();
     });
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/7QLGOJr47dRXAn
<!-- nda-end --> ## Summary by Sourcery

Replace the YQL V3 types settings entry with a global settings key and update related UI and tests to use it.

Enhancements:
- Switch the YQL V3 types setting from SettingName.DEVELOPMENT.YQL_TYPES to the global::development::yqlTypes key in the settings panel.
- Simplify the YQL V3 types settings UI by using the generic BooleanSettingItem component.

Tests:
- Adjust navigation screenshot test to toggle the YQL V3 types setting using the new global::development::yqlTypes key.

Chores:
- Remove the unused SettingName.DEVELOPMENT.YQL_TYPES constant from shared settings constants.