### PR TITLE
chore: react-unipika fixes [YTFRONT-2241]

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -46,7 +46,7 @@
         "@gravity-ui/navigation": "^3.7.0",
         "@gravity-ui/prettier-config": "^1.1.0",
         "@gravity-ui/react-data-table": "^2.1.1",
-        "@gravity-ui/react-unipika": "^0.7.0",
+        "@gravity-ui/react-unipika": "^0.7.1",
         "@gravity-ui/stylelint-config": "^4.0.1",
         "@gravity-ui/table": "^1.10.1",
         "@gravity-ui/timeline": "^1.25.1",
@@ -5610,9 +5610,9 @@
       }
     },
     "node_modules/@gravity-ui/react-unipika": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@gravity-ui/react-unipika/-/react-unipika-0.7.0.tgz",
-      "integrity": "sha512-qXJYhoEGUyZSh8osKiTXQ7OTFqpGO3pVwsC/FcQoIMJFm0HfjweF8Jwwn6wK5pnDFjK+ZH/jg/tbTX1HG6lmBQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/react-unipika/-/react-unipika-0.7.1.tgz",
+      "integrity": "sha512-TSBPRMCExbj/k+mMcT/PkNAjUVsNNc163kf55BMumaF2u1RasStLD1n7/KBASTNdPK2MqwM4hRrUbuQlRdQ4qA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -113,7 +113,7 @@
     "@gravity-ui/navigation": "^3.7.0",
     "@gravity-ui/prettier-config": "^1.1.0",
     "@gravity-ui/react-data-table": "^2.1.1",
-    "@gravity-ui/react-unipika": "^0.7.0",
+    "@gravity-ui/react-unipika": "^0.7.1",
     "@gravity-ui/stylelint-config": "^4.0.1",
     "@gravity-ui/table": "^1.10.1",
     "@gravity-ui/timeline": "^1.25.1",

--- a/packages/ui/src/ui/pages/navigation/tabs/Attributes/LoadButton.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Attributes/LoadButton.tsx
@@ -1,6 +1,8 @@
 import React, {useCallback} from 'react';
-import {Button, Icon} from '@gravity-ui/uikit';
+import {ActionTooltip, Button, Icon} from '@gravity-ui/uikit';
 import {ArrowDownToLine} from '@gravity-ui/icons';
+
+import i18n from './i18n';
 
 type Props = {
     ypath: string;
@@ -17,14 +19,16 @@ export const LoadButton = (props: Props) => {
     }, [onRequestLoadPath, ypath]);
 
     return (
-        <Button
-            className={className}
-            onClick={handleRequestLoad}
-            size="xs"
-            loading={loading}
-            qa="load-button"
-        >
-            <Icon data={ArrowDownToLine} size={12} />
-        </Button>
+        <ActionTooltip title={i18n('action_load-opaque-attribute')}>
+            <Button
+                className={className}
+                onClick={handleRequestLoad}
+                size="xs"
+                loading={loading}
+                qa="load-button"
+            >
+                <Icon data={ArrowDownToLine} size={12} />
+            </Button>
+        </ActionTooltip>
     );
 };

--- a/packages/ui/src/ui/pages/navigation/tabs/Attributes/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/navigation/tabs/Attributes/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/navigation/tabs/Attributes/i18n/en.json
+++ b/packages/ui/src/ui/pages/navigation/tabs/Attributes/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "action_load-opaque-attribute": "Load opaque attribute"
+}

--- a/packages/ui/src/ui/pages/navigation/tabs/Attributes/i18n/index.ts
+++ b/packages/ui/src/ui/pages/navigation/tabs/Attributes/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:attributes', dicts);

--- a/packages/ui/src/ui/store/actions/navigation/tabs/attributes/i18n/index.ts
+++ b/packages/ui/src/ui/store/actions/navigation/tabs/attributes/i18n/index.ts
@@ -2,4 +2,4 @@ import {addI18Keysets} from '../../../../../../i18n';
 
 import dicts from './dicts';
 
-export default addI18Keysets('yt:attributes', dicts);
+export default addI18Keysets('yt:attributes-actions', dicts);


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/oph0Zc8U7enmjD
<!-- nda-end -->    ## Summary by Sourcery

Update attribute navigation UI to support a tooltip for the load button and align i18n keysets with new attribute actions while bumping the react-unipika dependency.

New Features:
- Add a tooltip with localized text to the attributes load button in the navigation UI.

Enhancements:
- Introduce a dedicated i18n namespace for attributes actions and move attributes tab i18n into a local module.
- Upgrade @gravity-ui/react-unipika dependency to version ^0.7.1.

Build:
- Update package-lock.json for the @gravity-ui/react-unipika version bump.