### PR TITLE
fix(Accounts): edit quota limit text fix [YTFRONT-5854]

### DIFF
--- a/packages/ui/src/ui/components/QuotaEditor/QuotaEditor.tsx
+++ b/packages/ui/src/ui/components/QuotaEditor/QuotaEditor.tsx
@@ -71,7 +71,7 @@ export default class QuotaEditor extends React.Component<QuotaEditorProps> {
                 {renderSourceSuggest && (
                     <div className={block('item')}>
                         <div className={block('item-title')}>
-                            {sourceSuggestTitle || i18n('title_account-to-distribution')}
+                            {sourceSuggestTitle || i18n('title_account-for-distribution')}
                         </div>
                         {renderSourceSuggest({
                             value: sourceAccount || '',

--- a/packages/ui/src/ui/components/QuotaEditor/i18n/en.json
+++ b/packages/ui/src/ui/components/QuotaEditor/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "title_account-to-distribution": "Account to distribution",
+  "title_account-for-distribution": "Account for distribution",
   "label_free-to-distribute": "Free to distribute",
   "title_new-quota-limit": "New quota limit",
   "error_wrong-format": "wrong format!",


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/U9F9XJwJ7fj29V
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Correct the quota editor label for selecting an account used for distribution by referencing the proper i18n title key.