### PR TITLE
chore(TabletError): add i18n [YTFRONT-5069]

### DIFF
--- a/packages/ui/src/shared/tablet-errors-manager.ts
+++ b/packages/ui/src/shared/tablet-errors-manager.ts
@@ -23,12 +23,28 @@ export type TableMethodErrorsCount = {
 };
 
 export type TabletErrorsByBundleResponse = {
-    all_methods: Array<string>;
-    presented_methods: Array<string>;
+    all_methods: Array<AllMethodsValues>;
+    presented_methods: Array<AllMethodsValues>;
     errors: Array<TableMethodErrorsCount>;
     fixed_end_timestamp: unknown;
     total_row_count: number;
 };
+
+export type AllMethodsValues =
+    | 'Lookup'
+    | 'Select'
+    | 'Write'
+    | 'Compaction'
+    | 'Partitioning'
+    | 'Flush'
+    | 'Replication'
+    | 'PullRows'
+    | 'GetTabletInfo'
+    | 'ReadDynamicStore'
+    | 'FetchTabletStores'
+    | 'FetchTableRows'
+    | 'Trim'
+    | 'GetOrderedTabletSafeTrimRowCount';
 
 export type TabletErrorsBaseParams = {
     start_timestamp: number;

--- a/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundle.tsx
+++ b/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundle.tsx
@@ -29,6 +29,7 @@ import {makeNavigationLink} from '../../utils/app-url';
 
 import './TabletErrorsByBundle.scss';
 import {TabletErrorsByBundleToolbar} from './TabletErrorsByBundleToolbar';
+import i18n from './i18n';
 
 const block = cn('yt-tablet-errors-by-bunlde');
 
@@ -80,7 +81,7 @@ function useTabletErrorsColumns(loading: boolean) {
                 name: 'path',
                 header: (
                     <ColumnHeader
-                        column="Path"
+                        column={i18n('field_path')}
                         loading={loading}
                         pageIndex={pageFilter}
                         pageCount={pageCount}
@@ -104,7 +105,7 @@ function useTabletErrorsColumns(loading: boolean) {
             },
             {
                 name: 'dataOfLastError',
-                header: <ColumnHeader column="Date of last error" />,
+                header: <ColumnHeader column={i18n('field_date-of-last-error')} />,
                 render({row}) {
                     return moment(row.last_error_timestamp * 1000).format('YYYY-MM-DD HH:mm:ss');
                 },

--- a/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundleToolbar.tsx
+++ b/packages/ui/src/ui/pages/tablet-errors-by-bundle/TabletErrorsByBundleToolbar.tsx
@@ -26,6 +26,8 @@ import {
 import {loadTabletErrorsByBundle} from '../../store/actions/tablet-errors/tablet-errors-by-bundle';
 import UIFactory from '../../UIFactory';
 
+import i18n from './i18n';
+
 import './TabletErrorsByBundleToolbar.scss';
 
 const block = cn('yt-tablet-errors-by-bundle-toolbar');
@@ -88,7 +90,7 @@ export function TabletErrorsByBundleToolbar({
                         node: (
                             <TextInputWithDebounce
                                 className={block('path-filter')}
-                                placeholder={'Table path...'}
+                                placeholder={i18n('placeholder_table-path')}
                                 value={tablePathFilter}
                                 onUpdate={(value) => {
                                     dispatch(
@@ -104,7 +106,7 @@ export function TabletErrorsByBundleToolbar({
                         node: (
                             <Select
                                 multiple
-                                label="Methods:"
+                                label={i18n('field_methods')}
                                 value={methodsFilter}
                                 items={all_methods.map((value) => {
                                     return {value, text: value};
@@ -116,7 +118,7 @@ export function TabletErrorsByBundleToolbar({
                                         }),
                                     )
                                 }
-                                placeholder="Select..."
+                                placeholder={i18n('placeholder_select')}
                                 hasClear
                                 maxVisibleValuesTextLength={80}
                             />

--- a/packages/ui/src/ui/pages/tablet-errors-by-bundle/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/tablet-errors-by-bundle/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/tablet-errors-by-bundle/i18n/en.json
+++ b/packages/ui/src/ui/pages/tablet-errors-by-bundle/i18n/en.json
@@ -1,0 +1,7 @@
+{
+  "field_path": "Path",
+  "field_date-of-last-error": "Date of last error",
+  "field_methods": "Methods:",
+  "placeholder_table-path": "Table path...",
+  "placeholder_select": "Select..."
+}

--- a/packages/ui/src/ui/pages/tablet-errors-by-bundle/i18n/index.ts
+++ b/packages/ui/src/ui/pages/tablet-errors-by-bundle/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:tablet-errors-by-bundle', dicts);


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/LcR7bhSC7ddmAt
<!-- nda-end -->## Summary by Sourcery

Add internationalization support and stricter typing for the tablet errors by bundle UI.

Enhancements:
- Introduce a typed union for tablet method identifiers used in tablet error bundle responses.
- Localize labels and placeholders in the tablet errors by bundle toolbar and table columns via a new i18n keyset.