### PR TITLE
chore(System): rename system selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/pages/system/Nodes/NodeTypeSelector.tsx
+++ b/packages/ui/src/ui/pages/system/Nodes/NodeTypeSelector.tsx
@@ -4,7 +4,7 @@ import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {Select} from '@gravity-ui/uikit';
 
 import {NODE_TYPE_ITEMS} from '../../../constants/components/nodes/nodes';
-import {getSystemNodesNodeTypesToLoad} from '../../../store/selectors/system/nodes';
+import {selectSystemNodesNodeTypesToLoad} from '../../../store/selectors/system/nodes';
 import {setSysmetNodesNodeType} from '../../../store/actions/system/nodes-ts';
 import {NODE_TYPE, type NodeType} from '../../../../shared/constants/system';
 import {selectComponentsNodesNodeTypes} from '../../../store/selectors/components/nodes/nodes';
@@ -39,7 +39,7 @@ export function NodeTypeSelector(props: NodeTypeSelectorProps) {
 
 export function SystemNodeTypeSelector() {
     const dispatch = useDispatch();
-    const value = useSelector(getSystemNodesNodeTypesToLoad);
+    const value = useSelector(selectSystemNodesNodeTypesToLoad);
     return (
         <NodeTypeSelector
             value={value}

--- a/packages/ui/src/ui/pages/system/Nodes/Nodes.tsx
+++ b/packages/ui/src/ui/pages/system/Nodes/Nodes.tsx
@@ -28,7 +28,7 @@ import {
     getSettingSystemNodesNodeType,
     getSettingsSystemNodesCollapsed,
 } from '../../../store/selectors/settings/settings-ts';
-import {getSystemNodesNodeTypesToLoad} from '../../../store/selectors/system/nodes';
+import {selectSystemNodesNodeTypesToLoad} from '../../../store/selectors/system/nodes';
 import {
     type ComponentsNodesLinkParams,
     makeComponentsNodesLink,
@@ -267,7 +267,7 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 function NodesUpdater() {
     const dispatch = useDispatch();
 
-    const nodeTypes = useSelector(getSystemNodesNodeTypesToLoad);
+    const nodeTypes = useSelector(selectSystemNodesNodeTypesToLoad);
     const params = useMemoizedIfEqual(nodeTypes);
 
     const updateFn = React.useMemo(() => {

--- a/packages/ui/src/ui/pages/system/SchedulersAndAgents/SchedulersAndAgents.js
+++ b/packages/ui/src/ui/pages/system/SchedulersAndAgents/SchedulersAndAgents.js
@@ -11,10 +11,10 @@ import {CollapsibleSectionStateLess} from '../../../components/CollapsibleSectio
 import {StickyContainer} from '../../../components/StickyContainer/StickyContainer';
 import VisibleHostTypeRadioButton from '../../../pages/system/VisibleHostTypeRadioButton';
 import {
-    getSystemAgentsWithState,
-    getSystemSchedulerAndAgentAlerts,
-    getSystemSchedulerAndAgentCounters,
-    getSystemSchedulersWithState,
+    selectSystemAgentsWithState,
+    selectSystemSchedulerAndAgentAlerts,
+    selectSystemSchedulerAndAgentCounters,
+    selectSystemSchedulersWithState,
 } from '../../../store/selectors/system/schedulers';
 import Scheduler from './Scheduler/Scheduler';
 import {YTAlertBlock} from '../../../components/Alert/Alert';
@@ -174,10 +174,10 @@ class SchedulersAndAgents extends Component {
 
 function mapStateToProps(state) {
     return {
-        schedulers: getSystemSchedulersWithState(state),
-        agents: getSystemAgentsWithState(state),
-        counters: getSystemSchedulerAndAgentCounters(state),
-        alerts: getSystemSchedulerAndAgentAlerts(state),
+        schedulers: selectSystemSchedulersWithState(state),
+        agents: selectSystemAgentsWithState(state),
+        counters: selectSystemSchedulerAndAgentCounters(state),
+        alerts: selectSystemSchedulerAndAgentAlerts(state),
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
         collapsed: getSettingsSystemSchedulersCollapsed(state),
     };

--- a/packages/ui/src/ui/store/selectors/system/index.ts
+++ b/packages/ui/src/ui/store/selectors/system/index.ts
@@ -1,6 +1,0 @@
-import {type RootState} from '../../reducers';
-
-export const isSystemResourcesLoaded = (state: RootState) => {
-    const {loaded, nodeAttrsLoaded} = state.system.resources;
-    return loaded && nodeAttrsLoaded;
-};

--- a/packages/ui/src/ui/store/selectors/system/nodes.ts
+++ b/packages/ui/src/ui/store/selectors/system/nodes.ts
@@ -3,7 +3,7 @@ import {createSelector} from 'reselect';
 import {getSettingSystemNodesNodeType} from '../../../store/selectors/settings/settings-ts';
 import {NODE_TYPE} from '../../../../shared/constants/system';
 
-export const getSystemNodesNodeTypesToLoad = createSelector(
+export const selectSystemNodesNodeTypesToLoad = createSelector(
     [getSettingSystemNodesNodeType],
     (nodeTypes) => {
         const valueSet = new Set(nodeTypes);

--- a/packages/ui/src/ui/store/selectors/system/schedulers.js
+++ b/packages/ui/src/ui/store/selectors/system/schedulers.js
@@ -7,15 +7,16 @@ import ypath from '@ytsaurus/interface-helpers/lib/ypath';
 import {VisibleHostType} from '../../../constants/system/masters';
 import {getMastersHostType} from '../../../store/selectors/settings';
 
-export const getSystemSchedulers = (state) => state.system.schedulersAndAgents.schedulers;
-export const getSystemSchedulerAlerts = (state) => state.system.schedulersAndAgents.schedulerAlerts;
-export const getSystemAgents = (state) => state.system.schedulersAndAgents.agents;
-export const getSystemAgentAlerts = (state) => state.system.schedulersAndAgents.agentAlerts;
-export const getSystemSchedulerAndAgentVisibleHostType = (state) =>
+export const selectSystemSchedulers = (state) => state.system.schedulersAndAgents.schedulers;
+export const selectSystemSchedulerAlerts = (state) =>
+    state.system.schedulersAndAgents.schedulerAlerts;
+export const selectSystemAgents = (state) => state.system.schedulersAndAgents.agents;
+export const selectSystemAgentAlerts = (state) => state.system.schedulersAndAgents.agentAlerts;
+export const selectSystemSchedulerAndAgentVisibleHostType = (state) =>
     state.system.schedulersAndAgents.hostType;
 
-export const getSystemSchedulersWithState = createSelector(
-    [getSystemSchedulers, getMastersHostType],
+export const selectSystemSchedulersWithState = createSelector(
+    [selectSystemSchedulers, getMastersHostType],
     (schedulers, hostType) => {
         const path = hostType === VisibleHostType.host ? '' : '/@annotations/physical_host';
         return map_(schedulers, (sheduler) => {
@@ -32,8 +33,8 @@ export const getSystemSchedulersWithState = createSelector(
     },
 );
 
-export const getSystemAgentsWithState = createSelector(
-    [getSystemAgents, getMastersHostType],
+export const selectSystemAgentsWithState = createSelector(
+    [selectSystemAgents, getMastersHostType],
     (agents, hostType) => {
         const path = hostType === VisibleHostType.host ? '' : '/@annotations/physical_host';
         return map_(agents, (agent) => {
@@ -50,8 +51,8 @@ export const getSystemAgentsWithState = createSelector(
     },
 );
 
-export const getSystemSchedulerAndAgentCounters = createSelector(
-    [getSystemSchedulersWithState, getSystemAgentsWithState],
+export const selectSystemSchedulerAndAgentCounters = createSelector(
+    [selectSystemSchedulersWithState, selectSystemAgentsWithState],
     (schedulersWithState, agentsWithState) => {
         return {
             schedulers: extractSchedulersCounters(schedulersWithState),
@@ -60,8 +61,8 @@ export const getSystemSchedulerAndAgentCounters = createSelector(
     },
 );
 
-export const getSystemSchedulerAndAgentAlerts = createSelector(
-    [getSystemSchedulerAlerts, getSystemAgentAlerts],
+export const selectSystemSchedulerAndAgentAlerts = createSelector(
+    [selectSystemSchedulerAlerts, selectSystemAgentAlerts],
     (schedulerAlerts, agentAlerts) => {
         return {
             schedulers: schedulerAlerts,

--- a/packages/ui/src/ui/store/selectors/system/schedulers.js
+++ b/packages/ui/src/ui/store/selectors/system/schedulers.js
@@ -12,8 +12,6 @@ export const selectSystemSchedulerAlerts = (state) =>
     state.system.schedulersAndAgents.schedulerAlerts;
 export const selectSystemAgents = (state) => state.system.schedulersAndAgents.agents;
 export const selectSystemAgentAlerts = (state) => state.system.schedulersAndAgents.agentAlerts;
-export const selectSystemSchedulerAndAgentVisibleHostType = (state) =>
-    state.system.schedulersAndAgents.hostType;
 
 export const selectSystemSchedulersWithState = createSelector(
     [selectSystemSchedulers, getMastersHostType],


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/_t9dEivQ7dinAt
<!-- nda-end --> ## Summary by Sourcery

Rename system-related selectors to use a `select*` naming convention and update all consumers accordingly.

Enhancements:
- Rename system schedulers and agents selectors to `select*` names and propagate the changes to connected components and hooks.
- Rename system nodes selector to `selectSystemNodesNodeTypesToLoad` and update its usage across the nodes pages.