### PR TITLE
refactor(Operations/Incarnations): delete old incarnations [YTFRONT-5…

### DIFF
--- a/packages/ui/src/shared/constants/settings-types.ts
+++ b/packages/ui/src/shared/constants/settings-types.ts
@@ -107,7 +107,6 @@ interface A11YSettings {
 type OperationsSettings = OperationPresetsSettings & {
     'global::operations::statisticsAggregationType': 'avg' | 'min' | 'max' | 'sum' | 'count';
     'global::operations::statisticsActiveJobTypes': Record<string, string>;
-    'global::operations::showIncarnationsNext': boolean;
 };
 
 export type OperationPresetsSettings = {

--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -530,11 +530,7 @@ export interface UIFactory {
 
     getAnalyticsService(): AnalyticsService[];
 
-    renderIncarnationsTab(params: {
-        cluster: string;
-        operationId: string;
-        showIncarnationsNext: boolean;
-    }): React.ReactNode;
+    renderIncarnationsTab(params: {cluster: string; operationId: string}): React.ReactNode;
 
     getAiChatMessageComponent(
         message: ChatMessage,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -71,7 +71,6 @@ import {
     selectTotalCpuTimeSpent,
     selectTotalJobWallTime,
 } from '../../../store/selectors/operations/statistics-v2';
-import {selectShowIncarnationsNext} from '../../../store/selectors/settings/operations';
 import {getCurrentCluster} from '../../../store/selectors/thor';
 import {getYsonSettingsDisableDecode} from '../../../store/selectors/thor/unipika';
 import {type OperationPool, type OperationStates} from '../selectors';
@@ -428,7 +427,6 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
             jobsMonitorIsSupported,
             monitoringComponent,
             timelineTabVisible,
-            showIncarnationsNext,
         } = this.props;
         const {url, params} = match;
         const {operationId} = params;
@@ -484,7 +482,6 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
                             UIFactory.renderIncarnationsTab({
                                 cluster,
                                 operationId,
-                                showIncarnationsNext,
                             })
                         }
                     />
@@ -602,7 +599,6 @@ const mapStateToProps = (state: RootState, routerProps: RouteProps) => {
         operationPerformanceUrlTemplate: selectOperationPerformanceUrlTemplate(state),
         operationEvents,
         ysonSettings: getYsonSettingsDisableDecode(state),
-        showIncarnationsNext: selectShowIncarnationsNext(state),
     };
 };
 

--- a/packages/ui/src/ui/store/selectors/settings/operations.ts
+++ b/packages/ui/src/ui/store/selectors/settings/operations.ts
@@ -1,6 +1,0 @@
-import {createSelector} from 'reselect';
-import {selectSettingsData} from './settings-base';
-
-export const selectShowIncarnationsNext = createSelector([selectSettingsData], (data) => {
-    return data['global::operations::showIncarnationsNext'] === true;
-});


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/iojGrghS7fRqR4
<!-- nda-end -->  …857]

## Summary by Sourcery

Simplify the incarnations tab rendering by removing the legacy `showIncarnationsNext` feature flag and its dependencies.

Enhancements:
- Streamline the UIFactory incarnations tab API to only require cluster and operation ID parameters.

Chores:
- Remove the obsolete `global::operations::showIncarnationsNext` setting and associated selectors for operations.