### PR TITLE
chore(UI): remove scheme filter logic [YTFRONT-5744]

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -83,7 +83,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/type-is": "^1.6.3",
         "@vitejs/plugin-react": "^4.6.0",
-        "@ytsaurus/components": "^0.2.2",
+        "@ytsaurus/components": "^0.2.4",
         "bem-cn-lite": "^4.1.0",
         "bignumber.js": "^9.1.2",
         "colord": "^2.9.1",
@@ -13557,9 +13557,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ytsaurus/components": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@ytsaurus/components/-/components-0.2.2.tgz",
-      "integrity": "sha512-P639NLzst18hUJlnrP+KlllfbxJvrh7CKa05wOIFfSiOZ84oeM43ZSkqBAkIn0HWL3V1OoD9B5jd2ArEGf91Eg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@ytsaurus/components/-/components-0.2.4.tgz",
+      "integrity": "sha512-10B+B6MgMuSj9dXkZAxjHVr33cC1vK4ExcTLS9rkv6HTgGK4njq4+C8PZCIhwDM+mbo6yMuAB+YTBXfMGVFOaA==",
       "dev": true,
       "dependencies": {
         "@gravity-ui/i18n": "^1.8.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -150,7 +150,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/type-is": "^1.6.3",
     "@vitejs/plugin-react": "^4.6.0",
-    "@ytsaurus/components": "^0.2.2",
+    "@ytsaurus/components": "^0.2.4",
     "bem-cn-lite": "^4.1.0",
     "bignumber.js": "^9.1.2",
     "colord": "^2.9.1",

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
@@ -5,7 +5,7 @@ import {
     selectNavigationClusterConfig,
     selectNavigationFilter,
     selectNavigationPath,
-    selectTableWithFilter,
+    selectNavigationTable,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
 import {selectQueryEngine} from '../../../../store/selectors/query-tracker/query';
 import {selectPageSize} from '../../../../store/selectors/navigation/content/table-ts';
@@ -21,7 +21,7 @@ export const NavigationTable: FC = () => {
     const dispatch = useDispatch();
     const ysonSettings = useSelector(getYsonSettingsDisableDecode);
     const clusterConfig = useSelector(selectNavigationClusterConfig);
-    const table = useSelector(selectTableWithFilter);
+    const table = useSelector(selectNavigationTable);
     const engine = useSelector(selectQueryEngine);
     const limit = useSelector(selectPageSize);
     const path = useSelector(selectNavigationPath);

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
@@ -48,28 +48,12 @@ export const selectNavigationTable = (state: RootState) => state.queryTracker.qu
 const filterValueInText = (value: string, filter: string) =>
     value.toLowerCase().includes(filter.toLowerCase());
 
-export const selectTableWithFilter = createSelector(
-    [selectNavigationTable, selectNavigationFilter],
-    (table, filter) => {
-        if (!table) return null;
-
-        return {
-            ...table,
-            schema: table.schema.filter(({name, type}) => {
-                return filterValueInText(name, filter) || filterValueInText(type, filter);
-            }),
-        };
-    },
-);
-
-export const selectClustersByFilter = createSelector(
-    [selectClusterList, selectNavigationFilter],
-    (clusters, filter) => {
+export const selectClustersByFilter: (state: RootState) => ReturnType<typeof selectClusterList> =
+    createSelector([selectClusterList, selectNavigationFilter], (clusters, filter) => {
         if (!filter) return clusters;
 
         return clusters.filter(({name}) => filterValueInText(name, filter));
-    },
-);
+    });
 
 export const selectNodeListByFilter = createSelector(
     [selectNavigationNodes, selectNavigationFilter, selectNavigationPath],


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/3HRZE_oL7dKiGd
<!-- nda-end -->## Summary by Sourcery

Remove query tracker table schema filtering logic in the navigation view and align selectors and dependencies with the updated UI components package.

Enhancements:
- Drop the table schema filter selector from query tracker navigation and use the raw navigation table selector instead.
- Add an explicit return type to the clusters-by-filter selector for stronger typing.
- Update the @ytsaurus/components dependency to version ^0.2.4 in the UI package.