### PR TITLE
chore(Groups): rename groups selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/pages/groups/GroupEditorDialog/GroupEditorDialog.tsx
+++ b/packages/ui/src/ui/pages/groups/GroupEditorDialog/GroupEditorDialog.tsx
@@ -13,11 +13,11 @@ import i18n from './i18n';
 
 import {closeGroupEditorModal, fetchGroups, saveGroupData} from '../../../store/actions/groups';
 import {
-    getGroupEditorGroupIdm,
-    getGroupEditorGroupName,
-    getGroupEditorIdmDataOtherMembers,
-    getGroupEditorRoles,
-    getGroupEditorVisible,
+    selectGroupEditorGroupIdm,
+    selectGroupEditorGroupName,
+    selectGroupEditorIdmDataOtherMembers,
+    selectGroupEditorRoles,
+    selectGroupEditorVisible,
 } from '../../../store/selectors/groups';
 import {type RootState} from '../../../store/reducers';
 import {type ResponsibleType, type RoleConverted} from '../../../utils/acl/acl-types';
@@ -214,12 +214,12 @@ class GroupEditorDialog extends React.Component<GroupsPageTableProps> {
 }
 
 const mapStateToProps = (state: RootState) => {
-    const otherMembers = getGroupEditorIdmDataOtherMembers(state);
-    const {responsible, members} = getGroupEditorRoles(state);
+    const otherMembers = selectGroupEditorIdmDataOtherMembers(state);
+    const {responsible, members} = selectGroupEditorRoles(state);
     return {
-        visible: getGroupEditorVisible(state),
-        groupName: getGroupEditorGroupName(state),
-        idm: getGroupEditorGroupIdm(state),
+        visible: selectGroupEditorVisible(state),
+        groupName: selectGroupEditorGroupName(state),
+        idm: selectGroupEditorGroupIdm(state),
         members,
         responsible,
         otherMembers,

--- a/packages/ui/src/ui/pages/groups/GroupsPageFilters/GroupsPageFilters.tsx
+++ b/packages/ui/src/ui/pages/groups/GroupsPageFilters/GroupsPageFilters.tsx
@@ -6,7 +6,7 @@ import {setGroupsNameFilter} from '../../../store/actions/groups';
 import ErrorBoundary from '../../../containers/ErrorBoundary/ErrorBoundary';
 import Filter from '../../../components/Filter/Filter';
 import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
-import {getGroupsNameFilter} from '../../../store/selectors/groups';
+import {selectGroupsNameFilter} from '../../../store/selectors/groups';
 import {type RootState} from '../../../store/reducers';
 
 import './GroupsPageFilters.scss';
@@ -55,7 +55,7 @@ class GroupsPageFilters extends React.Component<GroupsPageFiltersProps> {
 
 const mapStateToProps = (state: RootState) => {
     return {
-        groupFilter: getGroupsNameFilter(state),
+        groupFilter: selectGroupsNameFilter(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/groups/GroupsPageTable/GroupsPageTable.tsx
+++ b/packages/ui/src/ui/pages/groups/GroupsPageTable/GroupsPageTable.tsx
@@ -20,10 +20,10 @@ import {STICKY_TOOLBAR_BOTTOM} from '../../../components/WithStickyToolbar/WithS
 import GroupEditorDialog from '../../../pages/groups/GroupEditorDialog/GroupEditorDialog';
 import {
     type GroupsTreeNode,
-    getGroupEditorVisible,
-    getGroupsFlattenTree,
-    getGroupsSort,
-    getGroupsTableDataState,
+    selectGroupEditorVisible,
+    selectGroupsFlattenTree,
+    selectGroupsSort,
+    selectGroupsTableDataState,
 } from '../../../store/selectors/groups';
 
 import './GroupsPageTable.scss';
@@ -236,10 +236,10 @@ class GroupsPageTable extends React.Component<GroupsPageTableProps> {
 }
 
 const mapStateToProps = (state: RootState) => {
-    const {loaded, loading, error} = getGroupsTableDataState(state);
-    const groups = getGroupsFlattenTree(state);
-    const sort = getGroupsSort(state);
-    const showEditor = getGroupEditorVisible(state);
+    const {loaded, loading, error} = selectGroupsTableDataState(state);
+    const groups = selectGroupsFlattenTree(state);
+    const sort = selectGroupsSort(state);
+    const showEditor = selectGroupEditorVisible(state);
 
     return {
         loaded,

--- a/packages/ui/src/ui/store/actions/groups.ts
+++ b/packages/ui/src/ui/store/actions/groups.ts
@@ -10,9 +10,9 @@ import {
 } from '../../constants/groups';
 import {selectCluster} from '../../store/selectors/global';
 import {
-    getGroupEditorIdmDataVersion,
-    getGroupEditorSubjects,
-    getGroupsExpanded,
+    selectGroupEditorIdmDataVersion,
+    selectGroupEditorSubjects,
+    selectGroupsExpanded,
 } from '../../store/selectors/groups';
 import {flags} from '../../utils/index';
 import {listAllGroups} from '../../utils/users-groups';
@@ -82,7 +82,7 @@ export function setGroupsPageSorting(column: string, order: OrderType) {
 
 export function toggleGroupExpand(groupName: string, isExpanded: boolean) {
     return (dispatch: Dispatch, getState: () => RootState) => {
-        const expanded = {...getGroupsExpanded(getState())};
+        const expanded = {...selectGroupsExpanded(getState())};
 
         expanded[groupName] = isExpanded;
 
@@ -200,8 +200,8 @@ export function saveGroupData({
 
         if (updateGroup) {
             const state = getState();
-            const {members, responsible} = getGroupEditorSubjects(state);
-            const version = getGroupEditorIdmDataVersion(state);
+            const {members, responsible} = selectGroupEditorSubjects(state);
+            const version = selectGroupEditorIdmDataVersion(state);
             const newMembers = calculateMembers(members, membersToAdd, membersToRemove);
             const newResponsibles = calculateMembers(
                 responsible,

--- a/packages/ui/src/ui/store/selectors/groups.ts
+++ b/packages/ui/src/ui/store/selectors/groups.ts
@@ -17,12 +17,12 @@ import {type PreparedRole} from '../../utils/acl';
 
 // Table
 
-export const getGroupsTableDataState = (state: RootState) => state.groups.table;
+export const selectGroupsTableDataState = (state: RootState) => state.groups.table;
 
-const getGroups = (state: RootState) => state.groups.table.groups;
-export const getGroupsNameFilter = (state: RootState) => state.groups.table.nameFilter;
-export const getGroupsSort = (state: RootState) => state.groups.table.sort;
-export const getGroupsExpanded = (state: RootState) => state.groups.table.expanded;
+const selectGroups = (state: RootState) => state.groups.table.groups;
+export const selectGroupsNameFilter = (state: RootState) => state.groups.table.nameFilter;
+export const selectGroupsSort = (state: RootState) => state.groups.table.sort;
+export const selectGroupsExpanded = (state: RootState) => state.groups.table.expanded;
 
 export type GroupsTreeNode = Group & {
     parent?: string;
@@ -35,7 +35,7 @@ export type GroupsTreeNode = Group & {
 
 type GroupsTree = Record<string, GroupsTreeNode>;
 
-export const getGroupsTree = createSelector([getGroups], (groups) => {
+export const selectGroupsTree = createSelector([selectGroups], (groups) => {
     const res: GroupsTree = groups.reduce((acc: GroupsTree, item) => {
         acc[item.name] = {...item, children: [], leaves: []};
         return acc;
@@ -71,8 +71,8 @@ export const getGroupsTree = createSelector([getGroups], (groups) => {
     return res;
 });
 
-const getGroupsTreeFiltered = createSelector(
-    [getGroupsTree, getGroupsNameFilter],
+const selectGroupsTreeFiltered = createSelector(
+    [selectGroupsTree, selectGroupsNameFilter],
     (tree, nameFilter) => {
         const root = tree[ROOT_GROUP_NAME];
         const predicates = compact_([
@@ -87,8 +87,8 @@ const getGroupsTreeFiltered = createSelector(
     },
 );
 
-const getGroupsTreeFilteredAndExpanded = createSelector(
-    [getGroupsTree, getGroupsTreeFiltered, getGroupsExpanded, getGroupsNameFilter],
+const selectGroupsTreeFilteredAndExpanded = createSelector(
+    [selectGroupsTree, selectGroupsTreeFiltered, selectGroupsExpanded, selectGroupsNameFilter],
     (groupTree, groupsTreeFiltered, expandedByUser, groupNameFilter) => {
         const expandedBySearch: Record<string, boolean> = {};
 
@@ -144,8 +144,8 @@ const GROUP_FIELDS = {
     },
 };
 
-const getGroupsTreeFilteredAndSorted = createSelector(
-    [getGroupsTreeFilteredAndExpanded, getGroupsSort],
+const selectGroupsTreeFilteredAndSorted = createSelector(
+    [selectGroupsTreeFilteredAndExpanded, selectGroupsSort],
     (root, {column, order}) => {
         const {orderK, undefinedOrderK} = orderTypeToOrderK(order);
         const res = hammer.treeList.sortTree(
@@ -161,27 +161,27 @@ const getGroupsTreeFilteredAndSorted = createSelector(
     },
 );
 
-export const getGroupsFlattenTree = createSelector(
-    [getGroupsTreeFilteredAndSorted],
+export const selectGroupsFlattenTree = createSelector(
+    [selectGroupsTreeFilteredAndSorted],
     (root): GroupsTreeNode[] => {
         return hammer.treeList.flattenTree(root);
     },
 );
 
 // Editor
-export const getGroupEditorData = (state: RootState) => state.groups.editor.data;
-export const getGroupEditorVisible = (state: RootState) => state.groups.editor.showModal;
-export const getGroupEditorGroupName = (state: RootState) => state.groups.editor.groupName;
+export const selectGroupEditorData = (state: RootState) => state.groups.editor.data;
+export const selectGroupEditorVisible = (state: RootState) => state.groups.editor.showModal;
+export const selectGroupEditorGroupName = (state: RootState) => state.groups.editor.groupName;
 // eslint-disable-next-line camelcase
-export const getGroupEditorGroupIdm = (state: RootState) =>
+export const selectGroupEditorGroupIdm = (state: RootState) =>
     flags.get(state.groups.editor.data.$attributes?.upravlyator_managed as FlagType);
-const getGroupEditorIdmData = (state: RootState) => state.groups.editor.idmData;
-export const getGroupEditorIdmDataVersion = (state: RootState) =>
+const selectGroupEditorIdmData = (state: RootState) => state.groups.editor.idmData;
+export const selectGroupEditorIdmDataVersion = (state: RootState) =>
     state.groups.editor.idmData.version;
-export const getGroupEditorIdmDataOtherMembers = (state: RootState) =>
+export const selectGroupEditorIdmDataOtherMembers = (state: RootState) =>
     state.groups.editor.idmData.group.other_members;
 
-export const getGroupEditorSubjects = createSelector([getGroupEditorIdmData], (idmData) => {
+export const selectGroupEditorSubjects = createSelector([selectGroupEditorIdmData], (idmData) => {
     const {
         group: {members, responsible},
     } = idmData;
@@ -191,8 +191,8 @@ export const getGroupEditorSubjects = createSelector([getGroupEditorIdmData], (i
     };
 });
 
-export const getGroupEditorRoles = createSelector(
-    [getGroupEditorIdmData, getGroupEditorData],
+export const selectGroupEditorRoles = createSelector(
+    [selectGroupEditorIdmData, selectGroupEditorData],
     (
         idmData,
         data,


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/MABpEclU7dj7Db
<!-- nda-end -->  ## Summary by Sourcery

Enhancements:
- Standardize naming of groups table and editor selectors to the `select*` prefix for improved clarity and consistency across the codebase.