### PR TITLE
chore: fix makeRoutedURL workaround [YTFRONT-5861]

### DIFF
--- a/packages/ui/src/ui/containers/RoutedButton/RoutedButton.tsx
+++ b/packages/ui/src/ui/containers/RoutedButton/RoutedButton.tsx
@@ -1,7 +1,7 @@
 import {Button, type ButtonLinkProps} from '@gravity-ui/uikit';
 import React, {forwardRef} from 'react';
 import {Link as RouterLink} from 'react-router-dom';
-import {makeRoutedURL} from '../../store/window-store';
+import {makeRoutedURL} from '../../store/location';
 import {useRoutedClickHandler} from '../../hooks/useRoutedClickHandler';
 
 type ButtonAdapterProps = ButtonLinkProps & {

--- a/packages/ui/src/ui/containers/RoutedLink/RoutedLink.tsx
+++ b/packages/ui/src/ui/containers/RoutedLink/RoutedLink.tsx
@@ -1,7 +1,7 @@
 import {Link, type LinkProps} from '@gravity-ui/uikit';
 import React, {forwardRef} from 'react';
 import {Link as RouterLink} from 'react-router-dom';
-import {makeRoutedURL} from '../../store/window-store';
+import {makeRoutedURL} from '../../store/location';
 import {useRoutedClickHandler} from '../../hooks/useRoutedClickHandler';
 
 type LinkAdapterProps = LinkProps & {

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.tsx
@@ -87,7 +87,7 @@ import {DetailTableCell} from './DetailTableCell';
 import {Page} from '../../../../constants/index';
 import PathView from '../../../../containers/PathFragment/PathFragment';
 import {Button, Flex, Icon as GravityIcon, Tooltip} from '@gravity-ui/uikit';
-import {makeRoutedURL} from '../../../../store/window-store';
+import {makeRoutedURL} from '../../../../store/location';
 
 const TABLE_SETTINGS: Settings = {
     displayIndices: false,

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageToolbar.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageToolbar.tsx
@@ -46,7 +46,7 @@ import {useAllUserNamesFiltered} from '../../../../hooks/global';
 import {useUpdater} from '../../../../hooks/use-updater';
 
 import './AccountUsageToolbar.scss';
-import {makeRoutedURL} from '../../../../store/window-store';
+import {makeRoutedURL} from '../../../../store/location';
 import i18n from './i18n';
 
 const block = cn('account-usage-toolbar');

--- a/packages/ui/src/ui/store/location.ts
+++ b/packages/ui/src/ui/store/location.ts
@@ -125,5 +125,3 @@ export function makeRoutedURL(url: string, paramOverrides: any = {}, rootState?:
 }
 
 export type MakeRotedUrlFnType = typeof makeRoutedURL;
-
-(window as any).makeRoutedURL = makeRoutedURL;

--- a/packages/ui/src/ui/store/window-store.ts
+++ b/packages/ui/src/ui/store/window-store.ts
@@ -1,13 +1,5 @@
 import {type AppBrowserHistory, type StoreType} from './store.main';
-import {type MakeRotedUrlFnType} from './location';
 import {type Store} from 'redux';
-import {
-    type CombinedSliceReducer,
-    type Slice,
-    type SliceCaseReducers,
-    type SliceSelectors,
-} from '@reduxjs/toolkit';
-import {type RootState} from './reducers';
 
 export function setWindowStoreAndHistory(store: Store, appBrowserHistory: AppBrowserHistory) {
     Object.assign(window, {store, appBrowserHistory});
@@ -20,44 +12,6 @@ export function getWindowStore(): StoreType {
     return (window as any).store;
 }
 
-export const makeRoutedURL: MakeRotedUrlFnType = (...args) =>
-    (window as any).makeRoutedURL(...args);
-
 export function getAppBrowserHistory(): AppBrowserHistory {
     return (window as any).appBrowserHistory;
-}
-
-export function injectReducers<
-    K extends string,
-    SS,
-    SCR extends SliceCaseReducers<SS>,
-    N extends string,
-    Selectors extends SliceSelectors<SS>,
->(reducerPath: K, slice: Slice<SS, SCR, N, K, Selectors>) {
-    if ((getWindowStore().getState() as any)[reducerPath] !== undefined) {
-        throw new Error(`Unexpected behavior: state['${reducerPath}'] is already defined`);
-    }
-
-    const {rootReducer} = getWindowStore() as any;
-    const injectedSlice = slice.injectInto(rootReducer as CombinedSliceReducer<RootState>, {
-        reducerPath,
-    });
-    getWindowStore().replaceReducer(rootReducer);
-    getAppBrowserHistory().replace(
-        makeRoutedURL(window.location.pathname, {}, (getWindowStore() as any).initialState),
-    );
-    return injectedSlice;
-}
-
-export function nameAndInitialState<K extends string, SliceState>(
-    reducerPath: K,
-    initialState: SliceState,
-) {
-    return {
-        name: reducerPath,
-        initialState: {
-            ...initialState,
-            ...(getWindowStore() as any).initialState[reducerPath],
-        } as SliceState,
-    };
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/exySHnlU7fX57p
<!-- nda-end -->## Summary by Sourcery

Decouple routed URL creation from the global window store and remove obsolete window-level helpers.

Bug Fixes:
- Ensure components use the centralized location module for routed URL generation instead of a window-store workaround.

Enhancements:
- Remove global makeRoutedURL exposure on window and delete unused dynamic reducer injection helpers from the window store module.
- Update routed navigation components and account usage pages to import makeRoutedURL directly from the location store module.