### PR TITLE
chore: rename settings selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/common/thor/unipika.ts
+++ b/packages/ui/src/ui/common/thor/unipika.ts
@@ -4,11 +4,11 @@ import unipikaLib from '@gravity-ui/unipika/lib/unipika';
 import hammer from '../hammer';
 import {getSettingBySelector} from '../utils/redux';
 import {
-    getFormat,
-    shouldCompact,
-    shouldEscapeWhitespace,
-    shouldShowDecoded,
-    useBinaryAsHex,
+    selectFormat,
+    selectShouldCompact,
+    selectShouldEscapeWhitespace,
+    selectShouldShowDecoded,
+    selectUseBinaryAsHex,
 } from '../../store/selectors/settings';
 import {type UnipikaSettings} from '../../components/Yson/StructuredYson/StructuredYsonTypes';
 import {prettyPrint} from '../../utils/unipika';
@@ -27,22 +27,22 @@ unipika.prepareSettings = function (settings: UnipikaSettings) {
     settings = settings || {};
     Object.assign(settings, getUnipikaSettingsFromConfig());
 
-    settings.format = parseSetting(settings, 'format', getSettingBySelector(getFormat));
+    settings.format = parseSetting(settings, 'format', getSettingBySelector(selectFormat));
     settings.showDecoded = parseSetting(
         settings,
         'showDecoded',
-        getSettingBySelector(shouldShowDecoded),
+        getSettingBySelector(selectShouldShowDecoded),
     );
-    settings.compact = parseSetting(settings, 'compact', getSettingBySelector(shouldCompact));
+    settings.compact = parseSetting(settings, 'compact', getSettingBySelector(selectShouldCompact));
     settings.escapeWhitespace = parseSetting(
         settings,
         'escapeWhitespace',
-        getSettingBySelector(shouldEscapeWhitespace),
+        getSettingBySelector(selectShouldEscapeWhitespace),
     );
     settings.binaryAsHex = parseSetting(
         settings,
         'binaryAsHex',
-        getSettingBySelector(useBinaryAsHex),
+        getSettingBySelector(selectUseBinaryAsHex),
     );
 
     settings.asHTML = parseSetting(settings, 'asHTML', true);
@@ -59,7 +59,7 @@ unipika.prettyprint = function (value: unknown, settings: UnipikaSettings) {
 };
 
 unipika.decode = function (str: string) {
-    const showDecoded = getSettingBySelector(shouldShowDecoded);
+    const showDecoded = getSettingBySelector(selectShouldShowDecoded);
     return showDecoded ? utf8.decode(str) : str;
 };
 

--- a/packages/ui/src/ui/components/MonacoEditor/MonacoEditor.tsx
+++ b/packages/ui/src/ui/components/MonacoEditor/MonacoEditor.tsx
@@ -15,7 +15,7 @@ import {
 import isEqual_ from 'lodash/isEqual';
 import '../../libs/monaco-yql-languages/monaco.contribution';
 import './MonacoEditor.scss';
-import {getSettingsEditorVimMode} from '../../store/selectors/settings/settings-ts';
+import {selectSettingsEditorVimMode} from '../../store/selectors/settings/settings-ts';
 
 const block = cn('yt-monaco-editor');
 
@@ -60,7 +60,7 @@ const MonacoEditor: FC<Props> = ({
     onChange,
     editorRef,
 }) => {
-    const vimMode = useSelector(getSettingsEditorVimMode);
+    const vimMode = useSelector(selectSettingsEditorVimMode);
     const theme = useSelector(selectTheme);
     const modelRef = useRef(monaco.editor.createModel(value, language));
     const vimModeRef = useRef<any>();

--- a/packages/ui/src/ui/containers/App/App.tsx
+++ b/packages/ui/src/ui/containers/App/App.tsx
@@ -19,7 +19,7 @@ import ActionModal from '../ActionModal/ActionModal';
 import {ChangePasswordFormPage} from '../../containers/Login/ChangePasswordFormPage/ChangePasswordFormPage';
 import {LoginFormPage} from '../../containers/Login/LoginFormPage/LoginFormPage';
 
-import {getSettingTheme, shouldUseSafeColors} from '../../store/selectors/settings';
+import {selectSettingTheme, selectShouldUseSafeColors} from '../../store/selectors/settings';
 
 import {RumUiProvider} from '../../rum/RumUiContext';
 import AppNavigation from '../AppNavigation/AppNavigation';
@@ -154,8 +154,8 @@ export function ThemeUpdater() {
 }
 
 export function useThemeProviderProperties() {
-    const selectedTheme = useSelector(getSettingTheme);
-    const useContrastTheme: boolean = useSelector(shouldUseSafeColors);
+    const selectedTheme = useSelector(selectSettingTheme);
+    const useContrastTheme: boolean = useSelector(selectShouldUseSafeColors);
     const systemLightTheme = useContrastTheme ? 'light-hc' : 'light';
     const systemDarkTheme = useContrastTheme ? 'dark-hc' : 'dark';
     let theme: AppThemeFontProps['theme'] = selectedTheme;

--- a/packages/ui/src/ui/containers/AppNavigation/AppNavigation.tsx
+++ b/packages/ui/src/ui/containers/AppNavigation/AppNavigation.tsx
@@ -20,7 +20,7 @@ import {useClusterFromLocation} from '../../hooks/use-cluster';
 import './AppNavigation.scss';
 import UIFactory from '../../UIFactory';
 import {type AppNavigationProps} from './AppNavigationPageLayout';
-import {getSettingNavigationPanelExpanded} from '../../store/selectors/settings';
+import {selectSettingNavigationPanelExpanded} from '../../store/selectors/settings';
 import {setSettingNavigationPanelExpanded} from '../../store/actions/settings/settings';
 import {setAsideHeaderWidth} from '../../store/actions/global';
 import {SettingsPanelLazy} from '../SettingsPanel/lazy';
@@ -86,7 +86,7 @@ export default function AppNavigation({children}: ExtProps) {
 
     const className = block();
 
-    const expanded = useSelector(getSettingNavigationPanelExpanded);
+    const expanded = useSelector(selectSettingNavigationPanelExpanded);
     const onChangeCompact = React.useCallback(
         (newCompact: boolean) => {
             dispatch(setSettingNavigationPanelExpanded(!newCompact));

--- a/packages/ui/src/ui/containers/AppNavigation/PagesPanel.tsx
+++ b/packages/ui/src/ui/containers/AppNavigation/PagesPanel.tsx
@@ -11,7 +11,7 @@ import Link from '../../containers/Link/Link';
 import {makeRoutedURL} from '../../store/location';
 import {Icon, List} from '@gravity-ui/uikit';
 import {PAGE_ICONS_BY_ID, emptyPageIcon} from '../../constants/slideoutMenu';
-import {isRecentPagesFirst} from '../../store/selectors/settings';
+import {selectIsRecentPagesFirst} from '../../store/selectors/settings';
 import i18n from './i18n';
 
 import './PagesPanel.scss';
@@ -26,7 +26,7 @@ export default function PagesPanel({
     cluster?: string;
 }) {
     const {all, recent, rest} = useSelector(getRecentPagesInfo);
-    const isRecentFirst = useSelector(isRecentPagesFirst);
+    const isRecentFirst = useSelector(selectIsRecentPagesFirst);
 
     const allFiltered = React.useMemo(() => {
         return sortBy_(

--- a/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
+++ b/packages/ui/src/ui/containers/ClusterPage/ClusterPage.js
@@ -48,7 +48,7 @@ import {selectClusterUiConfig} from '../../store/selectors/global';
 import {selectIsExperimentalPagesReady} from '../../store/selectors/global/experimental-pages';
 import {getClusterConfig} from '../../utils';
 import {NAMESPACES, SettingName} from '../../../shared/constants/settings';
-import {getClusterPagePaneSizes, getStartingPage} from '../../store/selectors/settings';
+import {selectClusterPagePaneSizes, selectStartingPage} from '../../store/selectors/settings';
 import {selectSettingNewDashboardPage} from '../../store/selectors/dashboard2/dashboard';
 import SupportedFeaturesUpdater from './SupportedFeaturesUpdater';
 import {useRumMeasureStart, useRumMeasureStop} from '../../rum/RumUiContext';
@@ -343,8 +343,8 @@ function mapStateToProps(state) {
         paramsError,
         login,
         splitScreen,
-        clusterPagePaneSizes: getClusterPagePaneSizes(state),
-        startingPage: getStartingPage(state),
+        clusterPagePaneSizes: selectClusterPagePaneSizes(state),
+        startingPage: selectStartingPage(state),
         paramsCluster,
         allowChyt: Boolean(selectClusterUiConfig(state).chyt_controller_base_url),
         allowStartPageRedirect: selectIsExperimentalPagesReady(state),

--- a/packages/ui/src/ui/containers/ClusterPageHeader/ClustersPanel.tsx
+++ b/packages/ui/src/ui/containers/ClusterPageHeader/ClustersPanel.tsx
@@ -16,7 +16,7 @@ import {CLUSTER_GROUPS, CLUSTER_GROUPS_ORDER, DEFAULT_GROUP} from '../../constan
 
 import {useSelector} from '../../store/redux-hooks';
 import {getRecentClustersInfo} from '../../store/selectors/slideoutMenu';
-import {isRecentClustersFirst} from '../../store/selectors/settings';
+import {selectIsRecentClustersFirst} from '../../store/selectors/settings';
 import {useClusterColorClassName} from './ClusterColor';
 import {type ClusterConfig} from '../../../shared/yt-types';
 import Link from '../../containers/Link/Link';
@@ -62,7 +62,7 @@ export default function ClustersPanel({className, onSelectCluster}: Props) {
     const lowerFilter = filter?.toLowerCase() || '';
 
     const recentInfo = useSelector(getRecentClustersInfo);
-    const showRecent = useSelector(isRecentClustersFirst);
+    const showRecent = useSelector(selectIsRecentClustersFirst);
     const groups = React.useMemo(() => {
         const {recent, rest} = recentInfo;
         if (showRecent && (recent?.length || rest?.length)) {

--- a/packages/ui/src/ui/containers/OpenQueryButtons/OpenQueryButtons.tsx
+++ b/packages/ui/src/ui/containers/OpenQueryButtons/OpenQueryButtons.tsx
@@ -9,7 +9,7 @@ import {QueryWidgetLazy} from '../../pages/query-tracker/QueryWidget/side-panel'
 import {QueryEngine} from '../../../shared/constants/engines';
 import {createQueryFromTablePath} from '../../store/actions/query-tracker/query';
 import {createNewQueryUrl} from '../../pages/query-tracker/utils/navigation';
-import {getNavigationSqlService} from '../../store/selectors/settings/navigation';
+import {selectNavigationSqlService} from '../../store/selectors/settings/navigation';
 import {selectPath} from '../../store/selectors/navigation';
 import UIFactory from '../../UIFactory';
 import {useSidePanel} from '../../hooks/use-side-panel';
@@ -84,7 +84,7 @@ export function OpenQueryButtons({className, autoOpen}: OpenQueryButtonProps) {
     const onOpenYqlKit = React.useCallback(() => setPanelMode('yqlkit'), []);
     const onClose = React.useCallback(() => setPanelMode(undefined), []);
 
-    const {isQtKitEnabled, isYqlKitEnabled} = useSelector(getNavigationSqlService);
+    const {isQtKitEnabled, isYqlKitEnabled} = useSelector(selectNavigationSqlService);
 
     const allowQtAutoOpen = autoOpen && isQtKitEnabled;
 

--- a/packages/ui/src/ui/containers/SettingsMenu/BooleanSettingItem.tsx
+++ b/packages/ui/src/ui/containers/SettingsMenu/BooleanSettingItem.tsx
@@ -6,7 +6,7 @@ import {Checkbox} from '@gravity-ui/uikit';
 import {type DescribedSettings} from '../../../shared/constants/settings-types';
 import {type KeysByType} from '../../../@types/types';
 
-import {getSettingsData} from '../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../store/selectors/settings/settings-base';
 import {setSettingByKey} from '../../store/actions/settings';
 import {SettingsItemLayot, type SettingsItemLayotProps} from './SettingsItemLayout';
 
@@ -17,7 +17,7 @@ export function BooleanSettingItem<T extends KeysByType<DescribedSettings, boole
     ...rest
 }: BooleanSettingItemProps<T>) {
     const dispatch = useDispatch();
-    const {[settingKey]: checked} = useSelector(getSettingsData);
+    const {[settingKey]: checked} = useSelector(selectSettingsData);
 
     return (
         <SettingsItemLayot {...rest}>

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuInput.js
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuInput.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 import {TextInput} from '@gravity-ui/uikit';
 
 import {setSetting} from '../../store/actions/settings';
-import {makeGetSetting} from '../../store/selectors/settings';
+import {selectGetSetting} from '../../store/selectors/settings';
 
 const block = cn('elements-page');
 
@@ -68,7 +68,7 @@ function SettingsMenuInput({
 }
 
 const mapStateToProps = (state) => {
-    const getSetting = makeGetSetting(state);
+    const getSetting = selectGetSetting(state);
 
     return {
         getSetting,

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuItem.js
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuItem.js
@@ -6,7 +6,7 @@ import block from 'bem-cn-lite';
 import {Checkbox, Switch} from '@gravity-ui/uikit';
 
 import {setSetting} from '../../store/actions/settings';
-import {makeGetSetting} from '../../store/selectors/settings';
+import {selectGetSetting} from '../../store/selectors/settings';
 
 import './SettingsMenu.scss';
 
@@ -90,7 +90,7 @@ class SettingsMenuItem extends Component {
 
 function mapStateToProps(state) {
     return {
-        getSetting: makeGetSetting(state),
+        getSetting: selectGetSetting(state),
     };
 }
 

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuRadio.tsx
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuRadio.tsx
@@ -5,7 +5,7 @@ import {type ConnectedProps, connect} from 'react-redux';
 import RadioButton, {type ItemType} from '../../components/RadioButton/RadioButton';
 
 import {setSetting} from '../../store/actions/settings';
-import {makeGetSetting} from '../../store/selectors/settings';
+import {selectGetSetting} from '../../store/selectors/settings';
 import {type RootState} from '../../store/reducers';
 import {type FIX_MY_TYPE} from '../../types';
 
@@ -113,7 +113,7 @@ const SettingsMenuRadio: VFC<Props> = (props) => {
 };
 
 const mapStateToProps = (state: RootState) => {
-    const getSetting = makeGetSetting(state);
+    const getSetting = selectGetSetting(state);
 
     return {
         getSetting,

--- a/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuSelect.tsx
+++ b/packages/ui/src/ui/containers/SettingsMenu/SettingsMenuSelect.tsx
@@ -12,7 +12,7 @@ import SelectFacade, {
     type YTSelectProps,
 } from '../../components/Select/Select';
 import {setSettingByKey} from '../../store/actions/settings';
-import {getSettingsData} from '../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../store/selectors/settings/settings-base';
 
 import {SettingsItemLayot, type SettingsItemLayotProps} from './SettingsItemLayout';
 
@@ -67,7 +67,7 @@ export function SettingMenuSelectByKey<K extends KeysByType<DescribedSettings, s
     description,
 }: SettingMenuSelectByKeyProps<K>) {
     const dispatch = useDispatch();
-    const value = useSelector(getSettingsData)[settingKey];
+    const value = useSelector(selectSettingsData)[settingKey];
 
     return (
         <div className={b('settings-item', {select: true})}>
@@ -148,7 +148,7 @@ export function SettingsMenuRadioByKey<K extends KeysByType<DescribedSettings, s
 
 function useSettingByKey<K extends keyof DescribedSettings>(settingKey: K) {
     const dispatch = useDispatch();
-    const value = useSelector(getSettingsData)[settingKey];
+    const value = useSelector(selectSettingsData)[settingKey];
 
     return {
         value,

--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/GraphAutoCenterSetting.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/GraphAutoCenterSetting.tsx
@@ -1,11 +1,11 @@
 import React, {type FC} from 'react';
 import {useSelector} from '../../../store/redux-hooks';
-import {getSettingsQueryTrackerNewGraphType} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsQueryTrackerNewGraphType} from '../../../store/selectors/settings/settings-ts';
 import {BooleanSettingItem} from '../../SettingsMenu/BooleanSettingItem';
 import i18n from './i18n';
 
 export const GraphAutoCenterSetting: FC = () => {
-    const useNewGraphView = useSelector(getSettingsQueryTrackerNewGraphType);
+    const useNewGraphView = useSelector(selectSettingsQueryTrackerNewGraphType);
 
     if (!useNewGraphView) {
         return null;

--- a/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
@@ -34,7 +34,7 @@ import ypath from '../../common/thor/ypath';
 import {AGGREGATOR_RADIO_ITEMS} from '../../constants/operations/statistics';
 import {NAMESPACES, SettingName} from '../../../shared/constants/settings';
 import {getRecentPagesInfo} from '../../store/selectors/slideoutMenu';
-import {getCurrentClusterNS} from '../../store/selectors/settings/settings-ts';
+import {selectCurrentClusterNS} from '../../store/selectors/settings/settings-ts';
 import SettingsMenuItem from '../../containers/SettingsMenu/SettingsMenuItem';
 import SettingsMenuRadio from '../../containers/SettingsMenu/SettingsMenuRadio';
 import SettingsMenuInput from '../SettingsMenu/SettingsMenuInput';
@@ -87,7 +87,7 @@ function wrapEscapeText(text: string) {
 }
 
 function useSettings(cluster: string, isAdmin: boolean): Array<SettingsPage> {
-    const clusterNS = useSelector(getCurrentClusterNS);
+    const clusterNS = useSelector(selectCurrentClusterNS);
 
     const httpProxyVersion = useSelector(selectHttpProxyVersion);
     const schedulerVersion = useSelector(selectGlobalSchedulerVersion);

--- a/packages/ui/src/ui/hooks/settings/use-settings-column-sizes.ts
+++ b/packages/ui/src/ui/hooks/settings/use-settings-column-sizes.ts
@@ -4,7 +4,7 @@ import isEqual_ from 'lodash/isEqual';
 import {type KeysByType} from '../../../@types/types';
 import {type DescribedSettings} from '../../../shared/constants/settings-types';
 
-import {getSettingsData} from '../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../store/selectors/settings/settings-base';
 import {setSettingByKey} from '../../store/actions/settings';
 import {type RootState} from '../../store/reducers';
 import {useDispatch, useSelector} from '../../store/redux-hooks';
@@ -17,7 +17,7 @@ export function useSettingsColumnSizes<
     K extends KeysByType<DescribedSettings, Record<string, number>>,
 >(key: K, {minWidth = 50, maxWidth = 800}: {minWidth?: number; maxWidth?: number} = {}) {
     const dispatch = useDispatch();
-    const columnSizes = useSelector(getSettingsData)[key] ?? {};
+    const columnSizes = useSelector(selectSettingsData)[key] ?? {};
 
     type UpdateFn = ColumnSizes | ((oldState: ColumnSizes) => ColumnSizes);
 
@@ -27,7 +27,7 @@ export function useSettingsColumnSizes<
         columnSizes,
         setColumnSizes: (updateFn: UpdateFn) => {
             dispatch((_dispatch: unknown, getState: () => RootState) => {
-                const prevColumnSizes = getSettingsData(getState())[key] ?? {};
+                const prevColumnSizes = selectSettingsData(getState())[key] ?? {};
                 const changes = 'function' === typeof updateFn ? updateFn({}) : updateFn;
                 const newValue = {
                     ...prevColumnSizes,

--- a/packages/ui/src/ui/hooks/settings/use-settings-column-visibility.ts
+++ b/packages/ui/src/ui/hooks/settings/use-settings-column-visibility.ts
@@ -3,7 +3,7 @@ import isEqual_ from 'lodash/isEqual';
 import {type KeysByType} from '../../../@types/types';
 import {type DescribedSettings} from '../../../shared/constants/settings-types';
 
-import {getSettingsData} from '../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../store/selectors/settings/settings-base';
 import {setSettingByKey} from '../../store/actions/settings';
 import {type RootState} from '../../store/reducers';
 import {useDispatch, useSelector} from '../../store/redux-hooks';
@@ -16,7 +16,7 @@ export function useSettingsVisibleColumns<K extends KeysByType<DescribedSettings
     key: K,
 ) {
     const dispatch = useDispatch();
-    const visibleColumns = useSelector(getSettingsData)[key] ?? [];
+    const visibleColumns = useSelector(selectSettingsData)[key] ?? [];
 
     return {
         visibleColumns,
@@ -24,7 +24,7 @@ export function useSettingsVisibleColumns<K extends KeysByType<DescribedSettings
             updateFn: ColumnVisibility | ((oldState: ColumnVisibility) => ColumnVisibility),
         ) => {
             dispatch((_dispatch: unknown, getState: () => RootState) => {
-                const prevVisibleColumns = getSettingsData(getState())[key] ?? [];
+                const prevVisibleColumns = selectSettingsData(getState())[key] ?? [];
                 const newVisibility = 'function' === typeof updateFn ? updateFn({}) : updateFn;
 
                 const newVisibleColumns: DescribedSettings[K] = [
@@ -51,7 +51,7 @@ export function useSettingsVisibleColumns<K extends KeysByType<DescribedSettings
             updateFn: ColumnOrder | ((prevOrder: ColumnOrder) => ColumnOrder),
         ) => {
             dispatch((_dispatch: unknown, getState: () => RootState) => {
-                const prevVisibleColumns = getSettingsData(getState())[key] ?? [];
+                const prevVisibleColumns = selectSettingsData(getState())[key] ?? [];
                 const visible = new Set<string>(prevVisibleColumns);
 
                 const newOrder = 'function' === typeof updateFn ? updateFn([]) : updateFn;

--- a/packages/ui/src/ui/hooks/use-updater.ts
+++ b/packages/ui/src/ui/hooks/use-updater.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import {useSelector} from '../store/redux-hooks';
 
 import {Updater} from '../utils/hammer/updater';
-import {getUseAutoRefresh} from '../store/selectors/settings/settings-ts';
+import {selectUseAutoRefresh} from '../store/selectors/settings/settings-ts';
 import {useMemoizedIfEqual} from './use-memoized';
 
 export const DEFAULT_UPDATER_TIMEOUT = 30 * 1000;
@@ -35,7 +35,7 @@ export function useUpdater(
         forceAutoRefresh,
     }: UseUpdaterOptions = {},
 ) {
-    const useAutoRefresh = useSelector(getUseAutoRefresh) as boolean;
+    const useAutoRefresh = useSelector(selectUseAutoRefresh) as boolean;
     const optionsRef = React.useRef({skipNextCall: !useAutoRefresh});
 
     const allowAutoRefresh = forceAutoRefresh ?? useAutoRefresh;

--- a/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
@@ -21,7 +21,7 @@ import {
     selectAccountsIsFinalLoadingStatus,
     selectActiveAccount,
 } from '../../../store/selectors/accounts/accounts-ts';
-import {getLastVisitedTabs} from '../../../store/selectors/settings';
+import {selectLastVisitedTabs} from '../../../store/selectors/settings';
 import {type TabSettings, makeTabProps} from '../../../utils';
 
 import AccountsGeneralTab from '../tabs/general/AccountsGeneralTab';
@@ -155,7 +155,7 @@ export class Accounts extends React.Component<
 }
 
 const mapStateToProps = (state: RootState) => {
-    const lastVisitedTabs = getLastVisitedTabs(state);
+    const lastVisitedTabs = selectLastVisitedTabs(state);
 
     return {
         lastVisitedTab: lastVisitedTabs[Page.ACCOUNTS],

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountStaticConfiguration/AccountStaticConfiguration.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountStaticConfiguration/AccountStaticConfiguration.tsx
@@ -13,7 +13,7 @@ import hammer from '../../../../../common/hammer';
 import {setSettingsAccountsExpandStaticConfiguration} from '../../../../../store/actions/settings/settings';
 
 import './AccountStaticConfiguration.scss';
-import {getSettingsAccountsExpandStaticConfiguration} from '../../../../../store/selectors/settings/settings-ts';
+import {selectSettingsAccountsExpandStaticConfiguration} from '../../../../../store/selectors/settings/settings-ts';
 import {UI_COLLAPSIBLE_SIZE} from '../../../../../constants/global';
 import i18n from './i18n';
 
@@ -77,7 +77,7 @@ function AccountStaticConfiguration({className}: Props) {
 
     const account = useSelector(selectActiveAccount);
     const items = useSelector(selectActiveAccountStaticConfiguration);
-    const expandState = useSelector(getSettingsAccountsExpandStaticConfiguration);
+    const expandState = useSelector(selectSettingsAccountsExpandStaticConfiguration);
 
     const onToggle = React.useCallback(
         (value: boolean) => {

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsGeneralTab.js
@@ -18,8 +18,8 @@ import {
 } from '../../../../store/selectors/accounts/dashboard';
 
 import {
-    getAccountsVisibilityMode,
-    getAccountsVisibilityModeOfDashboard,
+    selectAccountsVisibilityMode,
+    selectAccountsVisibilityModeOfDashboard,
 } from '../../../../store/selectors/settings';
 import AccountsTotal from './AccountsTotal';
 
@@ -820,8 +820,8 @@ const makeMapStateToProps = () => {
             activeAccountAggregation: selectActiveAccountAggregationRow(state),
             favouriteAccountsSet,
             dashboardVisibilityMode: isDashboard
-                ? getAccountsVisibilityModeOfDashboard(state)
-                : getAccountsVisibilityMode(state),
+                ? selectAccountsVisibilityModeOfDashboard(state)
+                : selectAccountsVisibilityMode(state),
             abcServiceFilter: selectAccountsAbcServiceIdSlugFilter(state),
             columnFields: selectAccountsColumnFields(state),
 

--- a/packages/ui/src/ui/pages/components/Components/Components.js
+++ b/packages/ui/src/ui/pages/components/Components/Components.js
@@ -15,7 +15,7 @@ import Tabs from '../../../components/Tabs/Tabs';
 
 import {PROXY_TYPE} from '../../../constants/components/proxies/proxies';
 import {DEFAULT_TAB, Tab} from '../../../constants/components/main';
-import {getLastVisitedTabs} from '../../../store/selectors/settings';
+import {selectLastVisitedTabs} from '../../../store/selectors/settings';
 import {makeTabProps} from '../../../utils';
 import {Page} from '../../../constants/index';
 
@@ -88,7 +88,7 @@ function RedirectToTabletCells() {
 }
 
 const mapStateToProps = (state) => {
-    const lastVisitedTabs = getLastVisitedTabs(state);
+    const lastVisitedTabs = selectLastVisitedTabs(state);
     return {
         lastVisitedTab: lastVisitedTabs[Page.COMPONENTS],
         tabSize: UI_TAB_SIZE,

--- a/packages/ui/src/ui/pages/components/tabs/nodes/MemoryProgress/MemoryProgress.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/MemoryProgress/MemoryProgress.tsx
@@ -8,7 +8,7 @@ import {Progress} from '@gravity-ui/uikit';
 
 import hammer from '../../../../../common/hammer';
 import {Tooltip} from '@ytsaurus/components';
-import {getSettingsData} from '../../../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../../../store/selectors/settings/settings-base';
 import {type RootState} from '../../../../../store/reducers';
 
 import './MemoryProgress.scss';
@@ -90,7 +90,7 @@ class MemoryProgress extends React.Component<MemoryProgressProps & ReduxProps> {
 
 const mapStateToProps = (state: RootState) => {
     return {
-        showAll: getSettingsData(state)['global::components::memoryPopupShowAll'],
+        showAll: selectSettingsData(state)['global::components::memoryPopupShowAll'],
     };
 };
 

--- a/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
@@ -39,7 +39,7 @@ import {
     selectVisibleNodes,
 } from '../../../../../store/selectors/components/nodes/nodes';
 import {selectSelectedColumns} from '../../../../../store/selectors/settings';
-import {getSettingsEnableSideBar} from '../../../../../store/selectors/settings/settings-ts';
+import {selectSettingsEnableSideBar} from '../../../../../store/selectors/settings/settings-ts';
 import {defaultColumns} from '../../../../../pages/components/tabs/nodes/tables';
 import withVisible, {type WithVisibleProps} from '../../../../../hocs/withVisible';
 import {useUpdaterWithMemoizedParams} from '../../../../../hooks/use-updater';
@@ -388,7 +388,7 @@ const mapStateToProps = (state: RootState) => {
 
     const nodesTableProps = selectComponentNodesTableProps(state);
 
-    const sideBarEnabled = getSettingsEnableSideBar(state);
+    const sideBarEnabled = selectSettingsEnableSideBar(state);
 
     return {
         loading,

--- a/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
@@ -38,7 +38,7 @@ import {
     selectRequiredAttributes,
     selectVisibleNodes,
 } from '../../../../../store/selectors/components/nodes/nodes';
-import {getSelectedColumns} from '../../../../../store/selectors/settings';
+import {selectSelectedColumns} from '../../../../../store/selectors/settings';
 import {getSettingsEnableSideBar} from '../../../../../store/selectors/settings/settings-ts';
 import {defaultColumns} from '../../../../../pages/components/tabs/nodes/tables';
 import withVisible, {type WithVisibleProps} from '../../../../../hocs/withVisible';
@@ -383,7 +383,7 @@ const mapStateToProps = (state: RootState) => {
         state.components.nodes.nodes;
 
     const visibleNodes = selectVisibleNodes(state);
-    const selectedColumns = getSelectedColumns(state) || defaultColumns;
+    const selectedColumns = selectSelectedColumns(state) || defaultColumns;
     const initialLoading = loading && !loaded;
 
     const nodesTableProps = selectComponentNodesTableProps(state);

--- a/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/hooks/use-navigation-widget.ts
+++ b/packages/ui/src/ui/pages/dashboard2/Dashboard/Widgets/Navigation/hooks/use-navigation-widget.ts
@@ -4,7 +4,7 @@ import {type RootState} from '../../../../../../store/reducers';
 import {usePathsQuery} from '../../../../../../store/api/dashboard2/navigation';
 import {selectCluster} from '../../../../../../store/selectors/global';
 import {selectNavigationTypeFilter} from '../../../../../../store/selectors/dashboard2/navigation';
-import {getLastVisited} from '../../../../../../store/selectors/settings';
+import {selectLastVisited} from '../../../../../../store/selectors/settings';
 import {selectFavouritePaths} from '../../../../../../store/selectors/favourites';
 
 import {type NavigationWidgetProps} from '../types';
@@ -13,7 +13,7 @@ export function useNavigationWidget(props: NavigationWidgetProps) {
     const type = useSelector((state: RootState) => selectNavigationTypeFilter(state, props.id));
     const cluster = useSelector(selectCluster);
 
-    const lastVisitedPaths = useSelector(getLastVisited);
+    const lastVisitedPaths = useSelector(selectLastVisited);
     const favouritePaths = useSelector(selectFavouritePaths);
 
     const {

--- a/packages/ui/src/ui/pages/navigation/Navigation/NavigationTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/navigation/Navigation/NavigationTopRowContent.tsx
@@ -16,7 +16,7 @@ import {
 import {selectCluster} from '../../../store/selectors/global';
 import {makeRoutedURL} from '../../../store/location';
 import {restoreObject} from '../../../store/actions/navigation/modals/restore-object';
-import {getNavigationDefaultPath} from '../../../store/selectors/settings';
+import {selectNavigationDefaultPath} from '../../../store/selectors/settings';
 import {
     selectFavouritePaths,
     selectIsCurrentPathInFavourites,
@@ -58,7 +58,7 @@ import './NavigationTopRowContent.scss';
 const block = cn('navigation-top-row-content');
 
 function NavigationTopRowContent() {
-    const defaultPath = useSelector(getNavigationDefaultPath);
+    const defaultPath = useSelector(selectNavigationDefaultPath);
 
     const [editMode, setEditMode] = React.useState(false);
 

--- a/packages/ui/src/ui/pages/navigation/NavigationDescription/hooks/use-description-collapse.ts
+++ b/packages/ui/src/ui/pages/navigation/NavigationDescription/hooks/use-description-collapse.ts
@@ -2,13 +2,13 @@ import {useCallback} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 
 import {setSettingAnnotationVisibility} from '../../../../store/actions/settings/settings';
-import {getSettingAnnotationVisibility} from '../../../../store/selectors/settings';
+import {selectSettingAnnotationVisibility} from '../../../../store/selectors/settings';
 
 import {AnnotationVisibility} from '../../../../../shared/constants/settings-ts';
 
 export function useDescriptionCollapse() {
     const dispatch = useDispatch();
-    const visibility = useSelector(getSettingAnnotationVisibility);
+    const visibility = useSelector(selectSettingAnnotationVisibility);
     const expanded = visibility === AnnotationVisibility.VISIBLE;
 
     const toggleExpanded = useCallback(() => {

--- a/packages/ui/src/ui/pages/navigation/content/MapNode/MapNodeUserSettings.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/MapNode/MapNodeUserSettings.tsx
@@ -3,12 +3,12 @@ import {Button, Checkbox, Icon} from '@gravity-ui/uikit';
 import React from 'react';
 import Dropdown from '../../../../components/Dropdown/Dropdown';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
-import {getSettingsData} from '../../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../../store/selectors/settings/settings-base';
 import {setSettingByKey} from '../../../../store/actions/settings';
 
 export function MapNodeUserSettings() {
     const dispatch = useDispatch();
-    const {['global::navigation::groupNodes']: groupped} = useSelector(getSettingsData);
+    const {['global::navigation::groupNodes']: groupped} = useSelector(selectSettingsData);
 
     return (
         <Dropdown

--- a/packages/ui/src/ui/pages/navigation/content/Table/DataTableWrapper/DataTableWrapper.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/DataTableWrapper/DataTableWrapper.tsx
@@ -12,7 +12,7 @@ import {injectTableCellData} from '../../../../../store/actions/navigation/conte
 import {selectOffsetValue} from '../../../../../store/selectors/navigation/content/table';
 import {selectSchemaByName} from '../../../../../store/selectors/navigation/tabs/schema';
 import {selectPrimitiveTypesMap} from '../../../../../store/selectors/global/supported-features';
-import {getSettingTableDisplayRawStrings} from '../../../../../store/selectors/settings';
+import {selectSettingTableDisplayRawStrings} from '../../../../../store/selectors/settings';
 import {shouldUseYqlTypes} from '../../../../../store/selectors/settings/settings-development';
 import {type YsonSettings} from '../../../../../store/selectors/thor/unipika';
 import {onCellPreview} from '../../../../../store/actions/navigation/modals/cell-preview';
@@ -48,7 +48,7 @@ export type DataTableWrapperProps = {
 };
 
 export default function DataTableWrapper(props: DataTableWrapperProps) {
-    const useRawStrings = useSelector(getSettingTableDisplayRawStrings);
+    const useRawStrings = useSelector(selectSettingTableDisplayRawStrings);
     const useYqlTypes = useSelector(shouldUseYqlTypes);
     const schemaByName = useSelector(selectSchemaByName);
     const primitiveTypes = useSelector(selectPrimitiveTypesMap);

--- a/packages/ui/src/ui/pages/navigation/content/Table/DataTableWrapper/DataTableWrapper.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/DataTableWrapper/DataTableWrapper.tsx
@@ -13,7 +13,7 @@ import {selectOffsetValue} from '../../../../../store/selectors/navigation/conte
 import {selectSchemaByName} from '../../../../../store/selectors/navigation/tabs/schema';
 import {selectPrimitiveTypesMap} from '../../../../../store/selectors/global/supported-features';
 import {selectSettingTableDisplayRawStrings} from '../../../../../store/selectors/settings';
-import {shouldUseYqlTypes} from '../../../../../store/selectors/settings/settings-development';
+import {selectShouldUseYqlTypes} from '../../../../../store/selectors/settings/settings-development';
 import {type YsonSettings} from '../../../../../store/selectors/thor/unipika';
 import {onCellPreview} from '../../../../../store/actions/navigation/modals/cell-preview';
 import {
@@ -49,7 +49,7 @@ export type DataTableWrapperProps = {
 
 export default function DataTableWrapper(props: DataTableWrapperProps) {
     const useRawStrings = useSelector(selectSettingTableDisplayRawStrings);
-    const useYqlTypes = useSelector(shouldUseYqlTypes);
+    const useYqlTypes = useSelector(selectShouldUseYqlTypes);
     const schemaByName = useSelector(selectSchemaByName);
     const primitiveTypes = useSelector(selectPrimitiveTypesMap);
 

--- a/packages/ui/src/ui/pages/navigation/content/Table/DownloadManager/DownloadManager.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/DownloadManager/DownloadManager.tsx
@@ -25,7 +25,7 @@ import Icon from '../../../../../components/Icon/Icon';
 import Link from '../../../../../containers/Link/Link';
 import Tabs from '../../../../../components/Tabs/Tabs';
 
-import {getRowsPerTablePage, getShowDecoded} from '../../../../../store/selectors/settings';
+import {selectRowsPerTablePage, selectShowDecoded} from '../../../../../store/selectors/settings';
 import {selectSchema} from '../../../../../store/selectors/navigation/tabs/schema';
 import {selectPath, selectTransaction} from '../../../../../store/selectors/navigation';
 import {selectCluster, selectCurrentClusterConfig} from '../../../../../store/selectors/global';
@@ -853,8 +853,8 @@ export class DownloadManager extends React.Component<Props, State> {
 const mapStateToProps = (state: RootState) => {
     const {loading}: {loading: boolean} = state.navigation.content.table;
 
-    const pageSize: number = getRowsPerTablePage(state);
-    const showDecoded: boolean = getShowDecoded(state);
+    const pageSize: number = selectRowsPerTablePage(state);
+    const showDecoded: boolean = selectShowDecoded(state);
     const offsetValue = selectOffsetValue(state);
     const allColumns: Array<{name: string; checked: boolean}> = selectAllColumns(state);
     const srcColumns = selectSrcColumns(state);

--- a/packages/ui/src/ui/pages/navigation/content/Table/TableOverview/SettingsButton.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/TableOverview/SettingsButton.tsx
@@ -20,7 +20,7 @@ import {
     selectCellSize,
     selectPageSize,
 } from '../../../../../store/selectors/navigation/content/table-ts';
-import {getSettingTableDisplayRawStrings} from '../../../../../store/selectors/settings';
+import {selectSettingTableDisplayRawStrings} from '../../../../../store/selectors/settings';
 import {setTableDisplayRawStrings} from '../../../../../store/actions/settings/settings';
 import {type RootState} from '../../../../../store/reducers';
 
@@ -99,7 +99,7 @@ const mapStateToProps = (state: RootState) => {
     const pageSize = selectPageSize(state);
     const cellSize = selectCellSize(state);
 
-    const allowRawStrings = getSettingTableDisplayRawStrings(state);
+    const allowRawStrings = selectSettingTableDisplayRawStrings(state);
 
     return {pageSize, cellSize, isFullScreen, allowRawStrings};
 };

--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Partitions/ColumnsButton.connected.ts
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/views/Partitions/ColumnsButton.connected.ts
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import ColumnsButton from '../../../../../../pages/navigation/tabs/Queue/ColumnsButton/ColumnsButton';
 import {setSettingsNavigationQueuePartitionsVisibility} from '../../../../../../store/actions/settings/settings';
 import {type RootState} from '../../../../../../store/reducers';
-import {getSettingsNavigationQueuePartitionsVisibility} from '../../../../../../store/selectors/settings/settings-ts';
+import {selectSettingsNavigationQueuePartitionsVisibility} from '../../../../../../store/selectors/settings/settings-ts';
 
 const allColumns = [
     {
@@ -56,7 +56,7 @@ const allColumns = [
 function mapStateToProps(state: RootState) {
     return {
         allColumns,
-        selectedColumns: getSettingsNavigationQueuePartitionsVisibility(state),
+        selectedColumns: selectSettingsNavigationQueuePartitionsVisibility(state),
     };
 }
 

--- a/packages/ui/src/ui/pages/odin/_selectors/index.ts
+++ b/packages/ui/src/ui/pages/odin/_selectors/index.ts
@@ -6,7 +6,7 @@ import {createSelector} from 'reselect';
 import {type RootState} from '../../../store/reducers';
 import Utils, {currentDate} from '../odin-utils';
 import {COLS_NUMBER} from '../odin-constants';
-import {makeGetSetting} from '../../../store/selectors/settings';
+import {selectGetSetting} from '../../../store/selectors/settings';
 import {ODIN_VISIBLE_METRIC_PRESETS, YA_NAMESPACES} from '../odin-settings';
 import {YT} from '../../../config/yt-config';
 
@@ -63,6 +63,9 @@ function makeClusterNameItems() {
 
 export const ODIN_CLUSTER_NAMES_ITEMS = makeClusterNameItems();
 
-export const getSettingOdinOverviewVisiblePresets = createSelector(makeGetSetting, (getSetting) => {
-    return getSetting(ODIN_VISIBLE_METRIC_PRESETS, YA_NAMESPACES.ODIN) || [];
-});
+export const getSettingOdinOverviewVisiblePresets = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        return getSetting(ODIN_VISIBLE_METRIC_PRESETS, YA_NAMESPACES.ODIN) || [];
+    },
+);

--- a/packages/ui/src/ui/pages/odin/_selectors/odin-overview.ts
+++ b/packages/ui/src/ui/pages/odin/_selectors/odin-overview.ts
@@ -4,7 +4,7 @@ import sortBy_ from 'lodash/sortBy';
 import {createSelector} from 'reselect';
 import {getSettingOdinOverviewVisiblePresets} from './index';
 import {type RootState} from '../../../store/reducers';
-import {makeGetSetting} from '../../../store/selectors/settings';
+import {selectGetSetting} from '../../../store/selectors/settings';
 import {OdinTab} from '../odin-constants';
 import {ODIN_LAST_VISITED_TAB} from '../odin-settings';
 import {NAMESPACES} from '../../../../shared/constants/settings';
@@ -78,6 +78,6 @@ export const getOdinOverviewClusterMetrics = createSelector(
 );
 
 export const getOdinLastVisitedTab = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting) => getSetting(ODIN_LAST_VISITED_TAB, NAMESPACES.GLOBAL) || OdinTab.OVERVIEW,
 );

--- a/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsFilterPresets.js
+++ b/packages/ui/src/ui/pages/operations/OperationsList/OperationsListToolbar/OperationsFilterPresets.js
@@ -18,7 +18,7 @@ import {
 import {DEFAULT_PRESET_SETTING} from '../../../../constants/operations';
 import {OPERATIONS_LIST_RUNNING_PRESET} from '../../../../constants/operations/list';
 
-import {makeGetSetting} from '../../../../store/selectors/settings';
+import {selectGetSetting} from '../../../../store/selectors/settings';
 import {
     selectOperationsListActivePresets,
     selectOperationsListFilterPresets,
@@ -184,7 +184,7 @@ class OperationsFilterPresets extends Component {
 function mapStateToProps(state) {
     const {operations} = state;
 
-    const getSetting = makeGetSetting(state);
+    const getSetting = selectGetSetting(state);
     let defaultPreset = getSetting(DEFAULT_PRESET_SETTING, NAMESPACES.OPERATION);
     const presets = selectOperationsListFilterPresets(state);
 

--- a/packages/ui/src/ui/pages/path-viewer/PathViewer.js
+++ b/packages/ui/src/ui/pages/path-viewer/PathViewer.js
@@ -17,7 +17,7 @@ import {
     toggleParameters,
 } from '../../store/actions/path-viewer';
 import {KeyCode} from '../../constants/index';
-import {getFormat} from '../../store/selectors/settings';
+import {selectFormat} from '../../store/selectors/settings';
 import {COMMAND} from '../../constants/path-viewer';
 
 import './PathViewer.scss';
@@ -161,7 +161,7 @@ function Overview({className}) {
 export default function PathViewer() {
     const dispatch = useDispatch();
     const {data, loading, error, errorData} = useSelector((state) => state.pathViewer);
-    const format = useSelector(getFormat);
+    const format = useSelector(selectFormat);
     const settings = useMemo(() => ({format}), [format]);
 
     useEffect(() => {

--- a/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesGraph.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesGraph.tsx
@@ -9,7 +9,7 @@ import {QueriesNodeConnection} from './QueriesNodeConnection';
 import {PathPopup} from './DetailBlock/PathPopup';
 import {OperationType} from './enums';
 import {useSelector} from '../../../../store/redux-hooks';
-import {getSettingsQueryTrackerGraphAutoCenter} from '../../../../store/selectors/settings/settings-ts';
+import {selectSettingsQueryTrackerGraphAutoCenter} from '../../../../store/selectors/settings/settings-ts';
 import {checkControlCommandKey} from '../../../../utils/keyboard';
 import {openInNewTab} from '../../../../utils/utils';
 import {getOperationPageUrlFromNodeProgress} from '../services/getOperationPageUrlFromNodeProgress';
@@ -32,7 +32,7 @@ const Graph: FC<Props> = ({processedGraph}) => {
     );
 
     const [loading, setLoading] = useState(true);
-    const autoCenter = useSelector(getSettingsQueryTrackerGraphAutoCenter);
+    const autoCenter = useSelector(selectSettingsQueryTrackerGraphAutoCenter);
 
     const {data, isLoading} = useQueriesGraphLayout(processedGraph, scale);
 

--- a/packages/ui/src/ui/pages/query-tracker/Plan/Plan.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/Plan.tsx
@@ -12,7 +12,7 @@ import {LargeGraphInfo} from './LargeGraphInfo';
 import './Plan.scss';
 import {QueriesGraphLazy} from './GraphEditor';
 import {useSelector} from '../../../store/redux-hooks';
-import {getSettingsQueryTrackerNewGraphType} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsQueryTrackerNewGraphType} from '../../../store/selectors/settings/settings-ts';
 import {selectProcessedGraph} from '../../../store/selectors/query-tracker/queryPlan';
 import {type PlanView} from './PlanActions';
 
@@ -27,7 +27,7 @@ interface PlanProps {
 
 export default React.memo(function Plan({planView, isActive, className, prepareNode}: PlanProps) {
     const graph = useSelector(selectProcessedGraph);
-    const newGraphType = useSelector(getSettingsQueryTrackerNewGraphType);
+    const newGraphType = useSelector(selectSettingsQueryTrackerNewGraphType);
 
     const [showLargeGraph, setShowLargeGraph] = React.useState(false);
     const resultProgressShowMinimap = true; // can be set as user setting in the future

--- a/packages/ui/src/ui/pages/query-tracker/QueryToken/AddQueryTokenForm/AddQueryTokenForm.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryToken/AddQueryTokenForm/AddQueryTokenForm.tsx
@@ -1,7 +1,7 @@
 import React, {type FC, useEffect, useState} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {appendQueryToken} from '../../../../store/actions/settings/settings';
-import {getQueryTokens} from '../../../../store/selectors/settings/settings-queries';
+import {selectQueryTokens} from '../../../../store/selectors/settings/settings-queries';
 import {type FormApi, YTDFDialog, makeErrorFields} from '../../../../containers/Dialog';
 import {type QueryToken} from '../../../../../shared/constants/settings-types';
 import {YT} from '../../../../config/yt-config';
@@ -32,7 +32,7 @@ const clusterOptions = Object.values(YT.clusters)
 
 export const AddQueryTokenForm: FC<Props> = ({visible, onClose}) => {
     const dispatch = useDispatch();
-    const tokens = useSelector(getQueryTokens);
+    const tokens = useSelector(selectQueryTokens);
     const [error, setError] = useState<YTError>();
 
     useEffect(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenButton/QueryTokenDropdown.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenButton/QueryTokenDropdown.tsx
@@ -3,7 +3,7 @@ import {Flex, Icon, Select, Text, Tooltip} from '@gravity-ui/uikit';
 import './QueryTokenDropdown.scss';
 import cn from 'bem-cn-lite';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
-import {getQueryTokens} from '../../../../store/selectors/settings/settings-queries';
+import {selectQueryTokens} from '../../../../store/selectors/settings/settings-queries';
 import CircleQuestionIcon from '@gravity-ui/icons/svgs/circle-question.svg';
 import {updateQueryDraft} from '../../../../store/actions/query-tracker/query';
 import {type QuerySecret} from '../../../../types/query-tracker/api';
@@ -14,7 +14,7 @@ const block = cn('yt-qt-token-dropdown');
 
 export const QueryTokenDropdown: FC = () => {
     const dispatch = useDispatch();
-    const tokens = useSelector(getQueryTokens);
+    const tokens = useSelector(selectQueryTokens);
     const secretIds = useSelector(selectCurrentSecretIds);
 
     const options = useMemo(() => {

--- a/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenTable/QueryTokenTable.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryToken/QueryTokenTable/QueryTokenTable.tsx
@@ -1,7 +1,7 @@
 import React, {type FC} from 'react';
 import {Table, useTable} from '@gravity-ui/table';
 import {useSelector} from '../../../../store/redux-hooks';
-import {getQueryTokens} from '../../../../store/selectors/settings/settings-queries';
+import {selectQueryTokens} from '../../../../store/selectors/settings/settings-queries';
 import {QueryTokenRemoveButton} from './QueryTokenRemoveButton';
 import {type ColumnDef} from '@gravity-ui/table/tanstack';
 import {Button, Flex, Icon, Text, Tooltip} from '@gravity-ui/uikit';
@@ -80,7 +80,7 @@ const columns: ColumnDef<QueryToken>[] = [
 ];
 
 export const QueryTokenTable: FC = () => {
-    const tokens = useSelector(getQueryTokens);
+    const tokens = useSelector(selectQueryTokens);
     const table = useTable({data: tokens, columns});
 
     if (!tokens.length) return null;

--- a/packages/ui/src/ui/pages/query-tracker/QueryTracker/QueryTracker.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTracker/QueryTracker.tsx
@@ -31,7 +31,7 @@ import {setSettingByKey} from '../../../store/actions/settings';
 import {CellPreviewModal} from '../../../containers/CellPreviewModal/CellPreviewModal';
 import {SET_QUERY_PARAMS} from '../../../store/reducers/query-tracker/query-tracker-contants';
 import {RedirectConfirmModal} from '../../../components/RedirectConfirmModal';
-import {getLastUserChoiceQueryEngine} from '../../../store/selectors/settings/settings-queries';
+import {selectLastUserChoiceQueryEngine} from '../../../store/selectors/settings/settings-queries';
 import i18n from './i18n';
 
 const b = cn('query-tracker-page');
@@ -55,7 +55,7 @@ function QueryPageDraft() {
     const dispatch = useDispatch();
     const routeParams = useSelector(selectQueryGetParams);
     const cluster = useSelector(selectNavigationCluster);
-    const favoriteEngine = useSelector(getLastUserChoiceQueryEngine) ?? QueryEngine.YQL;
+    const favoriteEngine = useSelector(selectLastUserChoiceQueryEngine) ?? QueryEngine.YQL;
 
     useEffect(() => {
         const engine =

--- a/packages/ui/src/ui/pages/query-tracker/querySuggestionsModule/createInlineSuggestions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/querySuggestionsModule/createInlineSuggestions.ts
@@ -2,7 +2,7 @@ import {type CancellationToken, type Position, type editor, type languages} from
 import {getRangeToInsertSuggestion} from '../../../libs/monaco-yql-languages/helpers/getRangeToInsertSuggestion';
 import {type QueryEngine} from '../../../../shared/constants/engines';
 import {getWindowStore} from '../../../store/window-store';
-import {getQuerySuggestionsEnabled} from '../../../store/selectors/settings/settings-queries';
+import {selectQuerySuggestionsEnabled} from '../../../store/selectors/settings/settings-queries';
 import UIFactory from '../../../UIFactory';
 import debounce_ from 'lodash/debounce';
 
@@ -21,7 +21,7 @@ export const createInlineSuggestions =
         _token: CancellationToken,
     ): Promise<{items: languages.InlineCompletion[]}> => {
         const state = getWindowStore().getState();
-        const enabled = getQuerySuggestionsEnabled(state);
+        const enabled = selectQuerySuggestionsEnabled(state);
 
         if (!enabled) {
             return {

--- a/packages/ui/src/ui/pages/query-tracker/querySuggestionsModule/useMonacoQuerySuggestions.ts
+++ b/packages/ui/src/ui/pages/query-tracker/querySuggestionsModule/useMonacoQuerySuggestions.ts
@@ -1,11 +1,11 @@
 import {useCallback, useEffect} from 'react';
 import * as monaco from 'monaco-editor';
 import {useSelector} from '../../../store/redux-hooks';
-import {getQuerySuggestionsEnabled} from '../../../store/selectors/settings/settings-queries';
+import {selectQuerySuggestionsEnabled} from '../../../store/selectors/settings/settings-queries';
 import UIFactory from '../../../UIFactory';
 
 export const useMonacoQuerySuggestions = (editor?: monaco.editor.IStandaloneCodeEditor) => {
-    const enabled = useSelector(getQuerySuggestionsEnabled);
+    const enabled = useSelector(selectQuerySuggestionsEnabled);
 
     useEffect(() => {
         UIFactory.getInlineSuggestionsApi()?.sendTelemetry(enabled ? 'enabled' : 'disabled');

--- a/packages/ui/src/ui/pages/scheduling/PoolStaticConfiguration/SchedulingStaticConfiguration.tsx
+++ b/packages/ui/src/ui/pages/scheduling/PoolStaticConfiguration/SchedulingStaticConfiguration.tsx
@@ -14,7 +14,7 @@ import {DataTableYT} from '../../../components/DataTableYT';
 import format from '../../../common/hammer/format';
 
 import './SchedulingStaticConfiguration.scss';
-import {getSettingsSchedulingExpandStaticConfiguration} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsSchedulingExpandStaticConfiguration} from '../../../store/selectors/settings/settings-ts';
 import {setSettingsSchedulingExpandStaticConfiguration} from '../../../store/actions/settings/settings';
 import UIFactory from '../../../UIFactory';
 import {selectCluster} from '../../../store/selectors/global';
@@ -26,7 +26,7 @@ function SchedulingStaticConfiguration() {
     const dispatch = useDispatch();
     const isRoot = useSelector(getIsRoot);
 
-    const collapsed = useSelector(getSettingsSchedulingExpandStaticConfiguration);
+    const collapsed = useSelector(selectSettingsSchedulingExpandStaticConfiguration);
     const onToggle = React.useCallback(
         (value: boolean) => {
             dispatch(setSettingsSchedulingExpandStaticConfiguration(value));

--- a/packages/ui/src/ui/pages/system/Chunks/Chunks.js
+++ b/packages/ui/src/ui/pages/system/Chunks/Chunks.js
@@ -22,7 +22,7 @@ import {StickyContainer} from '../../../components/StickyContainer/StickyContain
 
 import {SYSTEM_CHUNKS_TABLE_ID} from '../../../constants/tables';
 import {loadChunks} from '../../../store/actions/system/chunks';
-import {getSettingsSystemChunksCollapsed} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsSystemChunksCollapsed} from '../../../store/selectors/settings/settings-ts';
 import {setSettingsSystemChunksCollapsed} from '../../../store/actions/settings/settings';
 import {useUpdater} from '../../../hooks/use-updater';
 
@@ -269,7 +269,7 @@ function mapStateToProps(state) {
         types,
         sortState: state.tables[SYSTEM_CHUNKS_TABLE_ID],
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
-        collapsed: getSettingsSystemChunksCollapsed(state),
+        collapsed: selectSettingsSystemChunksCollapsed(state),
     };
 }
 

--- a/packages/ui/src/ui/pages/system/CypressProxies/CypressProxies.tsx
+++ b/packages/ui/src/ui/pages/system/CypressProxies/CypressProxies.tsx
@@ -7,7 +7,7 @@ import {useUpdater} from '../../../hooks/use-updater';
 import {setSettingsSystemCypressProxiesCollapsed} from '../../../store/actions/settings/settings';
 import {loadSystemCypressProxies} from '../../../store/actions/system/cypress-proxies';
 import {selectCluster} from '../../../store/selectors/global';
-import {getSettingsSystemCypressProxiesCollapsed} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsSystemCypressProxiesCollapsed} from '../../../store/selectors/settings/settings-ts';
 import {useDispatch} from '../../../store/redux-hooks';
 import {type MakeUrlParams} from '../ProxiesImpl/RoleGroup';
 import {ProxiesImpl} from '../ProxiesImpl/ProxiesImpl';
@@ -23,7 +23,7 @@ function CypressProxiesOverview({counters}: {counters: SystemNodeCounters}) {
 
 function CypressProxies() {
     const cluster = useSelector(selectCluster);
-    const collapsed = useSelector(getSettingsSystemCypressProxiesCollapsed);
+    const collapsed = useSelector(selectSettingsSystemCypressProxiesCollapsed);
     const roleGroups = useSelector(getCypressProxiesRoleGroups);
     const counters = useSelector(getCypressProxiesCounters);
     const dispatch = useDispatch();

--- a/packages/ui/src/ui/pages/system/HttpProxies/HttpProxies.tsx
+++ b/packages/ui/src/ui/pages/system/HttpProxies/HttpProxies.tsx
@@ -6,7 +6,7 @@ import SystemStateOverview from '../SystemStateOverview/SystemStateOverview';
 
 import {loadSystemProxies} from '../../../store/actions/system/proxies';
 import {selectCluster} from '../../../store/selectors/global';
-import {getSettingsSystemHttpProxiesCollapsed} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsSystemHttpProxiesCollapsed} from '../../../store/selectors/settings/settings-ts';
 import {setSettingsSystemHttpProxiesCollapsed} from '../../../store/actions/settings/settings';
 import {type RootState} from '../../../store/reducers';
 import {useDispatch} from '../../../store/redux-hooks';
@@ -78,7 +78,7 @@ function mapStateToProps(state: RootState) {
         counters,
         roleGroups,
         loaded,
-        collapsed: getSettingsSystemHttpProxiesCollapsed(state),
+        collapsed: selectSettingsSystemHttpProxiesCollapsed(state),
         cluster: selectCluster(state),
     };
 }

--- a/packages/ui/src/ui/pages/system/Masters/MasterGroup.js
+++ b/packages/ui/src/ui/pages/system/Masters/MasterGroup.js
@@ -6,7 +6,7 @@ import block from 'bem-cn-lite';
 import {Flex} from '@gravity-ui/uikit';
 
 import format from '../../../common/hammer/format';
-import {getMastersHostType} from '../../../store/selectors/settings';
+import {selectMastersHostType} from '../../../store/selectors/settings';
 import Icon from '../../../components/Icon/Icon';
 
 import {SwitchLeaderButton} from './SwitchLeader';
@@ -124,7 +124,7 @@ class MasterGroup extends Component {
 }
 
 const mapStateToProps = (state) => {
-    const hostType = getMastersHostType(state);
+    const hostType = selectMastersHostType(state);
     return {hostType};
 };
 

--- a/packages/ui/src/ui/pages/system/Masters/Masters.js
+++ b/packages/ui/src/ui/pages/system/Masters/Masters.js
@@ -13,7 +13,7 @@ import SystemStateOverview from '../SystemStateOverview/SystemStateOverview';
 import MasterGroup from './MasterGroup';
 
 import {loadMasters} from '../../../store/actions/system/masters';
-import {getSettingsSystemMastersCollapsed} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsSystemMastersCollapsed} from '../../../store/selectors/settings/settings-ts';
 import {setSettingsSystemMastersCollapsed} from '../../../store/actions/settings/settings';
 import {useUpdater} from '../../../hooks/use-updater';
 
@@ -295,7 +295,7 @@ function mapStateToProps(state) {
         counters,
         alerts,
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
-        collapsed: getSettingsSystemMastersCollapsed(state),
+        collapsed: selectSettingsSystemMastersCollapsed(state),
     };
 }
 

--- a/packages/ui/src/ui/pages/system/Nodes/Nodes.tsx
+++ b/packages/ui/src/ui/pages/system/Nodes/Nodes.tsx
@@ -25,8 +25,8 @@ import {selectCluster} from '../../../store/selectors/global';
 import {type RootState} from '../../../store/reducers';
 
 import {
-    getSettingSystemNodesNodeType,
-    getSettingsSystemNodesCollapsed,
+    selectSettingSystemNodesNodeType,
+    selectSettingsSystemNodesCollapsed,
 } from '../../../store/selectors/settings/settings-ts';
 import {selectSystemNodesNodeTypesToLoad} from '../../../store/selectors/system/nodes';
 import {
@@ -252,8 +252,8 @@ function mapStateToProps(state: RootState) {
         loaded,
         counters,
         overviewCounters,
-        collapsed: getSettingsSystemNodesCollapsed(state),
-        nodeType: getSettingSystemNodesNodeType(state),
+        collapsed: selectSettingsSystemNodesCollapsed(state),
+        nodeType: selectSettingSystemNodesNodeType(state),
         roleGroups,
     };
 }

--- a/packages/ui/src/ui/pages/system/RpcProxies/RpcProxies.tsx
+++ b/packages/ui/src/ui/pages/system/RpcProxies/RpcProxies.tsx
@@ -8,7 +8,7 @@ import {setSettingsSystemRpcProxiesCollapsed} from '../../../store/actions/setti
 import {loadSystemRPCProxies} from '../../../store/actions/system/rpc-proxies';
 import {selectCluster} from '../../../store/selectors/global';
 import {type RootState} from '../../../store/reducers';
-import {getSettingsSystemRpcProxiesCollapsed} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsSystemRpcProxiesCollapsed} from '../../../store/selectors/settings/settings-ts';
 import {useDispatch} from '../../../store/redux-hooks';
 import {type MakeUrlParams} from '../ProxiesImpl/RoleGroup';
 import {ProxiesImpl} from '../ProxiesImpl/ProxiesImpl';
@@ -71,7 +71,7 @@ function mapStateToProps(state: RootState) {
     return {
         counters,
         roleGroups,
-        collapsed: getSettingsSystemRpcProxiesCollapsed(state),
+        collapsed: selectSettingsSystemRpcProxiesCollapsed(state),
         cluster: selectCluster(state),
     };
 }

--- a/packages/ui/src/ui/pages/system/SchedulersAndAgents/SchedulersAndAgents.js
+++ b/packages/ui/src/ui/pages/system/SchedulersAndAgents/SchedulersAndAgents.js
@@ -24,7 +24,7 @@ import {loadSchedulersAndAgents} from '../../../store/actions/system';
 import prepareTags from './prepareTags';
 
 import './Schedulers.scss';
-import {getSettingsSystemSchedulersCollapsed} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsSystemSchedulersCollapsed} from '../../../store/selectors/settings/settings-ts';
 import {setSettingsSystemSchedulersCollapsed} from '../../../store/actions/settings/settings';
 import {useUpdater} from '../../../hooks/use-updater';
 import {UI_COLLAPSIBLE_SIZE} from '../../../constants/global';
@@ -179,7 +179,7 @@ function mapStateToProps(state) {
         counters: selectSystemSchedulerAndAgentCounters(state),
         alerts: selectSystemSchedulerAndAgentAlerts(state),
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
-        collapsed: getSettingsSystemSchedulersCollapsed(state),
+        collapsed: selectSettingsSystemSchedulersCollapsed(state),
     };
 }
 

--- a/packages/ui/src/ui/pages/system/VisibleHostTypeRadioButton.js
+++ b/packages/ui/src/ui/pages/system/VisibleHostTypeRadioButton.js
@@ -6,7 +6,7 @@ import {setSetting} from '../../store/actions/settings';
 import {NAMESPACES, SettingName} from '../../../shared/constants/settings';
 import RadioButton from '../../components/RadioButton/RadioButton';
 import {mastersRadioButtonItems} from '../../constants/system/masters';
-import {getMastersHostType} from '../../store/selectors/settings';
+import {selectMastersHostType} from '../../store/selectors/settings';
 
 VisibleHostTypeRadioButton.propTypes = {
     hostType: PropTypes.string,
@@ -35,7 +35,7 @@ function VisibleHostTypeRadioButton({hostType, setSetting, className}) {
 
 const mapStateToProps = (state) => {
     return {
-        hostType: getMastersHostType(state),
+        hostType: selectMastersHostType(state),
     };
 };
 

--- a/packages/ui/src/ui/render-app.tsx
+++ b/packages/ui/src/ui/render-app.tsx
@@ -9,7 +9,7 @@ import {useSelector} from './store/redux-hooks';
 
 import {Router} from 'react-router';
 
-import {getSettingsData} from './store/selectors/settings/settings-base';
+import {selectSettingsData} from './store/selectors/settings/settings-base';
 import {createMainEntryStore} from './store/store.main';
 
 import App from './containers/App/App';
@@ -35,7 +35,7 @@ function AppWithStore({store, history}: ReturnType<typeof createMainEntryStore>)
 }
 
 function AppRoot({history}: Pick<ReturnType<typeof createMainEntryStore>, 'history'>) {
-    const lang = useSelector(getSettingsData)['global::lang'] ?? 'en';
+    const lang = useSelector(selectSettingsData)['global::lang'] ?? 'en';
 
     React.useMemo(() => {
         ytSetLang(lang);

--- a/packages/ui/src/ui/store/actions/accounts/account-usage.ts
+++ b/packages/ui/src/ui/store/actions/accounts/account-usage.ts
@@ -38,7 +38,7 @@ import {
     getAccountUsageViewType,
 } from '../../selectors/accounts/account-usage';
 import {selectActiveAccount} from '../../../store/selectors/accounts/accounts-ts';
-import {getSettingsAccountUsageViewType} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsAccountUsageViewType} from '../../../store/selectors/settings/settings-ts';
 import {type SortState} from '../../../types';
 import {
     type AccountUsageFiltersState,
@@ -81,7 +81,7 @@ export function syncAccountsUsageViewTypeWithSettings(): FiltersThunkAction {
         const state = getState();
         const viewType = getAccountUsageViewType(state);
         if (!viewType) {
-            const lastViewType = getSettingsAccountUsageViewType(state);
+            const lastViewType = selectSettingsAccountUsageViewType(state);
             dispatch(setAccountUsageFilters({viewType: lastViewType}));
         } else {
             dispatch(setSettingsAccountUsageViewType(viewType));

--- a/packages/ui/src/ui/store/actions/cluster-params.ts
+++ b/packages/ui/src/ui/store/actions/cluster-params.ts
@@ -12,9 +12,9 @@ import {INIT_CLUSTER_PARAMS, PRELOAD_ERROR, UPDATE_CLUSTER} from '../../constant
 import {getXsrfCookieName} from '../../utils';
 import {RESET_STORE_BEFORE_CLUSTER_CHANGE} from '../../constants/utils';
 import {
-    isRecentClustersFirst,
-    isRecentPagesFirst,
-    shouldUsePreserveState,
+    selectIsRecentClustersFirst,
+    selectIsRecentPagesFirst,
+    selectShouldUsePreserveState,
 } from '../../store/selectors/settings';
 import {rumLogError} from '../../rum/rum-counter';
 import {RumWrapper, YTApiId} from '../../rum/rum-wrap-api';
@@ -168,13 +168,13 @@ function initClusterAndUserSettingsAfterClusterChanging(params: {
 
         const state = getState();
 
-        if (isRecentClustersFirst(state)) {
+        if (selectIsRecentClustersFirst(state)) {
             dispatch(splitMenuItemsAction('cluster'));
         } else {
             dispatch(joinMenuItemsAction('clusters'));
         }
 
-        if (isRecentPagesFirst(state)) {
+        if (selectIsRecentPagesFirst(state)) {
             dispatch(splitMenuItemsAction('page'));
         } else {
             dispatch(joinMenuItemsAction('pages'));
@@ -227,7 +227,7 @@ export function updateCluster(cluster: string): GlobalThunkAction {
                     dispatch({
                         type: RESET_STORE_BEFORE_CLUSTER_CHANGE,
                         data: {
-                            shouldUsePreserveState: shouldUsePreserveState(getState()),
+                            shouldUsePreserveState: selectShouldUsePreserveState(getState()),
                         },
                     });
                 }

--- a/packages/ui/src/ui/store/actions/components/nodes/nodes.ts
+++ b/packages/ui/src/ui/store/actions/components/nodes/nodes.ts
@@ -16,7 +16,7 @@ import {
     type selectRequiredAttributes,
     selectTagsFromAttributes,
 } from '../../../../store/selectors/components/nodes/nodes';
-import {getTemplates} from '../../../../store/selectors/settings';
+import {selectTemplates} from '../../../../store/selectors/settings';
 import {type RootState} from '../../../../store/reducers';
 import {Node} from '../../../../store/reducers/components/nodes/nodes/node';
 import {
@@ -172,7 +172,7 @@ export function applyPreset(
 export function savePreset(name: string, data: FIX_MY_TYPE): NodesThunkAction {
     return (dispatch, getState) => {
         const state = getState();
-        const prevTemplates = getTemplates(state) || {};
+        const prevTemplates = selectTemplates(state) || {};
         const templates = {
             ...prevTemplates,
             [name]: data,
@@ -185,7 +185,7 @@ export function savePreset(name: string, data: FIX_MY_TYPE): NodesThunkAction {
 export function removePreset(name: string): NodesThunkAction {
     return (dispatch, getState) => {
         const state = getState();
-        const templates = omit_(getTemplates(state), name);
+        const templates = omit_(selectTemplates(state), name);
 
         dispatch(setSetting(TEMPLATES, COMPONENTS, templates));
     };

--- a/packages/ui/src/ui/store/actions/favourites.js
+++ b/packages/ui/src/ui/store/actions/favourites.js
@@ -3,11 +3,11 @@ import {getMetrics} from '../../common/utils/metrics';
 import find_ from 'lodash/find';
 
 import {
-    getAccountsNS,
-    getBundlesNS,
-    getChytNS,
-    getClusterNS,
-    makeGetSetting,
+    selectAccountsNS,
+    selectBundlesNS,
+    selectChytNS,
+    selectClusterNS,
+    selectGetSetting,
 } from '../../store/selectors/settings';
 import {SettingName} from '../../../shared/constants/settings';
 import {reloadSetting, setSetting} from '../../store/actions/settings';
@@ -24,14 +24,14 @@ export function accountsTrackVisit(account) {
             return;
         }
 
-        const parentNS = getAccountsNS(getState());
+        const parentNS = selectAccountsNS(getState());
         return dispatch(trackLastVisited(account, parentNS));
     };
 }
 
 export function navigationTrackVisit(path) {
     return (dispatch, getState) => {
-        const parentNS = getClusterNS(getState());
+        const parentNS = selectClusterNS(getState());
         return dispatch(trackLastVisited(path, parentNS));
     };
 }
@@ -43,7 +43,7 @@ export function bundlesTrackVisit(bundle) {
         if (!bundle || bundle === activeBundle) {
             return;
         }
-        const parentNS = getBundlesNS(state);
+        const parentNS = selectBundlesNS(state);
         return dispatch(trackLastVisited(bundle, parentNS));
     };
 }
@@ -52,7 +52,7 @@ function trackLastVisited(value, parentNS, settingName = SettingName.LOCAL.LAST_
     return (dispatch, getState) => {
         return dispatch(reloadSetting(settingName, parentNS)).then(() => {
             const state = getState();
-            const current = makeGetSetting(state)(settingName, parentNS) || [];
+            const current = selectGetSetting(state)(settingName, parentNS) || [];
             const currentPathItem = {path: value, count: 1};
 
             return dispatch(
@@ -83,7 +83,7 @@ export function accountsToggleFavourite(account) {
     getMetrics().countEvent('accounts_toggle-favourites');
 
     return (dispatch, getState) => {
-        const parentNS = getAccountsNS(getState());
+        const parentNS = selectAccountsNS(getState());
         return dispatch(toggleFavourite(account, parentNS));
     };
 }
@@ -92,7 +92,7 @@ export function chytToggleFavourite(clique) {
     getMetrics().countEvent('chyt_toggle-favourites');
 
     return (dispatch, getState) => {
-        const chytNS = getChytNS(getState());
+        const chytNS = selectChytNS(getState());
         return dispatch(toggleFavourite(clique, chytNS));
     };
 }
@@ -101,7 +101,7 @@ export function navigationToggleFavourite(path) {
     getMetrics().countEvent('navigation_toggle-favourites');
 
     return (dispatch, getState) => {
-        const parentNS = getClusterNS(getState());
+        const parentNS = selectClusterNS(getState());
         return dispatch(toggleFavourite(path, parentNS));
     };
 }
@@ -110,7 +110,7 @@ export function bundlesToggleFavourite(bundle) {
     getMetrics().countEvent('accounts_toggle-favourites');
 
     return (dispatch, getState) => {
-        const parentNS = getBundlesNS(getState());
+        const parentNS = selectBundlesNS(getState());
         return dispatch(toggleFavourite(bundle, parentNS));
     };
 }
@@ -119,7 +119,7 @@ export function toggleFavourite(value, parentNS, settingName = SettingName.LOCAL
     return (dispatch, getState) => {
         return dispatch(reloadSetting(settingName, parentNS)).then(() => {
             const state = getState();
-            const current = [...(makeGetSetting(state)(settingName, parentNS) || [])];
+            const current = [...(selectGetSetting(state)(settingName, parentNS) || [])];
             const currentPathItem = {path: value};
 
             const entry = find_(current, currentPathItem);

--- a/packages/ui/src/ui/store/actions/menu.js
+++ b/packages/ui/src/ui/store/actions/menu.js
@@ -11,7 +11,7 @@ import {
 } from '../../store/selectors/slideoutMenu';
 import {getMetrics} from '../../common/utils/metrics';
 import {NAMESPACES, SettingName} from '../../../shared/constants/settings';
-import {getClusterNS, getLastVisitedTabs} from '../../store/selectors/settings';
+import {selectClusterNS, selectLastVisitedTabs} from '../../store/selectors/settings';
 import {getPath} from '../../../shared/utils/settings';
 import {selectCluster, selectCurrentUserName} from '../../store/selectors/global';
 
@@ -88,8 +88,8 @@ export function trackPageVisit(page) {
 export function trackTabVisit(page, tab) {
     return (dispatch, getState) => {
         const state = getState();
-        const clusterNS = getClusterNS(state);
-        const lastVisitedTabs = getLastVisitedTabs(state);
+        const clusterNS = selectClusterNS(state);
+        const lastVisitedTabs = selectLastVisitedTabs(state);
         const newLastVisitedTabs = {...lastVisitedTabs, [page]: tab};
 
         dispatch(setSetting(SettingName.LOCAL.LAST_VISITED_TAB, clusterNS, newLastVisitedTabs));

--- a/packages/ui/src/ui/store/actions/navigation/content/table/table.js
+++ b/packages/ui/src/ui/store/actions/navigation/content/table/table.js
@@ -42,8 +42,8 @@ import {
     selectTransaction,
 } from '../../../../../store/selectors/navigation';
 import {
-    getDefaultTableColumnLimit,
-    isTableSimilarityEnabled,
+    selectDefaultTableColumnLimit,
+    selectIsTableSimilarityEnabled,
 } from '../../../../../store/selectors/settings';
 import {
     selectAllColumns,
@@ -89,7 +89,7 @@ function loadDynamicTable(requestOutputFormat, state, type, useZeroRangeForPrelo
     const attributes = selectAttributes(state);
     const useYqlTypes = selectIsYqlTypesEnabled(state);
     const moveBackward = selectMoveOffsetBackward(state);
-    const defaultTableColumnLimit = getDefaultTableColumnLimit(state);
+    const defaultTableColumnLimit = selectDefaultTableColumnLimit(state);
     const {offsetValue: offset, moveBackward: descending} = selectNextOffset(state);
     const transaction = selectTransaction(state);
     const orderBySupported = true;
@@ -290,7 +290,7 @@ async function loadStaticTable(requestOutputFormat, state, type, useZeroRangeFor
     const transaction = selectTransaction(state);
     const moveBackward = selectMoveOffsetBackward(state);
     const requestedPageSize = selectRequestedPageSize(state);
-    const defaultTableColumnLimit = getDefaultTableColumnLimit(state);
+    const defaultTableColumnLimit = selectDefaultTableColumnLimit(state);
 
     const {login} = state.global;
     // Get all columns always and update them then. We can get new columns. The scheme is not always strict
@@ -358,7 +358,7 @@ function loadTableRows(type, state, requestOutputFormat) {
 // Make a table request with page size row range and empty column range to get the list of all columns in table
 // and restore personalized columns list.
 function restoreColumns(state) {
-    const tableSimilarityEnabled = isTableSimilarityEnabled(state);
+    const tableSimilarityEnabled = selectIsTableSimilarityEnabled(state);
     const attributes = selectAttributes(state);
     const stringLimit = selectCellSize(state);
 
@@ -408,7 +408,7 @@ export function updateTableData() {
                 if (!isDynamic) {
                     // Get current columns for save visible status
                     const storedColumns = selectColumns(state);
-                    const defaultTableColumnLimit = getDefaultTableColumnLimit(state);
+                    const defaultTableColumnLimit = selectDefaultTableColumnLimit(state);
                     const preparedColumns = Columns.prepareColumns(
                         attributes,
                         rows,
@@ -482,7 +482,7 @@ export function getTableData() {
                 deniedKeyColumns = [],
             }) => {
                 const state = getState();
-                const defaultTableColumnLimit = getDefaultTableColumnLimit(state);
+                const defaultTableColumnLimit = selectDefaultTableColumnLimit(state);
                 const preparedColumns = Columns.prepareColumns(
                     attributes,
                     rows,

--- a/packages/ui/src/ui/store/actions/navigation/index.ts
+++ b/packages/ui/src/ui/store/actions/navigation/index.ts
@@ -10,7 +10,7 @@ import {navigationTrackVisit} from '../../../store/actions/favourites';
 import {RumWrapper, YTApiId, ytApiV3, ytApiV3Id} from '../../../rum/rum-wrap-api';
 import {RumMeasureTypes} from '../../../rum/rum-measure-types';
 
-import {isPathAutoCorrectionSettingEnabled} from '../../../store/selectors/settings';
+import {selectIsPathAutoCorrectionSettingEnabled} from '../../../store/selectors/settings';
 import {selectPath, selectTransaction} from '../../../store/selectors/navigation';
 
 import {
@@ -245,7 +245,7 @@ export function clearTransaction(): NavigationThunk {
 
 export function updatePath(path: string, shouldUpdateContentMode = true): NavigationThunk<string> {
     return (dispatch, getState) => {
-        const autoCorrectionEnabled = isPathAutoCorrectionSettingEnabled(getState());
+        const autoCorrectionEnabled = selectIsPathAutoCorrectionSettingEnabled(getState());
 
         const correctedPath = autoCorrectionEnabled ? autoCorrectPath(path) : path;
 

--- a/packages/ui/src/ui/store/actions/operations/statistics.js
+++ b/packages/ui/src/ui/store/actions/operations/statistics.js
@@ -5,7 +5,7 @@ import {
     SET_TREE_STATE,
 } from '../../../constants/operations/statistics';
 import {selectOperation} from '../../../store/selectors/operations/operation';
-import {getSettingOperationStatisticsActiveJobTypes} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingOperationStatisticsActiveJobTypes} from '../../../store/selectors/settings/settings-ts';
 import {setSettingsStatisticsActiveJobTypes} from '../../../store/actions/settings/settings';
 
 export function setTreeState(treeState) {
@@ -38,7 +38,7 @@ export function changeJobType(jobType) {
 
         const state = getState();
         const operationType = selectOperation(state).type;
-        const settingsJobTypes = getSettingOperationStatisticsActiveJobTypes(state);
+        const settingsJobTypes = selectSettingOperationStatisticsActiveJobTypes(state);
 
         if (settingsJobTypes && settingsJobTypes[operationType] !== jobType) {
             dispatch(

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -41,7 +41,7 @@ import {
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {prepareQueryPlanIds} from '../../../types/query-tracker/query';
 import {chytApiAction, spytApiAction} from '../../../utils/strawberryControllerApi';
-import {getSettingQueryTrackerStage} from '../../selectors/settings/settings-ts';
+import {selectSettingQueryTrackerStage} from '../../selectors/settings/settings-ts';
 import {
     selectDefaultQueryACO,
     selectDefaultYqlVersion,
@@ -331,7 +331,7 @@ export function loadQuery(
 > {
     return async (dispatch, getState) => {
         const state = getState();
-        const stage = getSettingQueryTrackerStage(state);
+        const stage = selectSettingQueryTrackerStage(state);
         dispatch({type: REQUEST_QUERY});
         dispatch(resetQueryTabs());
         try {

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -65,10 +65,10 @@ import {
 import {loadVisualization} from './queryChart';
 import {type ChytInfo} from '../../reducers/chyt/list';
 import {
-    getLastUserChoiceQueryChytClique,
-    getLastUserChoiceQueryDiscoveryPath,
-    getLastUserChoiceQueryEngine,
-    getLastUserChoiceYqlVersion,
+    selectLastUserChoiceQueryChytClique,
+    selectLastUserChoiceQueryDiscoveryPath,
+    selectLastUserChoiceQueryEngine,
+    selectLastUserChoiceYqlVersion,
 } from '../../selectors/settings/settings-queries';
 
 import {getClusterParams, prepareClusterUiConfig} from '../cluster-params';
@@ -123,9 +123,9 @@ export const setUserLastChoice =
         const state = getState();
         const {settings} = selectQueryDraft(state);
         const engine = selectQueryEngine(state);
-        const lastPath = getLastUserChoiceQueryDiscoveryPath(state);
-        const lastClique = getLastUserChoiceQueryChytClique(state);
-        const lastVersion = getLastUserChoiceYqlVersion(state);
+        const lastPath = selectLastUserChoiceQueryDiscoveryPath(state);
+        const lastClique = selectLastUserChoiceQueryChytClique(state);
+        const lastVersion = selectLastUserChoiceYqlVersion(state);
         const defaultYqlVersion = selectDefaultYqlVersion(state);
 
         const newSettings = {...settings};
@@ -469,7 +469,7 @@ export function createEmptyQuery(
 ): ThunkAction<any, RootState, any, SetQueryAction | ResetQueryTabsAction> {
     return (dispatch, getState) => {
         const state = getState();
-        const lastEngine = getLastUserChoiceQueryEngine(state);
+        const lastEngine = selectLastUserChoiceQueryEngine(state);
         const defaultQueryACO = selectDefaultQueryACO(state);
         const defaultSpytSettings = selectSpytDefaultSettings(state);
 

--- a/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
@@ -37,7 +37,7 @@ import {isFolderNode} from '../../../utils/navigation/isFolderNode';
 import {QueryEngine} from '../../../../shared/constants/engines';
 import {loadCliqueByCluster, loadTablePromptToQuery} from './query';
 import {selectQueryDraft} from '../../selectors/query-tracker/query';
-import {getDefaultTableColumnLimit} from '../../selectors/settings';
+import {selectDefaultTableColumnLimit} from '../../selectors/settings';
 import {selectIsYqlTypesEnabled} from '../../selectors/navigation/content/table';
 import {getClusterProxy, selectCurrentUserName} from '../../selectors/global';
 import {selectQueryResultGlobalSettings} from '../../selectors/query-tracker/queryResult';
@@ -114,7 +114,7 @@ export const loadTableAttributesByPath =
         const state = getState();
         const clusterConfig = selectNavigationClusterConfig(state);
         const {cellSize, pageSize} = selectQueryResultGlobalSettings();
-        const defaultTableColumnLimit = getDefaultTableColumnLimit(state);
+        const defaultTableColumnLimit = selectDefaultTableColumnLimit(state);
         const useYqlTypes = selectIsYqlTypesEnabled(state);
         const login = selectCurrentUserName(state);
         const ysonSettings = getYsonSettingsDisableDecode(state);

--- a/packages/ui/src/ui/store/actions/query-tracker/vcs.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/vcs.ts
@@ -28,10 +28,10 @@ import {selectFileEditor} from '../../selectors/query-tracker/queryFilesForm';
 import {setFileEditor} from '../../reducers/query-tracker/queryFilesFormSlice';
 import {type VcsRepository} from '../../../../shared/vcs';
 import {
-    getVcsBranch,
-    getVcsPath,
-    getVcsRepository,
-    getVcsType,
+    selectVcsBranch,
+    selectVcsPath,
+    selectVcsRepository,
+    selectVcsType,
 } from '../../selectors/settings/settings-vcs';
 import {setSettingByKey} from '../settings';
 
@@ -340,10 +340,10 @@ export const changeCurrentBranch =
 
 export const setLastVcs = (): AsyncAction => async (dispatch, getState) => {
     const state = getState();
-    const type = getVcsType(state);
-    const repository = getVcsRepository(state);
-    const branch = getVcsBranch(state);
-    const path = getVcsPath(state);
+    const type = selectVcsType(state);
+    const repository = selectVcsRepository(state);
+    const branch = selectVcsBranch(state);
+    const path = selectVcsPath(state);
 
     if (!type) return;
     await dispatch(getVcsRepositories(type));

--- a/packages/ui/src/ui/store/actions/scheduling/scheduling.ts
+++ b/packages/ui/src/ui/store/actions/scheduling/scheduling.ts
@@ -13,7 +13,7 @@ import {type BatchSubRequest} from '../../../../shared/yt-types';
 import {type RootState} from '../../../store/reducers';
 import {splitBatchResults} from '../../../../shared/utils/error';
 
-import {getSchedulingNS} from '../../../store/selectors/settings';
+import {selectSchedulingNS} from '../../../store/selectors/settings';
 import {toggleFavourite} from '../../../store/actions/favourites';
 import {
     type SchedulingContentMode,
@@ -350,7 +350,7 @@ export function changePoolChildrenFilter(poolChildrenFilter: string) {
 export function togglePoolFavourites(pool: string, tree: string): SchedulingThunk<void> {
     return (dispatch, getState) => {
         const value = `${pool}[${tree}]`;
-        const parentNS = getSchedulingNS(getState());
+        const parentNS = selectSchedulingNS(getState());
         return dispatch(toggleFavourite(value, parentNS));
     };
 }

--- a/packages/ui/src/ui/store/actions/settings/settings-base.ts
+++ b/packages/ui/src/ui/store/actions/settings/settings-base.ts
@@ -7,7 +7,7 @@ import {type DescribedSettings, type SettingKey} from '../../../../shared/consta
 import {SET_SETTING_VALUE} from '../../../constants/index';
 import {showToasterError} from '../../../utils/utils';
 import {selectCurrentUserName, selectSettingsCluster} from '../../selectors/global';
-import {getSettingsData} from '../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../store/selectors/settings/settings-base';
 
 export type SettingsThunkAction<T = Promise<void>> = ThunkAction<
     T,
@@ -31,7 +31,7 @@ export function setSettingByKey<K extends SettingKey, T extends DescribedSetting
         const {
             settings: {provider},
         } = state;
-        const data = getSettingsData(state);
+        const data = selectSettingsData(state);
         const login = selectCurrentUserName(state);
         const cluster = selectSettingsCluster(getState());
 

--- a/packages/ui/src/ui/store/actions/settings/settings.ts
+++ b/packages/ui/src/ui/store/actions/settings/settings.ts
@@ -8,7 +8,7 @@ import {setSetting, setSettingByKey} from './index';
 import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
 import {type AnnotationVisibilityType} from '../../../../shared/constants/settings-ts';
 import {type AccountUsageViewType} from '../../../store/reducers/accounts/usage/accounts-usage-filters';
-import {getQueryTokens} from '../../selectors/settings/settings-queries';
+import {selectQueryTokens} from '../../selectors/settings/settings-queries';
 import {type QueryToken} from '../../../../shared/constants/settings-types';
 
 type SettingThunkAction = ThunkAction<any, RootState, any, any>;
@@ -240,7 +240,7 @@ export function setSettingSystemNodesNodeType(nodeType: Array<string>): SettingT
 
 export function appendQueryToken(token: QueryToken): SettingThunkAction {
     return async (dispatch, getState) => {
-        const tokens = getQueryTokens(getState());
+        const tokens = selectQueryTokens(getState());
         await dispatch(
             setSettingByKey('global::queryTracker::tokens', [...tokens, token], {silent: true}),
         );
@@ -249,7 +249,7 @@ export function appendQueryToken(token: QueryToken): SettingThunkAction {
 
 export function removeQueryToken(name: string): SettingThunkAction {
     return (dispatch, getState) => {
-        const tokens = getQueryTokens(getState());
+        const tokens = selectQueryTokens(getState());
         const result = tokens.filter((token) => token.name !== name);
         dispatch(setSettingByKey('global::queryTracker::tokens', result));
     };

--- a/packages/ui/src/ui/store/actions/slideoutMenu.ts
+++ b/packages/ui/src/ui/store/actions/slideoutMenu.ts
@@ -6,8 +6,8 @@ import map_ from 'lodash/map';
 
 import {type RootState} from '../reducers';
 import {
-    getSettingsPagesOrder,
-    getSettingsPagesPinned,
+    selectSettingsPagesOrder,
+    selectSettingsPagesPinned,
 } from '../../store/selectors/settings/settings-ts';
 import {setSettingsPagesOrder, setSettingsPagesPinned} from '../../store/actions/settings/settings';
 import {getPagesOrderedByUser} from '../../store/selectors/slideoutMenu';
@@ -18,10 +18,10 @@ import {selectCurrentUserName} from '../selectors/global';
 export function togglePinnedPage(id: string): ThunkAction<any, RootState, any, any> {
     return (dispatch, getState) => {
         const state = getState();
-        const pinned = {...getSettingsPagesPinned(state)};
+        const pinned = {...selectSettingsPagesPinned(state)};
         const orderedPages = getPagesOrderedByUser(state);
 
-        const prevOrder = getSettingsPagesOrder(state);
+        const prevOrder = selectSettingsPagesOrder(state);
         const newOrder = map_(orderedPages, 'id');
 
         const itemIndex = findIndex_(orderedPages, (item) => item.id === id);
@@ -93,7 +93,7 @@ export function setPagesItemPosition(params: {
         const next = orderedPages[newIndex + 1];
 
         if ((item.pinned && prev && !prev.pinned) || (!item.pinned && next && next.pinned)) {
-            const pinned = {...getSettingsPagesPinned(state)};
+            const pinned = {...selectSettingsPagesPinned(state)};
             toggleBooleanInPlace(item.id, pinned);
             dispatch(setSettingsPagesPinned(pinned));
         }

--- a/packages/ui/src/ui/store/api/yt/checkPermissions/index.ts
+++ b/packages/ui/src/ui/store/api/yt/checkPermissions/index.ts
@@ -1,7 +1,7 @@
 import {DEFAULT_UPDATER_TIMEOUT} from '../../../../hooks/use-updater';
 import {useSelector} from '../../../../store/redux-hooks';
 import {selectCluster} from '../../../../store/selectors/global/cluster';
-import {getUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
+import {selectUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
 import {type OverrideDataType} from '../types';
 import {ytApi} from '../ytApi';
 import {type CheckPermissionParams, checkPermission} from './endpoint';
@@ -16,7 +16,7 @@ const checkPermissionApi = ytApi.injectEndpoints({
 });
 
 export function useCheckPermissionQuery(params: CheckPermissionParams) {
-    const useAutoRefresh = useSelector(getUseAutoRefresh);
+    const useAutoRefresh = useSelector(selectUseAutoRefresh);
     const cluster = useSelector(selectCluster);
 
     const options = {

--- a/packages/ui/src/ui/store/api/yt/executeBatch/index.ts
+++ b/packages/ui/src/ui/store/api/yt/executeBatch/index.ts
@@ -1,7 +1,7 @@
 import {useSelector} from '../../../../store/redux-hooks';
 import {type BaseQueryFn, type TypedUseMutationResult} from '@reduxjs/toolkit/query/react';
 
-import {getUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
+import {selectUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
 import {selectCluster} from '../../../../store/selectors/global';
 
 import {DEFAULT_UPDATER_TIMEOUT} from '../../../../hooks/use-updater';
@@ -62,7 +62,7 @@ export function useFetchBatchQuery<T>(
     args: BatchApiArgs,
     options?: UseQueryOptions<BatchQueryResult, BatchApiArgs>,
 ) {
-    const useAutoRefresh = useSelector(getUseAutoRefresh);
+    const useAutoRefresh = useSelector(selectUseAutoRefresh);
     const cluster = useSelector(selectCluster);
 
     const defaultOptions = {

--- a/packages/ui/src/ui/store/api/yt/get/index.ts
+++ b/packages/ui/src/ui/store/api/yt/get/index.ts
@@ -1,7 +1,7 @@
 import {DEFAULT_UPDATER_TIMEOUT} from '../../../../hooks/use-updater';
 import {useSelector} from '../../../../store/redux-hooks';
 import {selectCluster} from '../../../../store/selectors/global/cluster';
-import {getUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
+import {selectUseAutoRefresh} from '../../../../store/selectors/settings/settings-ts';
 import {type OverrideDataType} from '../types';
 import {ytApi} from '../ytApi';
 import {get} from './endpoint';
@@ -16,7 +16,7 @@ export const getApi = ytApi.injectEndpoints({
 });
 
 export function useGetQuery<T>(args: Parameters<typeof get>[0]) {
-    const useAutoRefresh = useSelector(getUseAutoRefresh);
+    const useAutoRefresh = useSelector(selectUseAutoRefresh);
     const cluster = useSelector(selectCluster);
 
     const options = {

--- a/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
@@ -9,9 +9,9 @@ import reduce_ from 'lodash/reduce';
 
 import {type SortState} from '../../../types';
 import {
-    getSettingsAccountUsageColumnsList,
-    getSettingsAccountUsageColumnsListFolders,
-    getSettingsAccountUsageColumnsTree,
+    selectSettingsAccountUsageColumnsList,
+    selectSettingsAccountUsageColumnsListFolders,
+    selectSettingsAccountUsageColumnsTree,
 } from '../../../store/selectors/settings/settings-ts';
 import format from '../../../common/hammer/format';
 import {type AccountUsageDataItem} from '../../../store/reducers/accounts/usage/account-usage-types';
@@ -292,9 +292,9 @@ function firstNotEmpty<T = keyof AccountUsageDataItem>(a1: Array<T>, a2: Array<T
 const getAccountUsageVisibleColumns = createSelector(
     [
         getAccountUsageViewType,
-        getSettingsAccountUsageColumnsTree,
-        getSettingsAccountUsageColumnsList,
-        getSettingsAccountUsageColumnsListFolders,
+        selectSettingsAccountUsageColumnsTree,
+        selectSettingsAccountUsageColumnsList,
+        selectSettingsAccountUsageColumnsListFolders,
     ],
     (viewType, treeColumns, listColumns, listFoldersColumns) => {
         switch (viewType) {

--- a/packages/ui/src/ui/store/selectors/accounts/dashboard.js
+++ b/packages/ui/src/ui/store/selectors/accounts/dashboard.js
@@ -6,8 +6,8 @@ import {
 } from '../../../store/selectors/accounts/accounts';
 import {selectFavouriteAccounts} from '../../../store/selectors/favourites';
 import {
-    getAccountsVisibilityMode,
-    getAccountsVisibilityModeOfDashboard,
+    selectAccountsVisibilityMode,
+    selectAccountsVisibilityModeOfDashboard,
 } from '../../../store/selectors/settings';
 import {filterFlattenTreeByViewContext} from '../../../utils/accounts';
 import {selectActiveAccount} from './accounts-ts';
@@ -28,7 +28,7 @@ export const selectFilteredAccountsOfDashboard = createSelector(
     [
         selectAccountsFlattenTree,
         selectUsableAccountsSet,
-        getAccountsVisibilityModeOfDashboard,
+        selectAccountsVisibilityModeOfDashboard,
         selectFavouriteAccountsSet,
     ],
     filterFlattenTreeByViewContext,
@@ -38,7 +38,7 @@ export const selectFilteredAccounts = createSelector(
     [
         selectAccountsFlattenTree,
         selectUsableAccountsSet,
-        getAccountsVisibilityMode,
+        selectAccountsVisibilityMode,
         selectFavouriteAccountsSet,
         selectActiveAccount,
     ],

--- a/packages/ui/src/ui/store/selectors/chyt/index.ts
+++ b/packages/ui/src/ui/store/selectors/chyt/index.ts
@@ -9,7 +9,7 @@ import {type ChytInfo} from '../../../store/reducers/chyt/list';
 import {type SortState} from '../../../types';
 import {multiSortBySortStateArray} from '../../../utils/sort-helpers';
 import {type StrawberryListAttributes} from '../../../utils/strawberryControllerApi';
-import {getSettingsData} from '../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../store/selectors/settings/settings-base';
 
 import {defaultColumns} from '../../../constants/chyt';
 
@@ -59,7 +59,7 @@ export type ChytSelectableColumn = keyof typeof CHYT_LIST_SELECTABLE_COLUMNS;
 type ChytColumnItem = {checked: boolean; column: ChytListColumns};
 
 export const selectChytListColumnsFromSettings = (state: RootState) => {
-    return getSettingsData(state)['global::chyt::list_columns'] ?? defaultColumns;
+    return selectSettingsData(state)['global::chyt::list_columns'] ?? defaultColumns;
 };
 
 export const selectChytListVisibleColumns = createSelector(

--- a/packages/ui/src/ui/store/selectors/components/nodes/filters-presets.js
+++ b/packages/ui/src/ui/store/selectors/components/nodes/filters-presets.js
@@ -1,7 +1,7 @@
 import {initialFiltersState} from '../../../../store/reducers/components/nodes/setup/setup';
 import {createSelector} from 'reselect';
 import transform_ from 'lodash/transform';
-import {getTemplates} from '../../../../store/selectors/settings';
+import {selectTemplates} from '../../../../store/selectors/settings';
 
 const getDefaultPreset = () => ({
     name: 'All',
@@ -9,7 +9,7 @@ const getDefaultPreset = () => ({
     isDefault: true,
 });
 
-const selectSavedPresets = createSelector(getTemplates, (presets = {}) =>
+const selectSavedPresets = createSelector(selectTemplates, (presets = {}) =>
     transform_(presets, (res, data, name) => res.push({name, data, isDefault: false}), []),
 );
 

--- a/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
+++ b/packages/ui/src/ui/store/selectors/components/nodes/nodes/data.ts
@@ -10,7 +10,7 @@ import {COMPONENTS_NODES_TABLE_ID} from '../../../../../constants/components/nod
 import {type RootState} from '../../../../../store/reducers';
 import {AttributesByProperty} from '../../../../../store/reducers/components/nodes/nodes/node';
 import {selectCluster} from '../../../../../store/selectors/global';
-import {getSelectedColumns} from '../../../../../store/selectors/settings';
+import {selectSelectedColumns} from '../../../../../store/selectors/settings';
 import {getMediumListNoCache} from '../../../../../store/selectors/thor';
 import {type ValueOf} from '../../../../../types';
 import {createMediumsPredicates} from '../../../../../utils/components/nodes/setup';
@@ -40,7 +40,7 @@ const selectSortState = (state: RootState) => state.tables[COMPONENTS_NODES_TABL
 const selectComponentsNodesNodeTypeRaw = (state: RootState) =>
     state.components.nodes.nodes.nodeTypes;
 
-const selectCustomColumns = (state: RootState) => getSelectedColumns(state) || defaultColumns;
+const selectCustomColumns = (state: RootState) => selectSelectedColumns(state) || defaultColumns;
 
 const selectMediumsPredicates = createSelector(
     [selectComponentNodesFiltersSetup, getMediumListNoCache],

--- a/packages/ui/src/ui/store/selectors/dashboard2/dashboard.ts
+++ b/packages/ui/src/ui/store/selectors/dashboard2/dashboard.ts
@@ -1,7 +1,7 @@
 import {createSelector} from '@reduxjs/toolkit';
 
 import {type RootState} from '../../../store/reducers';
-import {getSettingsData} from '../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../store/selectors/settings/settings-base';
 import {selectCluster} from '../../../store/selectors/global';
 
 import {dashboardConfig} from '../../../constants/dashboard2';
@@ -9,7 +9,7 @@ import {dashboardConfig} from '../../../constants/dashboard2';
 import {makeDefaultConfig} from '../../../utils/dashboard2/make-default-config';
 
 export const selectDashboardConfig = createSelector(
-    [getSettingsData, selectCluster],
+    [selectSettingsData, selectCluster],
     (data, cluster) => {
         // if user setuped his dashboard on current cluster no need to retrun default values
         if (
@@ -24,4 +24,4 @@ export const selectDashboardConfig = createSelector(
 );
 
 export const selectSettingNewDashboardPage = (state: RootState) =>
-    getSettingsData(state)['global::newDashboardPage'];
+    selectSettingsData(state)['global::newDashboardPage'];

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -4,13 +4,13 @@ import sortBy_ from 'lodash/sortBy';
 import {createSelector} from 'reselect';
 
 import {
-    getAccountsNS,
-    getBundlesNS,
-    getChytNS,
-    getClusterNS,
-    getSchedulingNS,
-    makeGetSetting,
+    selectAccountsNS,
+    selectBundlesNS,
     selectChaosBundlesNS,
+    selectChytNS,
+    selectClusterNS,
+    selectGetSetting,
+    selectSchedulingNS,
 } from '../../store/selectors/settings';
 import {SettingName} from '../../../shared/constants/settings';
 import {selectActiveAccount} from '../../store/selectors/accounts/accounts';
@@ -23,12 +23,12 @@ import {selectChytCurrentAlias} from './chyt';
 //************* Selectors for Accounts *****************
 
 export const selectFavouriteAccounts = createSelector(
-    [makeGetSetting, getAccountsNS],
+    [selectGetSetting, selectAccountsNS],
     prepareFavourites,
 );
 
 export const selectLastVisitedAccounts = createSelector(
-    [makeGetSetting, getAccountsNS],
+    [selectGetSetting, selectAccountsNS],
     prepareLastVisited,
 );
 
@@ -39,10 +39,13 @@ export const selectIsActiveAccountInFavourites = createSelector(
     prepareIsInFavourites,
 );
 
-export const selectFavouriteChyt = createSelector([makeGetSetting, getChytNS], prepareFavourites);
+export const selectFavouriteChyt = createSelector(
+    [selectGetSetting, selectChytNS],
+    prepareFavourites,
+);
 
 export const selectLastVisitedChyt = createSelector(
-    [makeGetSetting, getChytNS],
+    [selectGetSetting, selectChytNS],
     prepareLastVisited,
 );
 
@@ -56,12 +59,12 @@ export const selectIsActiveCliqueInFavourites = createSelector(
 //************* Selectors for Navigation *****************
 
 export const selectFavouritePaths = createSelector(
-    [makeGetSetting, getClusterNS],
+    [selectGetSetting, selectClusterNS],
     prepareFavourites,
 );
 
 export const selectLastVisitedPaths = createSelector(
-    [makeGetSetting, getClusterNS],
+    [selectGetSetting, selectClusterNS],
     prepareLastVisited,
 );
 
@@ -75,7 +78,7 @@ export const selectIsCurrentPathInFavourites = createSelector(
 //************* Selectors for Scheduling *****************
 
 export const selectFavouritePools = createSelector(
-    [makeGetSetting, getSchedulingNS],
+    [selectGetSetting, selectSchedulingNS],
     prepareFavourites,
 );
 
@@ -87,7 +90,7 @@ export const selectIsActivePoolInFavourites = createSelector(
 //************* Selectors for Bundles *****************
 
 export const selectFavouriteBundles = createSelector(
-    [makeGetSetting, getBundlesNS],
+    [selectGetSetting, selectBundlesNS],
     prepareFavourites,
 );
 
@@ -99,7 +102,7 @@ export const selectIsActiveBundleInFavourites = createSelector(
 // ************ Selectors for Chaos bundles ***********
 
 export const selectFavouriteChaosBundles = createSelector(
-    [makeGetSetting, selectChaosBundlesNS],
+    [selectGetSetting, selectChaosBundlesNS],
     prepareFavourites,
 );
 

--- a/packages/ui/src/ui/store/selectors/global/fonts.ts
+++ b/packages/ui/src/ui/store/selectors/global/fonts.ts
@@ -1,9 +1,9 @@
 import {createSelector} from 'reselect';
 
 import {uiSettings} from '../../../config/ui-settings';
-import {getSettingsData} from '../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../store/selectors/settings/settings-base';
 
-const selectSettingSelectedFontType = createSelector(getSettingsData, (data) => {
+const selectSettingSelectedFontType = createSelector(selectSettingsData, (data) => {
     return data['global::fontType'];
 });
 

--- a/packages/ui/src/ui/store/selectors/global/is-developer.ts
+++ b/packages/ui/src/ui/store/selectors/global/is-developer.ts
@@ -1,6 +1,6 @@
 import {YT} from '../../../config/yt-config';
 import {type RootState} from '../../../store/reducers';
-import {getSettingsData} from '../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../store/selectors/settings/settings-base';
 
 const selectIsDeveloper = (state: RootState): boolean => state?.global?.isDeveloper;
 
@@ -14,7 +14,7 @@ export const selectIsDeveloperOrWatchmen = (state: RootState): boolean => {
 };
 
 const selectSettingsRegularUserUI = (state: RootState) => {
-    return getSettingsData(state)['global::development::regularUserUI'];
+    return selectSettingsData(state)['global::development::regularUserUI'];
 };
 
 export const selectIsAdmin = (state: RootState): boolean => {

--- a/packages/ui/src/ui/store/selectors/global/max-content-width.ts
+++ b/packages/ui/src/ui/store/selectors/global/max-content-width.ts
@@ -1,9 +1,9 @@
 import {type RootState} from '../../../store/reducers';
-import {getSettingsData} from '../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../store/selectors/settings/settings-base';
 
 export const selectIsMaxContentWidthEnabled = (state: RootState) =>
     state.global.enableMaxContentWidth;
 
 export const selectMaxContentWidth = (state: RootState) => {
-    return getSettingsData(state)['global::maxContentWidth'];
+    return selectSettingsData(state)['global::maxContentWidth'];
 };

--- a/packages/ui/src/ui/store/selectors/navigation/content/map-node.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/map-node.js
@@ -15,7 +15,7 @@ import values_ from 'lodash/values';
 import ypath from '../../../../common/thor/ypath';
 import hammer from '../../../../common/hammer';
 import {selectParsedPath, selectTransaction} from '../../../../store/selectors/navigation';
-import {makeGetSetting} from '../../../../store/selectors/settings';
+import {selectGetSetting} from '../../../../store/selectors/settings';
 import {NAMESPACES, SettingName} from '../../../../../shared/constants/settings';
 import {ContentMode, NAVIGATION_MAP_NODE_TABLE_ID} from '../../../../constants/navigation';
 import {Node} from '../../../../utils/navigation/content/map-nodes/node';
@@ -161,7 +161,7 @@ const selectNodes = createSelector(
 );
 
 export const selectFilteredNodes = createSelector(
-    [selectNodes, makeGetSetting, selectTextFilter],
+    [selectNodes, selectGetSetting, selectTextFilter],
     (nodes, getSetting, filter) => {
         const useSmartFilter = getSetting('useSmartFilter', NAMESPACES.NAVIGATION);
         if (useSmartFilter) {
@@ -181,7 +181,7 @@ export const selectFilteredNodes = createSelector(
 );
 
 export const selectSelectedNodes = createSelector(
-    [selectSelected, selectNodes, makeGetSetting, selectSortState, selectTableColumns],
+    [selectSelected, selectNodes, selectGetSetting, selectSortState, selectTableColumns],
     (selected, allNodes, getSetting, sortState, columns) => {
         const nodes = filter_(allNodes, (node) => Boolean(selected[ypath.getValue(node)]));
         const groupNodes = getSetting(SettingName.NAVIGATION.GROUP_NODES, NAMESPACES.NAVIGATION);
@@ -253,7 +253,7 @@ export const TYPE_WEIGHTS = map_(
 }, {});
 
 export const selectSortedNodes = createSelector(
-    [selectFilteredNodes, selectSortState, selectTableColumns, makeGetSetting],
+    [selectFilteredNodes, selectSortState, selectTableColumns, selectGetSetting],
     (nodes, sortState, columns, getSetting) => {
         const groupNodes = getSetting(SettingName.NAVIGATION.GROUP_NODES, NAMESPACES.NAVIGATION);
         const groupByType = groupNodes && {
@@ -293,7 +293,7 @@ export const selectMapNodeResourcesLoading = (state) =>
 
 const DATE_REGEXP = /^\d{4}[-]\d{2}[-]\d{2}(T\d{2}:\d{2}:\d{2})?(\.[a-zA-Z0-9]+)?$/;
 export const selectShouldApplyCustomSort = createSelector(
-    [selectNodes, makeGetSetting, selectSortState],
+    [selectNodes, selectGetSetting, selectSortState],
     (nodes, getSetting, sortState) =>
         getSetting(SettingName.NAVIGATION.USE_SMART_SORT, NAMESPACES.NAVIGATION) &&
         sortState?.field === 'name' &&

--- a/packages/ui/src/ui/store/selectors/navigation/content/replicated-table.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/content/replicated-table.ts
@@ -6,7 +6,7 @@ import {createSelector} from 'reselect';
 import ypath from '../../../../common/thor/ypath';
 import {type RootState} from '../../../../store/reducers';
 import {calculateLoadingStatus} from '../../../../utils/utils';
-import {getSettingsData} from '../../settings/settings-base';
+import {selectSettingsData} from '../../settings/settings-base';
 
 export const selectNavigationReplicatedTableLoadingStatus = createSelector(
     [
@@ -74,7 +74,7 @@ export const selectReplicatedTableReplicasMap = createSelector(
     },
 );
 
-export const selectReplicatedTableSortSettings = createSelector([getSettingsData], (data) => {
+export const selectReplicatedTableSortSettings = createSelector([selectSettingsData], (data) => {
     const sortValue = data['global::navigation::replicatedTableSortState'];
 
     if (sortValue && typeof sortValue === 'object' && typeof sortValue.field === 'string') {

--- a/packages/ui/src/ui/store/selectors/navigation/content/table-ts.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/content/table-ts.ts
@@ -10,7 +10,7 @@ import {CypressNodeTypes} from '../../../../utils/cypress-attributes';
 import {selectAttributes} from '../index';
 import Columns from '../../../../utils/navigation/content/table/columns';
 import {getColumnsValues} from '../../../../utils/navigation/content/table/table';
-import {getSettingsData} from '../../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../../store/selectors/settings/settings-base';
 import {TABLE_DEFAULTS} from '../../../../constants/settings/table';
 
 export const selectLoaded = (state: RootState) => state.navigation.content.table.loaded;
@@ -37,7 +37,7 @@ const selectPageSizeRaw = (state: RootState) => state.navigation.content.table.p
 const selectCellSizeRaw = (state: RootState) => state.navigation.content.table.cellSize;
 
 export const selectCellSize = createSelector(
-    [selectCellSizeRaw, getSettingsData],
+    [selectCellSizeRaw, selectSettingsData],
     (cellSize, settings) => {
         return (
             cellSize ??
@@ -48,7 +48,7 @@ export const selectCellSize = createSelector(
 );
 
 export const selectPageSize = createSelector(
-    [selectPageSizeRaw, getSettingsData],
+    [selectPageSizeRaw, selectSettingsData],
     (pageSize, settings) => {
         return (
             pageSize ??

--- a/packages/ui/src/ui/store/selectors/navigation/content/table.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/table.js
@@ -8,7 +8,7 @@ import unipika from '../../../../common/thor/unipika';
 import {createSelector} from 'reselect';
 
 import {selectAttributes} from '../../../../store/selectors/navigation';
-import {shouldUseYqlTypes} from '../../../../store/selectors/settings/settings-development';
+import {selectShouldUseYqlTypes} from '../../../../store/selectors/settings/settings-development';
 
 import Columns from '../../../../utils/navigation/content/table/columns';
 import Query from '../../../../utils/navigation/content/table/query';
@@ -199,6 +199,6 @@ export const selectIsYqlSchemaExists = createSelector([selectAttributes], (attri
 });
 
 export const selectIsYqlTypesEnabled = createSelector(
-    [shouldUseYqlTypes],
+    [selectShouldUseYqlTypes],
     (isSettingEnabled) => isSettingEnabled,
 );

--- a/packages/ui/src/ui/store/selectors/navigation/index.js
+++ b/packages/ui/src/ui/store/selectors/navigation/index.js
@@ -2,7 +2,7 @@ import {createSelector} from 'reselect';
 import ypath from '@ytsaurus/interface-helpers/lib/ypath';
 
 import {NAVIGATION_MAP_NODE_TABLE_ID} from '../../../constants/navigation/index';
-import {getNavigationDefaultPath} from '../../../store/selectors/settings';
+import {selectNavigationDefaultPath} from '../../../store/selectors/settings';
 import {isFinalLoadingStatus} from '../../../utils/utils';
 
 export const selectTransaction = (state) => state.navigation.navigation.transaction;
@@ -17,7 +17,7 @@ export const selectSortState = (state) => state.tables[NAVIGATION_MAP_NODE_TABLE
 export const selectType = createSelector(selectAttributes, (attributes) => attributes?.type);
 
 export const selectPath = createSelector(
-    [selectRawPath, getNavigationDefaultPath],
+    [selectRawPath, selectNavigationDefaultPath],
     (rawPath, defaultPath) => rawPath || defaultPath,
 );
 

--- a/packages/ui/src/ui/store/selectors/operations/operations-list.ts
+++ b/packages/ui/src/ui/store/selectors/operations/operations-list.ts
@@ -6,7 +6,7 @@ import isEqual_ from 'lodash/isEqual';
 
 import {type RootState} from '../../../store/reducers';
 import {calculateLoadingStatus, isFinalLoadingStatus} from '../../../utils/utils';
-import {getSettingsDataRaw} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingsDataRaw} from '../../../store/selectors/settings/settings-ts';
 import {NAMESPACES} from '../../../../shared/constants/settings';
 import {NS_SEPARATOR} from '../../../../shared/utils/settings';
 import {
@@ -68,7 +68,7 @@ function createPreconfiguredPresets(login: string) {
 }
 
 export const selectOperationsListFilterPresets = createSelector(
-    [getSettingsDataRaw, selectCurrentUserName],
+    [selectSettingsDataRaw, selectCurrentUserName],
     (data, login): Record<string, OperationsListPreset> => {
         const collectionKeys: Array<keyof OperationPresetsSettings> = filter_(
             Object.keys(data) as Array<keyof OperationPresetsSettings>,

--- a/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
@@ -9,7 +9,7 @@ import {
     QueriesListFilterPresets,
     QueriesListMode,
 } from '../../../types/query-tracker/queryList';
-import {getSettingsData} from '../settings/settings-base';
+import {selectSettingsData} from '../settings/settings-base';
 import {selectIsVcsVisible} from './vcs';
 import groupBy_ from 'lodash/groupBy';
 import moment from 'moment';
@@ -108,7 +108,7 @@ export const selectQueryListColumns = createSelector(
 );
 
 export const selectHasCustomHistoryFilters = createSelector(
-    [selectQueriesFilters, getSettingsData],
+    [selectQueriesFilters, selectSettingsData],
     (filter) => {
         const {from, to, state, user} = filter;
         const defaultFilter = DefaultQueriesListFilter[QueriesListMode.History];
@@ -175,5 +175,5 @@ export function selectQueriesListFilterParams(state: RootState): QueriesListPara
 }
 
 export function selectQueryListHistoryColumns(state: RootState) {
-    return getSettingsData(state)['global::queryTracker::history::Columns'];
+    return selectSettingsData(state)['global::queryTracker::history::Columns'];
 }

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -9,8 +9,8 @@ import {
     isSingleProgress,
 } from '../../../types/query-tracker/api';
 import {
-    getSettingQueryTrackerStage,
-    getSettingQueryTrackerYQLAgentStage,
+    selectSettingQueryTrackerStage,
+    selectSettingQueryTrackerYQLAgentStage,
 } from '../settings/settings-ts';
 import {getQueryTrackerStage} from '../../../config';
 import {type QTEditorError, isQTEditorError} from '../../../types/query-tracker/editor';
@@ -128,7 +128,7 @@ export const selectSupportedEnginesOptions = createSelector(
 );
 
 export const selectQueryTrackerRequestOptions = createSelector(
-    [getSettingQueryTrackerStage, getSettingQueryTrackerYQLAgentStage],
+    [selectSettingQueryTrackerStage, selectSettingQueryTrackerYQLAgentStage],
     (stage, yqlAgentStage) => {
         const res: QTRequestOptions = {
             stage: stage || QT_STAGE,

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryAco.ts
@@ -1,7 +1,7 @@
 import intersection_ from 'lodash/intersection';
 import {type SelectOption} from '@gravity-ui/uikit';
 import {type RootState} from '../../reducers';
-import {getSettingsData} from '../settings/settings-base';
+import {selectSettingsData} from '../settings/settings-base';
 import {createSelector} from 'reselect';
 import {DEFAULT_QUERY_ACO, SHARED_QUERY_ACO, selectEffectiveApiStage} from './query';
 import {selectClusterUiConfig} from '../global';
@@ -22,7 +22,7 @@ export const selectQueryTrackerInfoClusters = (state: RootState) =>
 export const selectLastSelectedACONamespaces = (state: RootState) => {
     const stage = selectEffectiveApiStage(state);
 
-    return getSettingsData(state)[`qt-stage::${stage}::queryTracker::lastSelectedACOs`] ?? [];
+    return selectSettingsData(state)[`qt-stage::${stage}::queryTracker::lastSelectedACOs`] ?? [];
 };
 
 export const selectQueryACOOptions = (state: RootState): SelectOption[] => {
@@ -80,7 +80,7 @@ export const selectClusterDefaultQueryACO = (state: RootState) => {
 export const selectUserDefaultQueryACO = (state: RootState) => {
     const stage = selectEffectiveApiStage(state);
 
-    return getSettingsData(state)[`qt-stage::${stage}::queryTracker::defaultACO`];
+    return selectSettingsData(state)[`qt-stage::${stage}::queryTracker::defaultACO`];
 };
 
 export const selectDefaultQueryACO = (state: RootState) => {

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
@@ -2,7 +2,7 @@ import {type RootState} from '../../reducers';
 import {createSelector} from 'reselect';
 import {selectClusterList} from '../slideoutMenu';
 import {type NavigationNode} from '../../reducers/query-tracker/queryNavigationSlice';
-import {makeGetSetting} from '../settings';
+import {selectGetSetting} from '../settings';
 import {createNestedNS} from '../../../../shared/utils/settings';
 import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
 
@@ -23,7 +23,7 @@ export const selectNavigationClusterConfig = createSelector(
 );
 
 export const selectFavouritePaths = createSelector(
-    [makeGetSetting, selectNavigationCluster],
+    [selectGetSetting, selectNavigationCluster],
     (getSetting, cluster) => {
         if (!cluster) return [];
         const parentNS = createNestedNS(cluster, NAMESPACES.LOCAL);

--- a/packages/ui/src/ui/store/selectors/query-tracker/settings.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/settings.ts
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect';
-import {getSettingsData} from '../settings/settings-base';
+import {selectSettingsData} from '../settings/settings-base';
 
 export const selectSettingQueryTrackerQueriesListSidebarVisibilityMode = createSelector(
-    getSettingsData,
+    selectSettingsData,
     (settings) => Boolean(settings['global::queryTracker::queriesListSidebarVisibilityMode']),
 );

--- a/packages/ui/src/ui/store/selectors/scheduling/overview-columns.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/overview-columns.ts
@@ -2,7 +2,7 @@ import {createSelector} from 'reselect';
 import uniq_ from 'lodash/uniq';
 import compact_ from 'lodash/compact';
 
-import {getSettingsData} from '../../../store/selectors/settings/settings-base';
+import {selectSettingsData} from '../../../store/selectors/settings/settings-base';
 import {
     type SchedulingColumn,
     isSchedulingColumnName,
@@ -22,7 +22,7 @@ const DEFAULT_COLUMNS: Array<SchedulingColumn> = [
     'actions',
 ];
 
-export const getSchedulingOverivewColumns = createSelector([getSettingsData], (data) => {
+export const getSchedulingOverivewColumns = createSelector([selectSettingsData], (data) => {
     const columns = data['global::scheduling::overviewColumns'];
     if (!columns) {
         return [...DEFAULT_COLUMNS];

--- a/packages/ui/src/ui/store/selectors/settings/index.js
+++ b/packages/ui/src/ui/store/selectors/settings/index.js
@@ -7,102 +7,104 @@ import {FAVOURITES, NAMESPACES, SettingName} from '../../../../shared/constants/
 
 import {DEFAULT_PATH} from '../../../constants/navigation';
 
-function _getSetting(settings) {
+function createGetSetting(settings) {
     return (name, parentNS) => settings.data[getPath(name, parentNS)];
 }
 
-const _settings = (state) => state.settings;
+const selectSettings = (state) => state.settings;
 
-export const makeGetSetting = createSelector(_settings, _getSetting);
+export const selectGetSetting = createSelector(selectSettings, createGetSetting);
 
-const getCluster = (state) => state.global.cluster;
+const selectCluster = (state) => state.global.cluster;
 
-export const getClusterNS = createSelector(getCluster, (cluster) =>
+export const selectClusterNS = createSelector(selectCluster, (cluster) =>
     createNestedNS(cluster, NAMESPACES.LOCAL),
 );
 
-export const getSchedulingNS = createSelector(getClusterNS, (clusterNS) =>
+export const selectSchedulingNS = createSelector(selectClusterNS, (clusterNS) =>
     createNestedNS('scheduling', clusterNS),
 );
 
-export const getAccountsNS = createSelector(getClusterNS, (clusterNS) =>
+export const selectAccountsNS = createSelector(selectClusterNS, (clusterNS) =>
     createNestedNS('accounts', clusterNS),
 );
 
-export const getBundlesNS = createSelector(getClusterNS, (clusterNS) =>
+export const selectBundlesNS = createSelector(selectClusterNS, (clusterNS) =>
     createNestedNS('bundles', clusterNS),
 );
 
-export const selectChaosBundlesNS = createSelector(getClusterNS, (clusterNS) =>
+export const selectChaosBundlesNS = createSelector(selectClusterNS, (clusterNS) =>
     createNestedNS('chaosBundles', clusterNS),
 );
 
-export const getChytNS = createSelector(getClusterNS, (clusterNS) => {
+export const selectChytNS = createSelector(selectClusterNS, (clusterNS) => {
     return createNestedNS('chyt', clusterNS);
 });
 
-export const getSettingTheme = createSelector(makeGetSetting, (getSetting) =>
+export const selectSettingTheme = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.GLOBAL.THEME, NAMESPACES.GLOBAL),
 );
 
-export const getLastVisitedTabs = createSelector(
-    [makeGetSetting, getClusterNS],
+export const selectLastVisitedTabs = createSelector(
+    [selectGetSetting, selectClusterNS],
     (getSetting, clusterNS) => getSetting(SettingName.LOCAL.LAST_VISITED_TAB, clusterNS) || {},
 );
 
 // [{ path: <path>, count: <count> }]
-export const getLastVisited = createSelector(
-    [makeGetSetting, getClusterNS],
+export const selectLastVisited = createSelector(
+    [selectGetSetting, selectClusterNS],
     (getSetting, clusterNS) => getSetting(SettingName.LOCAL.LAST_VISITED, clusterNS) || [],
 );
 
-export const getPopular = createSelector(
-    getLastVisited,
+export const selectPopular = createSelector(
+    selectLastVisited,
     // negate count to sort in descending order and make most visited entries come first
     (lastVisited) => sortBy_(lastVisited, (entry) => -entry.count),
 );
 
-export const getFavourites = createSelector(
-    [makeGetSetting, getClusterNS],
+export const selectFavourites = createSelector(
+    [selectGetSetting, selectClusterNS],
     (getSetting, clusterNS) => getSetting(FAVOURITES, clusterNS) || [],
 );
 
-export const getNavigationDefaultPath = createSelector(
-    [makeGetSetting, getClusterNS],
+export const selectNavigationDefaultPath = createSelector(
+    [selectGetSetting, selectClusterNS],
     (getSetting, clusterNS) =>
         getSetting(SettingName.LOCAL.NAVIGATION_DEFAULT_PATH, clusterNS) || DEFAULT_PATH,
 );
 
-export const isPathAutoCorrectionSettingEnabled = createSelector(makeGetSetting, (getSetting) =>
-    getSetting(SettingName.NAVIGATION.ENABLE_PATH_AUTO_CORRECTION, NAMESPACES.NAVIGATION),
+export const selectIsPathAutoCorrectionSettingEnabled = createSelector(
+    selectGetSetting,
+    (getSetting) =>
+        getSetting(SettingName.NAVIGATION.ENABLE_PATH_AUTO_CORRECTION, NAMESPACES.NAVIGATION),
 );
 
-export const isRecentClustersFirst = createSelector(makeGetSetting, (getSetting) =>
+export const selectIsRecentClustersFirst = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.MENU.RECENT_CLUSTER_FIRST, NAMESPACES.MENU),
 );
 
-export const isRecentPagesFirst = createSelector(makeGetSetting, (getSetting) =>
+export const selectIsRecentPagesFirst = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.MENU.RECENT_PAGE_FIRST, NAMESPACES.MENU),
 );
 
-export const shouldUseSafeColors = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldUseSafeColors = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.A11Y.USE_SAFE_COLORS, NAMESPACES.A11Y),
 );
 
-export const getStartingPage = createSelector(makeGetSetting, (getSetting) =>
+export const selectStartingPage = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.MENU.STARTING_PAGE, NAMESPACES.MENU),
 );
 
-export const shouldUsePreserveState = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldUsePreserveState = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.MENU.PRESERVE_STATE, NAMESPACES.MENU),
 );
 
-export const getTemplates = createSelector(makeGetSetting, (getSetting) =>
+export const selectTemplates = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.COMPONENTS.TEMPLATES, NAMESPACES.COMPONENTS),
 );
 
 /** @type {(state: import('../reducers').RootState) => string[]} */
-export const getSelectedColumns = createSelector(makeGetSetting, (getSetting) => {
+export const selectSelectedColumns = createSelector(selectGetSetting, (getSetting) => {
     const selectedColumns = getSetting(
         SettingName.COMPONENTS.SELECTED_COLUMNS,
         NAMESPACES.COMPONENTS,
@@ -114,100 +116,109 @@ export const getSelectedColumns = createSelector(makeGetSetting, (getSetting) =>
     return selectedColumns;
 });
 
-export const getFormat = createSelector(makeGetSetting, (getSetting) =>
+export const selectFormat = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.YSON.FORMAT, NAMESPACES.YSON),
 );
 
-export const shouldCompact = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldCompact = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.YSON.COMPACT, NAMESPACES.YSON),
 );
 
-export const shouldShowDecoded = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldShowDecoded = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.YSON.SHOW_DECODED, NAMESPACES.YSON),
 );
 
-export const shouldEscapeWhitespace = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldEscapeWhitespace = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.YSON.ESCAPE_WHITESPACES, NAMESPACES.YSON),
 );
 
-export const useBinaryAsHex = createSelector(makeGetSetting, (getSetting) =>
+export const selectUseBinaryAsHex = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.YSON.BINARY_AS_HEX, NAMESPACES.YSON),
 );
 
-export const getShowDecoded = createSelector([makeGetSetting], (getSetting) =>
+export const selectShowDecoded = createSelector([selectGetSetting], (getSetting) =>
     getSetting(SettingName.YSON.SHOW_DECODED, NAMESPACES.YSON),
 );
 
-export const getRowsPerTablePage = createSelector(makeGetSetting, (getSetting) =>
+export const selectRowsPerTablePage = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.ROWS_PER_TABLE_PAGE, NAMESPACES.NAVIGATION),
 );
 
-export const getMaximumTableStringSize = createSelector(makeGetSetting, (getSetting) =>
+export const selectMaximumTableStringSize = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.MAXIMUM_TABLE_STRING_SIZE, NAMESPACES.NAVIGATION),
 );
 
-export const getDefaultTableColumnLimit = createSelector(makeGetSetting, (getSetting) =>
+export const selectDefaultTableColumnLimit = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.DEFAULT_TABLE_COLUMN_LIMIT, NAMESPACES.NAVIGATION),
 );
 
-export const isTableSimilarityEnabled = createSelector(makeGetSetting, (getSetting) =>
+export const selectIsTableSimilarityEnabled = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.ENABLE_TABLE_SIMILARITY, NAMESPACES.NAVIGATION),
 );
 
-export const getClusterPagePaneSizes = createSelector(makeGetSetting, (getSetting) =>
+export const selectClusterPagePaneSizes = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.CLUSTER_PAGE_PANE_SIZES, NAMESPACES.NAVIGATION),
 );
 
-export const shouldGroupNodes = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldGroupNodes = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.GROUP_NODES, NAMESPACES.NAVIGATION),
 );
 
-export const shouldUseSmartFilter = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldUseSmartFilter = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.USE_SMART_FILTER, NAMESPACES.NAVIGATION),
 );
 
-export const shouldUseSmartSort = createSelector(makeGetSetting, (getSetting) =>
+export const selectShouldUseSmartSort = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.USE_SMART_SORT, NAMESPACES.NAVIGATION),
 );
 
-export const getDefaultChytAlias = createSelector(makeGetSetting, (getSetting) =>
+export const selectDefaultChytAlias = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.NAVIGATION.DEFAULT_CHYT_ALIAS, NAMESPACES.NAVIGATION),
 );
 
-export const getMastersHostType = createSelector(makeGetSetting, (getSetting) =>
+export const selectMastersHostType = createSelector(selectGetSetting, (getSetting) =>
     getSetting(SettingName.SYSTEM.MASTERS_HOST_TYPE, NAMESPACES.SYSTEM),
 );
 
-export const getAccountsVisibilityModeOfDashboard = createSelector(makeGetSetting, (getSetting) => {
-    return getSetting(SettingName.ACCOUNTS.DASHBOARD_VISIBILITY_MODE, NAMESPACES.ACCOUNTS);
-});
+export const selectAccountsVisibilityModeOfDashboard = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        return getSetting(SettingName.ACCOUNTS.DASHBOARD_VISIBILITY_MODE, NAMESPACES.ACCOUNTS);
+    },
+);
 
-export const getAccountsVisibilityMode = createSelector(makeGetSetting, (getSetting) => {
+export const selectAccountsVisibilityMode = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.ACCOUNTS.ACCOUNTS_VISIBILITY_MODE, NAMESPACES.ACCOUNTS);
 });
 
-export const getSettingTableDisplayRawStrings = createSelector(makeGetSetting, (getSetting) => {
-    return getSetting(SettingName.NAVIGATION.TABLE_DISPLAY_RAW_STRINGS, NAMESPACES.NAVIGATION);
-});
+export const selectSettingTableDisplayRawStrings = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        return getSetting(SettingName.NAVIGATION.TABLE_DISPLAY_RAW_STRINGS, NAMESPACES.NAVIGATION);
+    },
+);
 
-export const getSettingAnnotationVisibility = createSelector(makeGetSetting, (getSetting) => {
+export const selectSettingAnnotationVisibility = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.NAVIGATION.ANNOTATION_VISIBILITY, NAMESPACES.NAVIGATION);
 });
 
-export const getSettingNavigationPanelExpanded = createSelector(makeGetSetting, (getSetting) => {
-    const res = getSetting(SettingName.GLOBAL.NAVIGATION_PANEL_EXPAND, NAMESPACES.GLOBAL);
-    if (res !== undefined) {
-        return res;
-    }
+export const selectSettingNavigationPanelExpanded = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        const res = getSetting(SettingName.GLOBAL.NAVIGATION_PANEL_EXPAND, NAMESPACES.GLOBAL);
+        if (res !== undefined) {
+            return res;
+        }
 
-    try {
-        const data = localStorage['nvAsideHeader'];
-        if (!data) {
+        try {
+            const data = localStorage['nvAsideHeader'];
+            if (!data) {
+                return false;
+            }
+            const {isCompact} = JSON.parse(data) || {};
+            return !isCompact;
+        } catch {
             return false;
         }
-        const {isCompact} = JSON.parse(data) || {};
-        return !isCompact;
-    } catch {
-        return false;
-    }
-});
+    },
+);

--- a/packages/ui/src/ui/store/selectors/settings/navigation.ts
+++ b/packages/ui/src/ui/store/selectors/settings/navigation.ts
@@ -2,10 +2,10 @@ import {createSelector} from 'reselect';
 
 import UIFactory from '../../../UIFactory';
 import {selectIsAdmin} from '../../../store/selectors/global/is-developer';
-import {getSettingsData} from './settings-base';
+import {selectSettingsData} from './settings-base';
 
 export const selectNavigationSqlService = createSelector(
-    [getSettingsData, selectIsAdmin],
+    [selectSettingsData, selectIsAdmin],
     (data, isAdmin) => {
         const value = data['global::navigation::sqlService'];
         const isQtKitEnabled = value?.length ? -1 !== value.indexOf('qtkit') : isAdmin;

--- a/packages/ui/src/ui/store/selectors/settings/navigation.ts
+++ b/packages/ui/src/ui/store/selectors/settings/navigation.ts
@@ -4,7 +4,7 @@ import UIFactory from '../../../UIFactory';
 import {selectIsAdmin} from '../../../store/selectors/global/is-developer';
 import {getSettingsData} from './settings-base';
 
-export const getNavigationSqlService = createSelector(
+export const selectNavigationSqlService = createSelector(
     [getSettingsData, selectIsAdmin],
     (data, isAdmin) => {
         const value = data['global::navigation::sqlService'];

--- a/packages/ui/src/ui/store/selectors/settings/operations.ts
+++ b/packages/ui/src/ui/store/selectors/settings/operations.ts
@@ -1,6 +1,6 @@
 import {createSelector} from 'reselect';
-import {getSettingsData} from './settings-base';
+import {selectSettingsData} from './settings-base';
 
-export const selectShowIncarnationsNext = createSelector([getSettingsData], (data) => {
+export const selectShowIncarnationsNext = createSelector([selectSettingsData], (data) => {
     return data['global::operations::showIncarnationsNext'] === true;
 });

--- a/packages/ui/src/ui/store/selectors/settings/settings-base.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-base.ts
@@ -1,5 +1,5 @@
 import {type DescribedSettings} from '../../../../shared/constants/settings-types';
 import {type RootState} from '../../../store/reducers';
 
-export const getSettingsData = (state: RootState) =>
+export const selectSettingsData = (state: RootState) =>
     state.settings.data as unknown as DescribedSettings;

--- a/packages/ui/src/ui/store/selectors/settings/settings-development.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-development.ts
@@ -5,6 +5,6 @@ export const selectShowAiChat = createSelector([selectSettingsData], (data) => {
     return data['global::development::showAiChat'];
 });
 
-export const shouldUseYqlTypes = createSelector([selectSettingsData], (data) => {
+export const selectShouldUseYqlTypes = createSelector([selectSettingsData], (data) => {
     return data['global::development::yqlTypes'];
 });

--- a/packages/ui/src/ui/store/selectors/settings/settings-development.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-development.ts
@@ -1,10 +1,10 @@
 import {createSelector} from 'reselect';
-import {getSettingsData} from './settings-base';
+import {selectSettingsData} from './settings-base';
 
-export const selectShowAiChat = createSelector([getSettingsData], (data) => {
+export const selectShowAiChat = createSelector([selectSettingsData], (data) => {
     return data['global::development::showAiChat'];
 });
 
-export const shouldUseYqlTypes = createSelector([getSettingsData], (data) => {
+export const shouldUseYqlTypes = createSelector([selectSettingsData], (data) => {
     return data['global::development::yqlTypes'];
 });

--- a/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
@@ -2,35 +2,35 @@ import {createSelector} from 'reselect';
 import {selectSettingsData} from './settings-base';
 import {selectQueryDraft} from '../query-tracker/query';
 
-export const getQuerySuggestionsEnabled = createSelector(selectSettingsData, (data) => {
+export const selectQuerySuggestionsEnabled = createSelector(selectSettingsData, (data) => {
     return data['global::queryTracker::suggestions'] || false;
 });
 
-export const getLastUserChoiceQueryEngine = createSelector([selectSettingsData], (data) => {
+export const selectLastUserChoiceQueryEngine = createSelector([selectSettingsData], (data) => {
     return data[`global::queryTracker::lastEngine`];
 });
 
-export const getLastUserChoiceQueryDiscoveryPath = createSelector(
+export const selectLastUserChoiceQueryDiscoveryPath = createSelector(
     [selectSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastDiscoveryPath`];
     },
 );
 
-export const getLastUserChoiceQueryChytClique = createSelector(
+export const selectLastUserChoiceQueryChytClique = createSelector(
     [selectSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastChytClique`];
     },
 );
 
-export const getLastUserChoiceYqlVersion = createSelector(
+export const selectLastUserChoiceYqlVersion = createSelector(
     [selectSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastYqlVersion`];
     },
 );
 
-export const getQueryTokens = createSelector([selectSettingsData], (data) => {
+export const selectQueryTokens = createSelector([selectSettingsData], (data) => {
     return data['global::queryTracker::tokens'] || [];
 });

--- a/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
@@ -1,36 +1,36 @@
 import {createSelector} from 'reselect';
-import {getSettingsData} from './settings-base';
+import {selectSettingsData} from './settings-base';
 import {selectQueryDraft} from '../query-tracker/query';
 
-export const getQuerySuggestionsEnabled = createSelector(getSettingsData, (data) => {
+export const getQuerySuggestionsEnabled = createSelector(selectSettingsData, (data) => {
     return data['global::queryTracker::suggestions'] || false;
 });
 
-export const getLastUserChoiceQueryEngine = createSelector([getSettingsData], (data) => {
+export const getLastUserChoiceQueryEngine = createSelector([selectSettingsData], (data) => {
     return data[`global::queryTracker::lastEngine`];
 });
 
 export const getLastUserChoiceQueryDiscoveryPath = createSelector(
-    [getSettingsData, selectQueryDraft],
+    [selectSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastDiscoveryPath`];
     },
 );
 
 export const getLastUserChoiceQueryChytClique = createSelector(
-    [getSettingsData, selectQueryDraft],
+    [selectSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastChytClique`];
     },
 );
 
 export const getLastUserChoiceYqlVersion = createSelector(
-    [getSettingsData, selectQueryDraft],
+    [selectSettingsData, selectQueryDraft],
     (data, {settings}) => {
         return data[`local::${settings?.cluster}::queryTracker::lastYqlVersion`];
     },
 );
 
-export const getQueryTokens = createSelector([getSettingsData], (data) => {
+export const getQueryTokens = createSelector([selectSettingsData], (data) => {
     return data['global::queryTracker::tokens'] || [];
 });

--- a/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
@@ -11,35 +11,38 @@ import {type RootState} from '../../../store/reducers';
 import {NODE_TYPE} from '../../../../shared/constants/system';
 import {type ValueOf} from '../../../types';
 
-export const getSettingsDataRaw = (state: RootState) => state.settings.data;
+export const selectSettingsDataRaw = (state: RootState) => state.settings.data;
 
-export const getSettingsPagesOrder = createSelector(
+export const selectSettingsPagesOrder = createSelector(
     selectGetSetting,
     (getSetting): Array<string> => {
         return getSetting(SettingName.GLOBAL.PAGES_ORDER, NAMESPACES.GLOBAL) || [];
     },
 );
 
-export const getSettingsPagesPinned = createSelector(
+export const selectSettingsPagesPinned = createSelector(
     selectGetSetting,
     (getSetting): Record<string, boolean> => {
         return getSetting(SettingName.GLOBAL.PAGES_PINNED, NAMESPACES.GLOBAL) || {};
     },
 );
 
-export const getSettingsQueryTrackerNewGraphType = createSelector(selectSettingsData, (data) => {
+export const selectSettingsQueryTrackerNewGraphType = createSelector(selectSettingsData, (data) => {
     return data['global::queryTracker::useNewGraphView'] || false;
 });
 
-export const getSettingsQueryTrackerGraphAutoCenter = createSelector(selectSettingsData, (data) => {
-    return data['global::queryTracker::graphAutoCenter'] || false;
-});
+export const selectSettingsQueryTrackerGraphAutoCenter = createSelector(
+    selectSettingsData,
+    (data) => {
+        return data['global::queryTracker::graphAutoCenter'] || false;
+    },
+);
 
-export const getSettingsEditorVimMode = createSelector(selectSettingsData, (data) => {
+export const selectSettingsEditorVimMode = createSelector(selectSettingsData, (data) => {
     return data['global::editor::vimMode'] || false;
 });
 
-export const getSettingsSchedulingExpandStaticConfiguration = createSelector(
+export const selectSettingsSchedulingExpandStaticConfiguration = createSelector(
     selectGetSetting,
     (getSetting) => {
         return (
@@ -49,7 +52,7 @@ export const getSettingsSchedulingExpandStaticConfiguration = createSelector(
     },
 );
 
-export const getSettingsAccountsExpandStaticConfiguration = createSelector(
+export const selectSettingsAccountsExpandStaticConfiguration = createSelector(
     selectGetSetting,
     (getSetting) => {
         return (
@@ -59,67 +62,73 @@ export const getSettingsAccountsExpandStaticConfiguration = createSelector(
     },
 );
 
-export const getSettingsSystemMastersCollapsed = createSelector(selectGetSetting, (getSetting) => {
-    return getSetting(SettingName.SYSTEM.MASTERS_COLLAPSED, NAMESPACES.SYSTEM);
-});
+export const selectSettingsSystemMastersCollapsed = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        return getSetting(SettingName.SYSTEM.MASTERS_COLLAPSED, NAMESPACES.SYSTEM);
+    },
+);
 
-export const getSettingsSystemSchedulersCollapsed = createSelector(
+export const selectSettingsSystemSchedulersCollapsed = createSelector(
     selectGetSetting,
     (getSetting) => {
         return getSetting(SettingName.SYSTEM.SCHEDULERS_COLLAPSED, NAMESPACES.SYSTEM);
     },
 );
 
-export const getSettingsSystemChunksCollapsed = createSelector(selectGetSetting, (getSetting) => {
-    return getSetting(SettingName.SYSTEM.CHUNKS_COLLAPSED, NAMESPACES.SYSTEM);
-});
+export const selectSettingsSystemChunksCollapsed = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        return getSetting(SettingName.SYSTEM.CHUNKS_COLLAPSED, NAMESPACES.SYSTEM);
+    },
+);
 
-export const getSettingsSystemRpcProxiesCollapsed = createSelector(
+export const selectSettingsSystemRpcProxiesCollapsed = createSelector(
     selectGetSetting,
     (getSetting) => {
         return getSetting(SettingName.SYSTEM.RPC_PROXIES_COLLAPSED, NAMESPACES.SYSTEM);
     },
 );
 
-export const getSettingsSystemCypressProxiesCollapsed = createSelector(
+export const selectSettingsSystemCypressProxiesCollapsed = createSelector(
     selectSettingsData,
     (data) => {
         return data['global::system::cypressProxiesCollapsed'] ?? true;
     },
 );
-export const getSettingsSystemHttpProxiesCollapsed = createSelector(
+export const selectSettingsSystemHttpProxiesCollapsed = createSelector(
     selectGetSetting,
     (getSetting) => {
         return getSetting(SettingName.SYSTEM.HTTP_PROXIES_COLLAPSED, NAMESPACES.SYSTEM);
     },
 );
 
-export const getSettingsSystemNodesCollapsed = createSelector(selectGetSetting, (getSetting) => {
+export const selectSettingsSystemNodesCollapsed = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.SYSTEM.NODES_COLLAPSED, NAMESPACES.SYSTEM);
 });
 
-export const getSettingsAccountUsageViewType = createSelector(
+export const selectSettingsAccountUsageViewType = createSelector(
     selectGetSetting,
     (getSetting): AccountUsageViewType => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_VIEW_TYPE, NAMESPACES.ACCOUNTS);
     },
 );
 
-export const getSettingsAccountUsageColumnsTree = createSelector(
+export const selectSettingsAccountUsageColumnsTree = createSelector(
     selectGetSetting,
     (getSetting): Array<keyof AccountUsageDataItem> => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_TREE, NAMESPACES.ACCOUNTS);
     },
 );
 
-export const getSettingsAccountUsageColumnsList = createSelector(
+export const selectSettingsAccountUsageColumnsList = createSelector(
     selectGetSetting,
     (getSetting): Array<keyof AccountUsageDataItem> => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_LIST, NAMESPACES.ACCOUNTS);
     },
 );
 
-export const getSettingsAccountUsageColumnsListFolders = createSelector(
+export const selectSettingsAccountUsageColumnsListFolders = createSelector(
     selectGetSetting,
     (getSetting): Array<keyof AccountUsageDataItem> => {
         return getSetting(
@@ -129,7 +138,7 @@ export const getSettingsAccountUsageColumnsListFolders = createSelector(
     },
 );
 
-export const getSettingOperationStatisticsActiveJobTypes = createSelector(
+export const selectSettingOperationStatisticsActiveJobTypes = createSelector(
     selectGetSetting,
     (getSetting): ActiveJobTypesMap => {
         return (
@@ -139,32 +148,32 @@ export const getSettingOperationStatisticsActiveJobTypes = createSelector(
     },
 );
 
-export const getSettingsEnableSideBar = createSelector(selectGetSetting, (getSetting) => {
+export const selectSettingsEnableSideBar = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.COMPONENTS.ENABLE_SIDE_BAR, NAMESPACES.COMPONENTS) ?? true;
 });
 
 // YTFRONT-3327-column-button
-export const getSettingsNavigationQueuePartitionsVisibility = createSelector(
+export const selectSettingsNavigationQueuePartitionsVisibility = createSelector(
     selectGetSetting,
     (getSetting): Array<string> =>
         getSetting(SettingName.NAVIGATION.QUEUE_PARTITIONS_VISIBILITY, NAMESPACES.NAVIGATION),
 );
 
 // YTFRONT-3327-column-button
-export const getSettingsNavigationQueueConsumersVisibility = createSelector(
+export const selectSettingsNavigationQueueConsumersVisibility = createSelector(
     selectGetSetting,
     (getSetting): Array<string> =>
         getSetting(SettingName.NAVIGATION.QUEUE_CONSUMERS_VISIBILITY, NAMESPACES.NAVIGATION),
 );
 
 // YTFRONT-3327-column-button
-export const getSettingsNavigationConsumerPartitionsVisibility = createSelector(
+export const selectSettingsNavigationConsumerPartitionsVisibility = createSelector(
     selectGetSetting,
     (getSetting): Array<string> =>
         getSetting(SettingName.NAVIGATION.CONSUMER_PARTITIONS_VISIBILITY, NAMESPACES.NAVIGATION),
 );
 
-export const getSettingSystemNodesNodeType = createSelector(
+export const selectSettingSystemNodesNodeType = createSelector(
     selectGetSetting,
     (getSetting): Array<ValueOf<typeof NODE_TYPE>> => {
         const propValue = getSetting(SettingName.SYSTEM.NODES_NODE_TYPE, NAMESPACES.SYSTEM) ?? '';
@@ -187,7 +196,7 @@ export const getSettingSystemNodesNodeType = createSelector(
     },
 );
 
-export const getSettingQueryTrackerStage = createSelector(
+export const selectSettingQueryTrackerStage = createSelector(
     selectGetSetting,
     (getSetting): string | undefined => {
         const res = getSetting(SettingName.QUERY_TRACKER.STAGE, NAMESPACES.QUERY_TRACKER);
@@ -195,7 +204,7 @@ export const getSettingQueryTrackerStage = createSelector(
     },
 );
 
-export const getSettingQueryTrackerYQLAgentStage = createSelector(
+export const selectSettingQueryTrackerYQLAgentStage = createSelector(
     selectGetSetting,
     (getSetting): string | undefined => {
         const res = getSetting(SettingName.QUERY_TRACKER.YQL_AGENT_STAGE, NAMESPACES.QUERY_TRACKER);
@@ -203,11 +212,11 @@ export const getSettingQueryTrackerYQLAgentStage = createSelector(
     },
 );
 
-export const getCurrentClusterNS = createSelector(
+export const selectCurrentClusterNS = createSelector(
     [selectCluster, selectClusterNS],
     (cluster, ns) => {
         return cluster ? ns : undefined;
     },
 );
-export const getUseAutoRefresh = (state: RootState) =>
+export const selectUseAutoRefresh = (state: RootState) =>
     selectSettingsData(state)['global::autoRefresh'];

--- a/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
@@ -2,7 +2,7 @@ import {createSelector} from 'reselect';
 
 import {selectCluster} from '../../../store/selectors/global';
 import {getSettingsData} from './settings-base';
-import {getClusterNS, makeGetSetting} from '../../../store/selectors/settings';
+import {selectClusterNS, selectGetSetting} from '../../../store/selectors/settings';
 import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
 import {type AccountUsageViewType} from '../../../store/reducers/accounts/usage/accounts-usage-filters';
 import {type AccountUsageDataItem} from '../../../store/reducers/accounts/usage/account-usage-types';
@@ -13,12 +13,15 @@ import {type ValueOf} from '../../../types';
 
 export const getSettingsDataRaw = (state: RootState) => state.settings.data;
 
-export const getSettingsPagesOrder = createSelector(makeGetSetting, (getSetting): Array<string> => {
-    return getSetting(SettingName.GLOBAL.PAGES_ORDER, NAMESPACES.GLOBAL) || [];
-});
+export const getSettingsPagesOrder = createSelector(
+    selectGetSetting,
+    (getSetting): Array<string> => {
+        return getSetting(SettingName.GLOBAL.PAGES_ORDER, NAMESPACES.GLOBAL) || [];
+    },
+);
 
 export const getSettingsPagesPinned = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Record<string, boolean> => {
         return getSetting(SettingName.GLOBAL.PAGES_PINNED, NAMESPACES.GLOBAL) || {};
     },
@@ -37,7 +40,7 @@ export const getSettingsEditorVimMode = createSelector(getSettingsData, (data) =
 });
 
 export const getSettingsSchedulingExpandStaticConfiguration = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting) => {
         return (
             getSetting(SettingName.SCHEDULING.EXPAND_STATIC_CONFIGURATION, NAMESPACES.SCHEDULING) ||
@@ -47,7 +50,7 @@ export const getSettingsSchedulingExpandStaticConfiguration = createSelector(
 );
 
 export const getSettingsAccountsExpandStaticConfiguration = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting) => {
         return (
             getSetting(SettingName.ACCOUNTS.EXPAND_STATIC_CONFIGURATION, NAMESPACES.ACCOUNTS) ||
@@ -56,59 +59,65 @@ export const getSettingsAccountsExpandStaticConfiguration = createSelector(
     },
 );
 
-export const getSettingsSystemMastersCollapsed = createSelector(makeGetSetting, (getSetting) => {
+export const getSettingsSystemMastersCollapsed = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.SYSTEM.MASTERS_COLLAPSED, NAMESPACES.SYSTEM);
 });
 
-export const getSettingsSystemSchedulersCollapsed = createSelector(makeGetSetting, (getSetting) => {
-    return getSetting(SettingName.SYSTEM.SCHEDULERS_COLLAPSED, NAMESPACES.SYSTEM);
-});
+export const getSettingsSystemSchedulersCollapsed = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        return getSetting(SettingName.SYSTEM.SCHEDULERS_COLLAPSED, NAMESPACES.SYSTEM);
+    },
+);
 
-export const getSettingsSystemChunksCollapsed = createSelector(makeGetSetting, (getSetting) => {
+export const getSettingsSystemChunksCollapsed = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.SYSTEM.CHUNKS_COLLAPSED, NAMESPACES.SYSTEM);
 });
 
-export const getSettingsSystemRpcProxiesCollapsed = createSelector(makeGetSetting, (getSetting) => {
-    return getSetting(SettingName.SYSTEM.RPC_PROXIES_COLLAPSED, NAMESPACES.SYSTEM);
-});
+export const getSettingsSystemRpcProxiesCollapsed = createSelector(
+    selectGetSetting,
+    (getSetting) => {
+        return getSetting(SettingName.SYSTEM.RPC_PROXIES_COLLAPSED, NAMESPACES.SYSTEM);
+    },
+);
 
 export const getSettingsSystemCypressProxiesCollapsed = createSelector(getSettingsData, (data) => {
     return data['global::system::cypressProxiesCollapsed'] ?? true;
 });
 export const getSettingsSystemHttpProxiesCollapsed = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting) => {
         return getSetting(SettingName.SYSTEM.HTTP_PROXIES_COLLAPSED, NAMESPACES.SYSTEM);
     },
 );
 
-export const getSettingsSystemNodesCollapsed = createSelector(makeGetSetting, (getSetting) => {
+export const getSettingsSystemNodesCollapsed = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.SYSTEM.NODES_COLLAPSED, NAMESPACES.SYSTEM);
 });
 
 export const getSettingsAccountUsageViewType = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): AccountUsageViewType => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_VIEW_TYPE, NAMESPACES.ACCOUNTS);
     },
 );
 
 export const getSettingsAccountUsageColumnsTree = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Array<keyof AccountUsageDataItem> => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_TREE, NAMESPACES.ACCOUNTS);
     },
 );
 
 export const getSettingsAccountUsageColumnsList = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Array<keyof AccountUsageDataItem> => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_LIST, NAMESPACES.ACCOUNTS);
     },
 );
 
 export const getSettingsAccountUsageColumnsListFolders = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Array<keyof AccountUsageDataItem> => {
         return getSetting(
             SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_LIST_FOLDERS,
@@ -118,7 +127,7 @@ export const getSettingsAccountUsageColumnsListFolders = createSelector(
 );
 
 export const getSettingOperationStatisticsActiveJobTypes = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): ActiveJobTypesMap => {
         return (
             getSetting(SettingName.OPERATIONS.STATISTICS_ACTIVE_JOB_TYPES, NAMESPACES.OPERATION) ??
@@ -127,33 +136,33 @@ export const getSettingOperationStatisticsActiveJobTypes = createSelector(
     },
 );
 
-export const getSettingsEnableSideBar = createSelector(makeGetSetting, (getSetting) => {
+export const getSettingsEnableSideBar = createSelector(selectGetSetting, (getSetting) => {
     return getSetting(SettingName.COMPONENTS.ENABLE_SIDE_BAR, NAMESPACES.COMPONENTS) ?? true;
 });
 
 // YTFRONT-3327-column-button
 export const getSettingsNavigationQueuePartitionsVisibility = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Array<string> =>
         getSetting(SettingName.NAVIGATION.QUEUE_PARTITIONS_VISIBILITY, NAMESPACES.NAVIGATION),
 );
 
 // YTFRONT-3327-column-button
 export const getSettingsNavigationQueueConsumersVisibility = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Array<string> =>
         getSetting(SettingName.NAVIGATION.QUEUE_CONSUMERS_VISIBILITY, NAMESPACES.NAVIGATION),
 );
 
 // YTFRONT-3327-column-button
 export const getSettingsNavigationConsumerPartitionsVisibility = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Array<string> =>
         getSetting(SettingName.NAVIGATION.CONSUMER_PARTITIONS_VISIBILITY, NAMESPACES.NAVIGATION),
 );
 
 export const getSettingSystemNodesNodeType = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): Array<ValueOf<typeof NODE_TYPE>> => {
         const propValue = getSetting(SettingName.SYSTEM.NODES_NODE_TYPE, NAMESPACES.SYSTEM) ?? '';
         const items = typeof propValue === 'string' ? propValue.split(',') : [];
@@ -176,7 +185,7 @@ export const getSettingSystemNodesNodeType = createSelector(
 );
 
 export const getSettingQueryTrackerStage = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): string | undefined => {
         const res = getSetting(SettingName.QUERY_TRACKER.STAGE, NAMESPACES.QUERY_TRACKER);
         return res !== '' ? res : undefined;
@@ -184,15 +193,18 @@ export const getSettingQueryTrackerStage = createSelector(
 );
 
 export const getSettingQueryTrackerYQLAgentStage = createSelector(
-    makeGetSetting,
+    selectGetSetting,
     (getSetting): string | undefined => {
         const res = getSetting(SettingName.QUERY_TRACKER.YQL_AGENT_STAGE, NAMESPACES.QUERY_TRACKER);
         return res !== '' ? res : undefined;
     },
 );
 
-export const getCurrentClusterNS = createSelector([selectCluster, getClusterNS], (cluster, ns) => {
-    return cluster ? ns : undefined;
-});
+export const getCurrentClusterNS = createSelector(
+    [selectCluster, selectClusterNS],
+    (cluster, ns) => {
+        return cluster ? ns : undefined;
+    },
+);
 export const getUseAutoRefresh = (state: RootState) =>
     getSettingsData(state)['global::autoRefresh'];

--- a/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect';
 
 import {selectCluster} from '../../../store/selectors/global';
-import {getSettingsData} from './settings-base';
+import {selectSettingsData} from './settings-base';
 import {selectClusterNS, selectGetSetting} from '../../../store/selectors/settings';
 import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
 import {type AccountUsageViewType} from '../../../store/reducers/accounts/usage/accounts-usage-filters';
@@ -27,15 +27,15 @@ export const getSettingsPagesPinned = createSelector(
     },
 );
 
-export const getSettingsQueryTrackerNewGraphType = createSelector(getSettingsData, (data) => {
+export const getSettingsQueryTrackerNewGraphType = createSelector(selectSettingsData, (data) => {
     return data['global::queryTracker::useNewGraphView'] || false;
 });
 
-export const getSettingsQueryTrackerGraphAutoCenter = createSelector(getSettingsData, (data) => {
+export const getSettingsQueryTrackerGraphAutoCenter = createSelector(selectSettingsData, (data) => {
     return data['global::queryTracker::graphAutoCenter'] || false;
 });
 
-export const getSettingsEditorVimMode = createSelector(getSettingsData, (data) => {
+export const getSettingsEditorVimMode = createSelector(selectSettingsData, (data) => {
     return data['global::editor::vimMode'] || false;
 });
 
@@ -81,9 +81,12 @@ export const getSettingsSystemRpcProxiesCollapsed = createSelector(
     },
 );
 
-export const getSettingsSystemCypressProxiesCollapsed = createSelector(getSettingsData, (data) => {
-    return data['global::system::cypressProxiesCollapsed'] ?? true;
-});
+export const getSettingsSystemCypressProxiesCollapsed = createSelector(
+    selectSettingsData,
+    (data) => {
+        return data['global::system::cypressProxiesCollapsed'] ?? true;
+    },
+);
 export const getSettingsSystemHttpProxiesCollapsed = createSelector(
     selectGetSetting,
     (getSetting) => {
@@ -207,4 +210,4 @@ export const getCurrentClusterNS = createSelector(
     },
 );
 export const getUseAutoRefresh = (state: RootState) =>
-    getSettingsData(state)['global::autoRefresh'];
+    selectSettingsData(state)['global::autoRefresh'];

--- a/packages/ui/src/ui/store/selectors/settings/settings-vcs.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-vcs.ts
@@ -1,18 +1,18 @@
 import {createSelector} from 'reselect';
-import {getSettingsData} from './settings-base';
+import {selectSettingsData} from './settings-base';
 
-export const getVcsType = createSelector(getSettingsData, (data) => {
+export const getVcsType = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:type'] || '';
 });
 
-export const getVcsRepository = createSelector(getSettingsData, (data) => {
+export const getVcsRepository = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:repository'] || '';
 });
 
-export const getVcsBranch = createSelector(getSettingsData, (data) => {
+export const getVcsBranch = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:branch'] || '';
 });
 
-export const getVcsPath = createSelector(getSettingsData, (data) => {
+export const getVcsPath = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:path'] || '';
 });

--- a/packages/ui/src/ui/store/selectors/settings/settings-vcs.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-vcs.ts
@@ -1,18 +1,18 @@
 import {createSelector} from 'reselect';
 import {selectSettingsData} from './settings-base';
 
-export const getVcsType = createSelector(selectSettingsData, (data) => {
+export const selectVcsType = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:type'] || '';
 });
 
-export const getVcsRepository = createSelector(selectSettingsData, (data) => {
+export const selectVcsRepository = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:repository'] || '';
 });
 
-export const getVcsBranch = createSelector(selectSettingsData, (data) => {
+export const selectVcsBranch = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:branch'] || '';
 });
 
-export const getVcsPath = createSelector(selectSettingsData, (data) => {
+export const selectVcsPath = createSelector(selectSettingsData, (data) => {
     return data['global::vcs:path'] || '';
 });

--- a/packages/ui/src/ui/store/selectors/slideoutMenu.ts
+++ b/packages/ui/src/ui/store/selectors/slideoutMenu.ts
@@ -12,8 +12,8 @@ import {type RootState} from '../reducers';
 import {PAGE_ICONS_BY_ID} from '../../constants/slideoutMenu';
 
 import {
-    getSettingsPagesOrder,
-    getSettingsPagesPinned,
+    selectSettingsPagesOrder,
+    selectSettingsPagesPinned,
 } from '../../store/selectors/settings/settings-ts';
 import {selectClusterUiConfig} from '../../store/selectors/global';
 import {selectIsAdmin} from '../../store/selectors/global/is-developer';
@@ -131,7 +131,7 @@ export const getPagesOrderedByName = createSelector([getRecentPagesInfo], ({all}
 });
 
 export const getPagesOrderedByUser = createSelector(
-    [getPagesOrderedByName, getSettingsPagesOrder, getSettingsPagesPinned],
+    [getPagesOrderedByName, selectSettingsPagesOrder, selectSettingsPagesPinned],
     (pages, order, pinned) => {
         const pagesById = reduce_(
             pages,

--- a/packages/ui/src/ui/store/selectors/system/nodes.ts
+++ b/packages/ui/src/ui/store/selectors/system/nodes.ts
@@ -1,10 +1,10 @@
 import {createSelector} from 'reselect';
 
-import {getSettingSystemNodesNodeType} from '../../../store/selectors/settings/settings-ts';
+import {selectSettingSystemNodesNodeType} from '../../../store/selectors/settings/settings-ts';
 import {NODE_TYPE} from '../../../../shared/constants/system';
 
 export const selectSystemNodesNodeTypesToLoad = createSelector(
-    [getSettingSystemNodesNodeType],
+    [selectSettingSystemNodesNodeType],
     (nodeTypes) => {
         const valueSet = new Set(nodeTypes);
         if (valueSet.has(NODE_TYPE.ALL_NODES)) {

--- a/packages/ui/src/ui/store/selectors/system/schedulers.js
+++ b/packages/ui/src/ui/store/selectors/system/schedulers.js
@@ -5,7 +5,7 @@ import {createSelector} from 'reselect';
 
 import ypath from '@ytsaurus/interface-helpers/lib/ypath';
 import {VisibleHostType} from '../../../constants/system/masters';
-import {getMastersHostType} from '../../../store/selectors/settings';
+import {selectMastersHostType} from '../../../store/selectors/settings';
 
 export const selectSystemSchedulers = (state) => state.system.schedulersAndAgents.schedulers;
 export const selectSystemSchedulerAlerts = (state) =>
@@ -14,7 +14,7 @@ export const selectSystemAgents = (state) => state.system.schedulersAndAgents.ag
 export const selectSystemAgentAlerts = (state) => state.system.schedulersAndAgents.agentAlerts;
 
 export const selectSystemSchedulersWithState = createSelector(
-    [selectSystemSchedulers, getMastersHostType],
+    [selectSystemSchedulers, selectMastersHostType],
     (schedulers, hostType) => {
         const path = hostType === VisibleHostType.host ? '' : '/@annotations/physical_host';
         return map_(schedulers, (sheduler) => {
@@ -32,7 +32,7 @@ export const selectSystemSchedulersWithState = createSelector(
 );
 
 export const selectSystemAgentsWithState = createSelector(
-    [selectSystemAgents, getMastersHostType],
+    [selectSystemAgents, selectMastersHostType],
     (agents, hostType) => {
         const path = hostType === VisibleHostType.host ? '' : '/@annotations/physical_host';
         return map_(agents, (agent) => {

--- a/packages/ui/src/ui/store/selectors/thor/unipika.ts
+++ b/packages/ui/src/ui/store/selectors/thor/unipika.ts
@@ -2,11 +2,11 @@ import {createSelector} from 'reselect';
 import clone_ from 'lodash/clone';
 
 import {
-    getFormat,
-    getShowDecoded,
-    shouldCompact,
-    shouldEscapeWhitespace,
-    useBinaryAsHex,
+    selectFormat,
+    selectShouldCompact,
+    selectShouldEscapeWhitespace,
+    selectShowDecoded,
+    selectUseBinaryAsHex,
 } from '../../../store/selectors/settings';
 import {getUnipikaSettingsFromConfig} from '../../../common/thor/unipika-settings';
 
@@ -25,7 +25,13 @@ export interface YsonSettings {
  * So, to minimize side-effects each UI-component should use his-own copy of settings-object.
  */
 const getYsonSettings = createSelector(
-    [getFormat, getShowDecoded, shouldCompact, shouldEscapeWhitespace, useBinaryAsHex],
+    [
+        selectFormat,
+        selectShowDecoded,
+        selectShouldCompact,
+        selectShouldEscapeWhitespace,
+        selectUseBinaryAsHex,
+    ],
     (
         format: string,
         showDecoded: boolean,


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/NJ4C-Oxq7eCXxr
<!-- nda-end -->  ## Summary by Sourcery

Rename and standardize settings-related selectors and their usages across the UI codebase to follow a consistent `select*` naming convention.

Enhancements:
- Align settings, navigation, query tracker, and system selectors to a unified `select*` naming scheme and update all references.
- Replace legacy `get*`/`makeGetSetting` selector names with clearer `select*` counterparts for improved readability and maintainability.