### PR TITLE
chore: rename account-usage selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageColumnsButton.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageColumnsButton.tsx
@@ -5,9 +5,9 @@ import map_ from 'lodash/map';
 
 import Button from '../../../../components/Button/Button';
 import {
-    getAccountUsageSelectableColumns,
-    getAccountUsageVisibleDataColumns,
     readableAccountUsageColumnName,
+    selectAccountUsageSelectableColumns,
+    selectAccountUsageVisibleDataColumns,
 } from '../../../../store/selectors/accounts/account-usage';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import ColumnSelectorModal from '../../../../components/ColumnSelectorModal/ColumnSelectorModal';
@@ -44,8 +44,8 @@ interface DialogProps {
 
 function AccountUsageColumnsDialog({visible, onClose}: DialogProps) {
     const dispatch = useDispatch();
-    const visibleColumns = useSelector(getAccountUsageVisibleDataColumns);
-    const availableColumns = useSelector(getAccountUsageSelectableColumns);
+    const visibleColumns = useSelector(selectAccountUsageVisibleDataColumns);
+    const availableColumns = useSelector(selectAccountUsageSelectableColumns);
 
     const handleChange = React.useCallback((newValue: typeof value) => {
         const checked = filter_(newValue, 'checked');

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails.tsx
@@ -17,38 +17,38 @@ import {
     syncAccountsUsageViewTypeWithSettings,
 } from '../../../../store/actions/accounts/account-usage';
 import {
-    getAccountUsageAvailableColumns,
-    getAccountUsageCurrentSnapshot,
-    getAccountUsageListDiffError,
-    getAccountUsageListDiffItems,
-    getAccountUsageListDiffLoaded,
-    getAccountUsageListDiffLoading,
-    getAccountUsageListDiffMediums,
-    getAccountUsageListError,
-    getAccountUsageListItems,
-    getAccountUsageListLoaded,
-    getAccountUsageListLoading,
-    getAccountUsageListMediums,
-    getAccountUsagePageCount,
-    getAccountUsagePageIndex,
-    getAccountUsageSortStateByColumn,
-    getAccountUsageTreeDiffError,
-    getAccountUsageTreeDiffItems,
-    getAccountUsageTreeDiffLoaded,
-    getAccountUsageTreeDiffLoading,
-    getAccountUsageTreeDiffMediums,
-    getAccountUsageTreeError,
-    getAccountUsageTreeItems,
-    getAccountUsageTreeItemsBasePath,
-    getAccountUsageTreeLoaded,
-    getAccountUsageTreeLoading,
-    getAccountUsageTreeMediums,
-    getAccountUsageViewType,
-    getAccountUsageVisibleDataColumns,
-    getAccountsUsageDiffFromSnapshot,
-    getAccountsUsageDiffToSnapshot,
-    isAccountsUsageDiffView,
     readableAccountUsageColumnName,
+    selectAccountUsageAvailableColumns,
+    selectAccountUsageCurrentSnapshot,
+    selectAccountUsageListDiffError,
+    selectAccountUsageListDiffItems,
+    selectAccountUsageListDiffLoaded,
+    selectAccountUsageListDiffLoading,
+    selectAccountUsageListDiffMediums,
+    selectAccountUsageListError,
+    selectAccountUsageListItems,
+    selectAccountUsageListLoaded,
+    selectAccountUsageListLoading,
+    selectAccountUsageListMediums,
+    selectAccountUsagePageCount,
+    selectAccountUsagePageIndex,
+    selectAccountUsageSortStateByColumn,
+    selectAccountUsageTreeDiffError,
+    selectAccountUsageTreeDiffItems,
+    selectAccountUsageTreeDiffLoaded,
+    selectAccountUsageTreeDiffLoading,
+    selectAccountUsageTreeDiffMediums,
+    selectAccountUsageTreeError,
+    selectAccountUsageTreeItems,
+    selectAccountUsageTreeItemsBasePath,
+    selectAccountUsageTreeLoaded,
+    selectAccountUsageTreeLoading,
+    selectAccountUsageTreeMediums,
+    selectAccountUsageViewType,
+    selectAccountUsageVisibleDataColumns,
+    selectAccountsUsageDiffFromSnapshot,
+    selectAccountsUsageDiffToSnapshot,
+    selectIsAccountsUsageDiffView,
 } from '../../../../store/selectors/accounts/account-usage';
 import DataTable, {type Column, type Settings} from '@gravity-ui/react-data-table';
 import ArrowUpRightFromSquareIcon from '@gravity-ui/icons/svgs/arrow-up-right-from-square.svg';
@@ -113,7 +113,7 @@ const ROW_CLASS_NAME = block('row');
 
 function AccountUsageDetailsHeader(props: {column: keyof AccountUsageDataItem}) {
     const dispatch = useDispatch();
-    const sortOrder = useSelector(getAccountUsageSortStateByColumn);
+    const sortOrder = useSelector(selectAccountUsageSortStateByColumn);
     const {column} = props;
 
     const onSort = React.useCallback(
@@ -157,11 +157,11 @@ const UsageLoaderMemo = React.memo(UsageLoader);
 function useColumnsByPreset(mediums: Array<string>) {
     const dispatch = useDispatch();
 
-    const availableColumns = useSelector(getAccountUsageAvailableColumns);
-    const visibleColumns = useSelector(getAccountUsageVisibleDataColumns);
+    const availableColumns = useSelector(selectAccountUsageAvailableColumns);
+    const visibleColumns = useSelector(selectAccountUsageVisibleDataColumns);
     const cluster = useSelector(selectCluster);
-    const viewType = useSelector(getAccountUsageViewType);
-    const treePath = useSelector(getAccountUsageTreeItemsBasePath);
+    const viewType = useSelector(selectAccountUsageViewType);
+    const treePath = useSelector(selectAccountUsageTreeItemsBasePath);
 
     const handleAttributeButtonClick = useCallback(
         (accountData: AccountRequestData) => {
@@ -380,7 +380,7 @@ const UPDATE_TIMEOUT = 600000;
 
 function AccountUsageDetailsList() {
     const dispatch = useDispatch();
-    const currentSnapshot = useSelector(getAccountUsageCurrentSnapshot);
+    const currentSnapshot = useSelector(selectAccountUsageCurrentSnapshot);
 
     const updateFn = React.useCallback(() => {
         dispatch(fetchAccountUsageList());
@@ -388,12 +388,12 @@ function AccountUsageDetailsList() {
 
     useUpdater(updateFn, {timeout: UPDATE_TIMEOUT, onlyOnce: currentSnapshot !== undefined});
 
-    const items = useSelector(getAccountUsageListItems);
-    const loading = useSelector(getAccountUsageListLoading);
-    const loaded = useSelector(getAccountUsageListLoaded);
-    const error = useSelector(getAccountUsageListError);
+    const items = useSelector(selectAccountUsageListItems);
+    const loading = useSelector(selectAccountUsageListLoading);
+    const loaded = useSelector(selectAccountUsageListLoaded);
+    const error = useSelector(selectAccountUsageListError);
 
-    const mediums = useSelector(getAccountUsageListMediums);
+    const mediums = useSelector(selectAccountUsageListMediums);
     const columns = useColumnsByPreset(mediums);
 
     if (!loading && error) {
@@ -419,12 +419,12 @@ function AccountUsageDetailsListDiff() {
         dispatch(fetchAccountUsageListDiff());
     }, [dispatch]);
 
-    const items = useSelector(getAccountUsageListDiffItems);
-    const loading = useSelector(getAccountUsageListDiffLoading);
-    const loaded = useSelector(getAccountUsageListDiffLoaded);
-    const error = useSelector(getAccountUsageListDiffError);
+    const items = useSelector(selectAccountUsageListDiffItems);
+    const loading = useSelector(selectAccountUsageListDiffLoading);
+    const loaded = useSelector(selectAccountUsageListDiffLoaded);
+    const error = useSelector(selectAccountUsageListDiffError);
 
-    const mediums = useSelector(getAccountUsageListDiffMediums);
+    const mediums = useSelector(selectAccountUsageListDiffMediums);
     const columns = useColumnsByPreset(mediums);
 
     if (!loading && error) {
@@ -446,19 +446,19 @@ function AccountUsageDetailsListDiff() {
 
 function AccountUsageDetailsTree() {
     const dispatch = useDispatch();
-    const currentSnapshot = useSelector(getAccountUsageCurrentSnapshot);
+    const currentSnapshot = useSelector(selectAccountUsageCurrentSnapshot);
     const updateFn = React.useCallback(() => {
         dispatch(fetchAccountUsageTree());
     }, [dispatch]);
 
     useUpdater(updateFn, {timeout: UPDATE_TIMEOUT, onlyOnce: currentSnapshot !== undefined});
 
-    const items = useSelector(getAccountUsageTreeItems);
-    const loading = useSelector(getAccountUsageTreeLoading);
-    const loaded = useSelector(getAccountUsageTreeLoaded);
-    const error = useSelector(getAccountUsageTreeError);
+    const items = useSelector(selectAccountUsageTreeItems);
+    const loading = useSelector(selectAccountUsageTreeLoading);
+    const loaded = useSelector(selectAccountUsageTreeLoaded);
+    const error = useSelector(selectAccountUsageTreeError);
 
-    const mediums = useSelector(getAccountUsageTreeMediums);
+    const mediums = useSelector(selectAccountUsageTreeMediums);
     const columns = useColumnsByPreset(mediums);
 
     if (!loading && error) {
@@ -484,12 +484,12 @@ function AccountUsageDetailsTreeDiff() {
         dispatch(fetchAccountUsageTreeDiff());
     }, [dispatch]);
 
-    const items = useSelector(getAccountUsageTreeDiffItems);
-    const loading = useSelector(getAccountUsageTreeDiffLoading);
-    const loaded = useSelector(getAccountUsageTreeDiffLoaded);
-    const error = useSelector(getAccountUsageTreeDiffError);
+    const items = useSelector(selectAccountUsageTreeDiffItems);
+    const loading = useSelector(selectAccountUsageTreeDiffLoading);
+    const loaded = useSelector(selectAccountUsageTreeDiffLoaded);
+    const error = useSelector(selectAccountUsageTreeDiffError);
 
-    const mediums = useSelector(getAccountUsageTreeDiffMediums);
+    const mediums = useSelector(selectAccountUsageTreeDiffMediums);
     const columns = useColumnsByPreset(mediums);
 
     if (!loading && error) {
@@ -515,9 +515,9 @@ const AccountUsageDetailsTreeMemo = React.memo(AccountUsageDetailsTree);
 const AccountUsageDetailsTreeDiffMemo = React.memo(AccountUsageDetailsTreeDiff);
 
 function AccountUsageDetailsDiff({children}: {children: React.ReactNode}) {
-    const isDiffView = useSelector(isAccountsUsageDiffView);
-    const from = useSelector(getAccountsUsageDiffFromSnapshot);
-    const to = useSelector(getAccountsUsageDiffToSnapshot);
+    const isDiffView = useSelector(selectIsAccountsUsageDiffView);
+    const from = useSelector(selectAccountsUsageDiffFromSnapshot);
+    const to = useSelector(selectAccountsUsageDiffToSnapshot);
 
     if (!isDiffView) {
         return <>{i18n('alert_unexpected-view-mode')}</>;
@@ -546,7 +546,7 @@ const AccountUsageDetailsDiffMemo = React.memo(AccountUsageDetailsDiff);
 
 function AccountUsageDetails() {
     const dispatch = useDispatch();
-    const viewType = useSelector(getAccountUsageViewType);
+    const viewType = useSelector(selectAccountUsageViewType);
 
     React.useEffect(() => {
         dispatch(syncAccountsUsageViewTypeWithSettings());
@@ -578,7 +578,7 @@ const AccountsUsageDetailsListLoaderMemo = React.memo(AccountsUsageDetailsListLo
 const AccountsUsageDetailsTreeLoaderMemo = React.memo(AccountsUsageDetailsTreeLoader);
 
 function UsageLoader() {
-    const viewType = useSelector(getAccountUsageViewType);
+    const viewType = useSelector(selectAccountUsageViewType);
 
     switch (viewType) {
         case 'list':
@@ -596,28 +596,28 @@ function UsageLoader() {
 }
 
 function AccountsUsageDetailsListLoader() {
-    const loading = useSelector(getAccountUsageListLoading);
+    const loading = useSelector(selectAccountUsageListLoading);
     return <Loader visible={loading} />;
 }
 
 function AccountsUsageDetailsTreeLoader() {
-    const loading = useSelector(getAccountUsageTreeLoading);
+    const loading = useSelector(selectAccountUsageTreeLoading);
     return <Loader visible={loading} />;
 }
 
 function AccountsUsageDetailsListDiffLoader() {
-    const loading = useSelector(getAccountUsageListDiffLoading);
+    const loading = useSelector(selectAccountUsageListDiffLoading);
     return <Loader visible={loading} />;
 }
 
 function AccountsUsageDetailsTreeDiffLoader() {
-    const loading = useSelector(getAccountUsageTreeDiffLoading);
+    const loading = useSelector(selectAccountUsageTreeDiffLoading);
     return <Loader visible={loading} />;
 }
 
 function PageCounter() {
-    const value = useSelector(getAccountUsagePageIndex);
-    const count = useSelector(getAccountUsagePageCount);
+    const value = useSelector(selectAccountUsagePageIndex);
+    const count = useSelector(selectAccountUsagePageCount);
 
     return count > 1 ? (
         <Secondary>

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageTab.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageTab.tsx
@@ -9,7 +9,7 @@ import {NoContent} from '../../../../components/NoContent';
 import {selectActiveAccount} from '../../../../store/selectors/accounts/accounts-ts';
 
 import {useSelector} from '../../../../store/redux-hooks';
-import {getAccountUsageViewType} from '../../../../store/selectors/accounts/account-usage';
+import {selectAccountUsageViewType} from '../../../../store/selectors/accounts/account-usage';
 import ErrorBoundary from '../../../../containers/ErrorBoundary/ErrorBoundary';
 import {useDisableMaxContentWidth} from '../../../../containers/MaxContentWidth';
 import i18n from './i18n';
@@ -20,7 +20,7 @@ function AccountDetailedUsageTab() {
     useDisableMaxContentWidth();
 
     const account = useSelector(selectActiveAccount);
-    const viewType = useSelector(getAccountUsageViewType);
+    const viewType = useSelector(selectAccountUsageViewType);
 
     if (!account) {
         return (

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageToolbar.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageToolbar.tsx
@@ -19,19 +19,19 @@ import {selectCluster} from '../../../../store/selectors/global';
 import {Toolbar} from '../../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import Select from '../../../../components/Select/Select';
 import {
-    getAccountUsageCurrentSnapshot,
-    getAccountUsageDateRangeFilter,
-    getAccountUsageDateRangeTypeFilter,
-    getAccountUsageOwnerFilter,
-    getAccountUsagePageCount,
-    getAccountUsagePageIndex,
-    getAccountUsagePathFilter,
-    getAccountUsageSnapshots,
-    getAccountUsageTreeItemsBasePathSplitted,
-    getAccountUsageViewType,
-    getAccountsUsageDiffFromSnapshot,
-    getAccountsUsageDiffToSnapshot,
-    isAccountsUsageDiffView,
+    selectAccountUsageCurrentSnapshot,
+    selectAccountUsageDateRangeFilter,
+    selectAccountUsageDateRangeTypeFilter,
+    selectAccountUsageOwnerFilter,
+    selectAccountUsagePageCount,
+    selectAccountUsagePageIndex,
+    selectAccountUsagePathFilter,
+    selectAccountUsageSnapshots,
+    selectAccountUsageTreeItemsBasePathSplitted,
+    selectAccountUsageViewType,
+    selectAccountsUsageDiffFromSnapshot,
+    selectAccountsUsageDiffToSnapshot,
+    selectIsAccountsUsageDiffView,
 } from '../../../../store/selectors/accounts/account-usage';
 import TextInputWithDebounce from '../../../../components/TextInputWithDebounce/TextInputWithDebounce';
 import {Secondary, SecondaryBold} from '@ytsaurus/components';
@@ -73,8 +73,8 @@ const UsageBreadcrumbsMemo = React.memo(UsageBreadcrumbs);
 const SnapshotDiffFilterMemo = React.memo(SnapshotDiffFilter);
 
 function AccountUsageToolbar() {
-    const viewType = useSelector(getAccountUsageViewType);
-    const isDiffView = useSelector(isAccountsUsageDiffView);
+    const viewType = useSelector(selectAccountUsageViewType);
+    const isDiffView = useSelector(selectIsAccountsUsageDiffView);
 
     return (
         <div>
@@ -151,7 +151,7 @@ function snapshot2string(v?: number) {
 }
 
 function useSnapshotItems() {
-    const snapshots = useSelector(getAccountUsageSnapshots);
+    const snapshots = useSelector(selectAccountUsageSnapshots);
 
     const items = React.useMemo(() => {
         const res = map_(reverse_(snapshots.slice()), (item) => {
@@ -170,7 +170,7 @@ function useSnapshotItems() {
 function FromSnapshot() {
     const dispatch = useDispatch();
     const items = useSnapshotItems();
-    const value = useSelector(getAccountsUsageDiffFromSnapshot);
+    const value = useSelector(selectAccountsUsageDiffFromSnapshot);
 
     const handleChange = React.useCallback(
         (value: string) => {
@@ -197,7 +197,7 @@ function FromSnapshot() {
 function ToSnapshot() {
     const dispatch = useDispatch();
     const items = useSnapshotItems();
-    const value = useSelector(getAccountsUsageDiffToSnapshot);
+    const value = useSelector(selectAccountsUsageDiffToSnapshot);
 
     const handleChange = React.useCallback(
         (value: string) => {
@@ -239,7 +239,7 @@ function SnapshotFilter() {
     const dispatch = useDispatch();
     useFetchSnapshots();
 
-    const currentSnapshot = useSelector(getAccountUsageCurrentSnapshot);
+    const currentSnapshot = useSelector(selectAccountUsageCurrentSnapshot);
     const items = useSnapshotItems();
 
     const handleSnapshotChange = React.useCallback(
@@ -271,7 +271,7 @@ function SnapshotFilter() {
 function PathFilter() {
     const dispatch = useDispatch();
 
-    const filter = useSelector(getAccountUsagePathFilter);
+    const filter = useSelector(selectAccountUsagePathFilter);
 
     const handleChange = React.useCallback(
         (pathFilter: string) => {
@@ -293,7 +293,7 @@ function PathFilter() {
 function OwnerFilter() {
     const dispatch = useDispatch();
 
-    const filter = useSelector(getAccountUsageOwnerFilter);
+    const filter = useSelector(selectAccountUsageOwnerFilter);
 
     const handleChange = React.useCallback(
         (item: SuggestItem) => {
@@ -325,8 +325,8 @@ function OwnerFilter() {
 function DateRangeFilter() {
     const dispatch = useDispatch();
 
-    const {from, to} = useSelector(getAccountUsageDateRangeFilter);
-    const type = useSelector(getAccountUsageDateRangeTypeFilter);
+    const {from, to} = useSelector(selectAccountUsageDateRangeFilter);
+    const type = useSelector(selectAccountUsageDateRangeTypeFilter);
 
     const handleChange = React.useCallback(
         (dateRange: DatepickerOutputDates) => {
@@ -358,7 +358,7 @@ function DateRangeFilter() {
 function DateRangeTypeFilter() {
     const dispatch = useDispatch();
 
-    const value = useSelector(getAccountUsageDateRangeTypeFilter);
+    const value = useSelector(selectAccountUsageDateRangeTypeFilter);
     const handleChange = React.useCallback(
         (dateRangeType: any) => {
             dispatch(setAccountUsageDataFilter({dateRangeType}));
@@ -393,8 +393,8 @@ function DateRangeTypeFilter() {
 function PaginationFilter() {
     const dispatch = useDispatch();
 
-    const value = useSelector(getAccountUsagePageIndex);
-    const pageCount = useSelector(getAccountUsagePageCount);
+    const value = useSelector(selectAccountUsagePageIndex);
+    const pageCount = useSelector(selectAccountUsagePageCount);
 
     const handleChange = React.useCallback(
         (pageIndex: number) => {
@@ -479,7 +479,7 @@ function DiffTitle({title}: {title: string}) {
 function ViewType() {
     const dispatch = useDispatch();
 
-    const value = useSelector(getAccountUsageViewType);
+    const value = useSelector(selectAccountUsageViewType);
     const handleChange = React.useCallback(
         (value: string) => {
             dispatch(setAccountUsageViewType(value as any));
@@ -499,7 +499,7 @@ function ViewType() {
 
 export function UsageBreadcrumbs() {
     const dispatch = useDispatch();
-    const pathArr = useSelector(getAccountUsageTreeItemsBasePathSplitted);
+    const pathArr = useSelector(selectAccountUsageTreeItemsBasePathSplitted);
     const history = useHistory();
     const items = useMemo(() => {
         return map_(pathArr, (item, index) => {

--- a/packages/ui/src/ui/store/actions/accounts/account-usage-diff.ts
+++ b/packages/ui/src/ui/store/actions/accounts/account-usage-diff.ts
@@ -18,11 +18,11 @@ import {
     ACCOUNTS_USAGE_TREE_DIFF_SUCCESS,
 } from '../../../constants/accounts/accounts';
 import {
-    getAccountUsageListDiffRequestParams,
-    getAccountUsageTreeDiffRequestParams,
-    getAccountUsageTreePath,
-    getAccountsUsageDiffFromSnapshot,
-    getAccountsUsageDiffToSnapshot,
+    selectAccountUsageListDiffRequestParams,
+    selectAccountUsageTreeDiffRequestParams,
+    selectAccountUsageTreePath,
+    selectAccountsUsageDiffFromSnapshot,
+    selectAccountsUsageDiffToSnapshot,
 } from '../../../store/selectors/accounts/account-usage';
 import {
     type AccountUsageTreeDiffAction,
@@ -34,8 +34,8 @@ import {calcAccountsUsageBaseUrl} from './accounts-usage-base-url';
 type UsageListThunkAction = ThunkAction<any, RootState, any, AccountUsageListDiffAction>;
 
 function getFilterFromToTimestamps(state: RootState) {
-    const from = getAccountsUsageDiffFromSnapshot(state);
-    const to = getAccountsUsageDiffToSnapshot(state);
+    const from = selectAccountsUsageDiffFromSnapshot(state);
+    const to = selectAccountsUsageDiffToSnapshot(state);
     if ((!from && !to) || from === to) {
         return null;
     }
@@ -78,7 +78,7 @@ export function fetchAccountUsageListDiff(): UsageListThunkAction {
                 withCredentials: true,
             })
             .then((response) => {
-                const params = getAccountUsageListDiffRequestParams(getState());
+                const params = selectAccountUsageListDiffRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }
@@ -89,7 +89,7 @@ export function fetchAccountUsageListDiff(): UsageListThunkAction {
                 });
             })
             .catch((error: any) => {
-                const params = getAccountUsageListDiffRequestParams(getState());
+                const params = selectAccountUsageListDiffRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }
@@ -120,7 +120,7 @@ export function fetchAccountUsageTreeDiff(): UsageTreeThunkAction {
             timestamps,
             row_filter: {
                 ...params.row_filter,
-                base_path: getAccountUsageTreePath(state),
+                base_path: selectAccountUsageTreePath(state),
             },
         };
 
@@ -140,7 +140,7 @@ export function fetchAccountUsageTreeDiff(): UsageTreeThunkAction {
                 withCredentials: true,
             })
             .then((response) => {
-                const params = getAccountUsageTreeDiffRequestParams(getState());
+                const params = selectAccountUsageTreeDiffRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }
@@ -154,7 +154,7 @@ export function fetchAccountUsageTreeDiff(): UsageTreeThunkAction {
                 });
             })
             .catch((error: any) => {
-                const params = getAccountUsageTreeDiffRequestParams(getState());
+                const params = selectAccountUsageTreeDiffRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }

--- a/packages/ui/src/ui/store/actions/accounts/account-usage.ts
+++ b/packages/ui/src/ui/store/actions/accounts/account-usage.ts
@@ -25,17 +25,17 @@ import {
     type AccountsUsageDataResponse,
 } from '../../reducers/accounts/usage/accounts-usage-list';
 import {
-    getAccountUsageCurrentSnapshot,
-    getAccountUsageDateRangeFilter,
-    getAccountUsageFieldFiltersRequestParameter,
-    getAccountUsageListRequestParams,
-    getAccountUsageOwnerFilter,
-    getAccountUsagePageIndex,
-    getAccountUsagePathFilter,
-    getAccountUsageSortState,
-    getAccountUsageTreePath,
-    getAccountUsageTreeRequestParams,
-    getAccountUsageViewType,
+    selectAccountUsageCurrentSnapshot,
+    selectAccountUsageDateRangeFilter,
+    selectAccountUsageFieldFiltersRequestParameter,
+    selectAccountUsageListRequestParams,
+    selectAccountUsageOwnerFilter,
+    selectAccountUsagePageIndex,
+    selectAccountUsagePathFilter,
+    selectAccountUsageSortState,
+    selectAccountUsageTreePath,
+    selectAccountUsageTreeRequestParams,
+    selectAccountUsageViewType,
 } from '../../selectors/accounts/account-usage';
 import {selectActiveAccount} from '../../../store/selectors/accounts/accounts-ts';
 import {selectSettingsAccountUsageViewType} from '../../../store/selectors/settings/settings-ts';
@@ -79,7 +79,7 @@ export function normalizeTimestamp(timestamp?: unknown): number {
 export function syncAccountsUsageViewTypeWithSettings(): FiltersThunkAction {
     return (dispatch, getState) => {
         const state = getState();
-        const viewType = getAccountUsageViewType(state);
+        const viewType = selectAccountUsageViewType(state);
         if (!viewType) {
             const lastViewType = selectSettingsAccountUsageViewType(state);
             dispatch(setAccountUsageFilters({viewType: lastViewType}));
@@ -124,12 +124,12 @@ type UsageListThunkAction = ThunkAction<any, RootState, any, AccountUsageListAct
 export function getFilterParameters(state: RootState): AccountUsageDataParams {
     const account = selectActiveAccount(state);
     const cluster = selectCluster(state);
-    const sortStates = getAccountUsageSortState(state);
-    const path_regexp = getAccountUsagePathFilter(state);
-    const owner = getAccountUsageOwnerFilter(state);
+    const sortStates = selectAccountUsageSortState(state);
+    const path_regexp = selectAccountUsagePathFilter(state);
+    const owner = selectAccountUsageOwnerFilter(state);
 
-    const field_filters = getAccountUsageFieldFiltersRequestParameter(state);
-    const viewType = getAccountUsageViewType(state);
+    const field_filters = selectAccountUsageFieldFiltersRequestParameter(state);
+    const viewType = selectAccountUsageViewType(state);
 
     const row_filter: AccountUsageListDataParams['row_filter'] = Object.assign(
         {
@@ -155,7 +155,7 @@ export function getFilterParameters(state: RootState): AccountUsageDataParams {
         ),
         row_filter,
         page: {
-            index: getAccountUsagePageIndex(state),
+            index: selectAccountUsagePageIndex(state),
             size: PAGE_SIZE,
         },
     };
@@ -165,7 +165,7 @@ export function fetchAccountUsageList(): UsageListThunkAction {
     return (dispatch, getState) => {
         const state = getState();
 
-        const timestamp = getAccountUsageCurrentSnapshot(state);
+        const timestamp = selectAccountUsageCurrentSnapshot(state);
 
         const params = getFilterParameters(state);
         const requestParams: AccountUsageListDataParams = {
@@ -189,7 +189,7 @@ export function fetchAccountUsageList(): UsageListThunkAction {
                 withCredentials: true,
             })
             .then((response) => {
-                const params = getAccountUsageListRequestParams(getState());
+                const params = selectAccountUsageListRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }
@@ -200,7 +200,7 @@ export function fetchAccountUsageList(): UsageListThunkAction {
                 });
             })
             .catch((error: any) => {
-                const params = getAccountUsageListRequestParams(getState());
+                const params = selectAccountUsageListRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }
@@ -219,7 +219,7 @@ export function fetchAccountUsageTree(): UsageTreeThunkAction {
     return (dispatch, getState) => {
         const state = getState();
 
-        const timestamp = getAccountUsageCurrentSnapshot(state);
+        const timestamp = selectAccountUsageCurrentSnapshot(state);
 
         const params = getFilterParameters(state);
         const requestParams: AccountUsageTreeData['requestParams'] = {
@@ -227,7 +227,7 @@ export function fetchAccountUsageTree(): UsageTreeThunkAction {
             timestamp: normalizeTimestamp(timestamp),
             row_filter: {
                 ...params.row_filter,
-                base_path: getAccountUsageTreePath(state),
+                base_path: selectAccountUsageTreePath(state),
             },
         };
 
@@ -247,7 +247,7 @@ export function fetchAccountUsageTree(): UsageTreeThunkAction {
                 withCredentials: true,
             })
             .then((response) => {
-                const params = getAccountUsageTreeRequestParams(getState());
+                const params = selectAccountUsageTreeRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }
@@ -261,7 +261,7 @@ export function fetchAccountUsageTree(): UsageTreeThunkAction {
                 });
             })
             .catch((error: any) => {
-                const params = getAccountUsageTreeRequestParams(getState());
+                const params = selectAccountUsageTreeRequestParams(getState());
                 if (!isEqual_(params, requestParams)) {
                     return;
                 }
@@ -283,7 +283,7 @@ type FiltersThunkAction = ThunkAction<
 
 export function fetchAccountUsage(): FiltersThunkAction {
     return (dispatch, getState) => {
-        const viewType = getAccountUsageViewType(getState());
+        const viewType = selectAccountUsageViewType(getState());
         switch (viewType) {
             case 'tree':
                 return dispatch(fetchAccountUsageTree());
@@ -301,7 +301,7 @@ export function fetchAccountUsage(): FiltersThunkAction {
 
 export function setAccountUsageSortState(item: SortState, multisort?: boolean): FiltersThunkAction {
     return (dispatch, getState) => {
-        const prevSortState = getAccountUsageSortState(getState());
+        const prevSortState = selectAccountUsageSortState(getState());
         const sortState = updateSortStateArray(prevSortState, item, {multisort});
 
         dispatch({
@@ -331,7 +331,7 @@ export function setAccountUsageDataFilter(
 
         const {dateRangeType, ...rest} = data;
         if (isEmpty_(rest) && dateRangeType) {
-            const {from, to} = getAccountUsageDateRangeFilter(getState());
+            const {from, to} = selectAccountUsageDateRangeFilter(getState());
             if (!from && !to) {
                 return;
             }
@@ -367,7 +367,7 @@ export function setAccountUsageViewType(viewType: AccountUsageViewType): Filters
 
 export function setAccountUsageColumns(columns: Array<string>): FiltersThunkAction {
     return (dispatch, getState) => {
-        const viewType = getAccountUsageViewType(getState());
+        const viewType = selectAccountUsageViewType(getState());
         switch (viewType) {
             case 'list':
             case 'list-diff':

--- a/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
@@ -41,7 +41,9 @@ export const getAccountUsageSnapshots = (state: RootState) =>
 
 export const getAccountUsageCurrentSnapshot = (state: RootState) =>
     state.accounts.usage.filters.currentSnapshot;
+
 export const getAccountUsageTreePath = (state: RootState) => state.accounts.usage.filters.treePath;
+
 export const getAccountUsageSortState = (state: RootState) =>
     state.accounts.usage.filters.sortState;
 
@@ -49,81 +51,117 @@ export const getAccountUsageViewType = (state: RootState) => state.accounts.usag
 
 export const getAccountUsagePathFilter = (state: RootState) =>
     state.accounts.usage.filters.pathFilter;
+
 export const getAccountUsageOwnerFilter = (state: RootState) =>
     state.accounts.usage.filters.ownerFilter;
+
 export const getAccountUsageDateRangeFilter = (state: RootState) =>
     state.accounts.usage.filters.dateRange;
+
 export const getAccountUsageDateRangeTypeFilter = (state: RootState) =>
     state.accounts.usage.filters.dateRangeType;
+
 export const getAccountsUsageDiffFromSnapshot = (state: RootState) =>
     state.accounts.usage.filters.diffFromSnapshot;
+
 export const getAccountsUsageDiffToSnapshot = (state: RootState) =>
     state.accounts.usage.filters.diffToSnapshot;
+
 const getAccountUsagePageIndexRaw = (state: RootState) => state.accounts.usage.filters.pageIndex;
 
 export const getAccountUsageListRequestParams = (state: RootState) =>
     state.accounts.usage.list.requestParams;
+
 export const getAccountUsageListLoading = (state: RootState) => state.accounts.usage.list.loading;
+
 export const getAccountUsageListLoaded = (state: RootState) => state.accounts.usage.list.loaded;
+
 export const getAccountUsageListError = (state: RootState) => state.accounts.usage.list.error;
+
 export const getAccountUsageListItems = (state: RootState) =>
     state.accounts.usage.list.response?.items || [];
+
 export const getAccountUsageListFields = (state: RootState) =>
     state.accounts.usage.list.response?.fields || [];
+
 export const getAccountUsageListMediums = (state: RootState) =>
     state.accounts.usage.list.response?.mediums || [];
+
 export const getAccountUsageListRowCount = (state: RootState) =>
     state.accounts.usage.list.response?.row_count || 0;
 
 export const getAccountUsageTreeRequestParams = (state: RootState) =>
     state.accounts.usage.tree.requestParams;
+
 export const getAccountUsageTreeLoading = (state: RootState) => state.accounts.usage.tree.loading;
+
 export const getAccountUsageTreeLoaded = (state: RootState) => state.accounts.usage.tree.loaded;
+
 export const getAccountUsageTreeError = (state: RootState) => state.accounts.usage.tree.error;
+
 export const getAccountUsageTreeItems = (state: RootState) =>
     state.accounts.usage.tree.response?.items || [];
+
 export const getAccountUsageTreeFields = (state: RootState) =>
     state.accounts.usage.tree.response?.fields || [];
+
 export const getAccountUsageTreeMediums = (state: RootState) =>
     state.accounts.usage.tree.response?.mediums || [];
+
 export const getAccountUsageTreeRowCount = (state: RootState) =>
     state.accounts.usage.tree.response?.row_count || 0;
+
 export const getAccountUsageTreeItemsBasePath = (state: RootState) =>
     state.accounts.usage.tree.base_path;
 
 export const getAccountUsageListDiffRequestParams = (state: RootState) =>
     state.accounts.usage.listDiff.requestParams;
+
 export const getAccountUsageListDiffLoading = (state: RootState) =>
     state.accounts.usage.listDiff.loading;
+
 export const getAccountUsageListDiffLoaded = (state: RootState) =>
     state.accounts.usage.listDiff.loaded;
+
 export const getAccountUsageListDiffError = (state: RootState) =>
     state.accounts.usage.listDiff.error;
+
 export const getAccountUsageListDiffItems = (state: RootState) =>
     state.accounts.usage.listDiff.response?.items || [];
+
 export const getAccountUsageListDiffFields = (state: RootState) =>
     state.accounts.usage.listDiff.response?.fields || [];
+
 export const getAccountUsageListDiffMediums = (state: RootState) =>
     state.accounts.usage.listDiff.response?.mediums || [];
+
 export const getAccountUsageListDiffRowCount = (state: RootState) =>
     state.accounts.usage.listDiff.response?.row_count || 0;
 
 export const getAccountUsageTreeDiffRequestParams = (state: RootState) =>
     state.accounts.usage.treeDiff.requestParams;
+
 export const getAccountUsageTreeDiffLoading = (state: RootState) =>
     state.accounts.usage.treeDiff.loading;
+
 export const getAccountUsageTreeDiffLoaded = (state: RootState) =>
     state.accounts.usage.treeDiff.loaded;
+
 export const getAccountUsageTreeDiffError = (state: RootState) =>
     state.accounts.usage.treeDiff.error;
+
 export const getAccountUsageTreeDiffItems = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.items || [];
+
 export const getAccountUsageTreeDiffFields = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.fields || [];
+
 export const getAccountUsageTreeDiffMediums = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.mediums || [];
+
 export const getAccountUsageTreeDiffRowCount = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.row_count || 0;
+
 export const getAccountUsageTreeDiffItemsBasePath = (state: RootState) =>
     state.accounts.usage.treeDiff.base_path;
 
@@ -261,6 +299,7 @@ const defaultTreeColumns: Array<keyof AccountUsageDataItem> = [
     'node_count',
     'modification_time',
 ] as any;
+
 const defaultListColumns: Array<keyof AccountUsageDataItem> = [
     'owner',
     'disk_space',
@@ -270,6 +309,7 @@ const defaultListColumns: Array<keyof AccountUsageDataItem> = [
     'chunk_count',
     'modification_time',
 ] as any;
+
 const defaultListFoldersColumns: Array<keyof AccountUsageDataItem> = [
     'owner',
     'disk_space',

--- a/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
@@ -36,144 +36,151 @@ export function readableAccountUsageColumnName(column: string, withMediumPrefix?
     return format.Readable(readable);
 }
 
-export const getAccountUsageSnapshots = (state: RootState) =>
+export const selectAccountUsageSnapshots = (state: RootState) =>
     state.accounts.usage.snapshots.snapshot_timestamps;
 
-export const getAccountUsageCurrentSnapshot = (state: RootState) =>
+export const selectAccountUsageCurrentSnapshot = (state: RootState) =>
     state.accounts.usage.filters.currentSnapshot;
 
-export const getAccountUsageTreePath = (state: RootState) => state.accounts.usage.filters.treePath;
+export const selectAccountUsageTreePath = (state: RootState) =>
+    state.accounts.usage.filters.treePath;
 
-export const getAccountUsageSortState = (state: RootState) =>
+export const selectAccountUsageSortState = (state: RootState) =>
     state.accounts.usage.filters.sortState;
 
-export const getAccountUsageViewType = (state: RootState) => state.accounts.usage.filters.viewType;
+export const selectAccountUsageViewType = (state: RootState) =>
+    state.accounts.usage.filters.viewType;
 
-export const getAccountUsagePathFilter = (state: RootState) =>
+export const selectAccountUsagePathFilter = (state: RootState) =>
     state.accounts.usage.filters.pathFilter;
 
-export const getAccountUsageOwnerFilter = (state: RootState) =>
+export const selectAccountUsageOwnerFilter = (state: RootState) =>
     state.accounts.usage.filters.ownerFilter;
 
-export const getAccountUsageDateRangeFilter = (state: RootState) =>
+export const selectAccountUsageDateRangeFilter = (state: RootState) =>
     state.accounts.usage.filters.dateRange;
 
-export const getAccountUsageDateRangeTypeFilter = (state: RootState) =>
+export const selectAccountUsageDateRangeTypeFilter = (state: RootState) =>
     state.accounts.usage.filters.dateRangeType;
 
-export const getAccountsUsageDiffFromSnapshot = (state: RootState) =>
+export const selectAccountsUsageDiffFromSnapshot = (state: RootState) =>
     state.accounts.usage.filters.diffFromSnapshot;
 
-export const getAccountsUsageDiffToSnapshot = (state: RootState) =>
+export const selectAccountsUsageDiffToSnapshot = (state: RootState) =>
     state.accounts.usage.filters.diffToSnapshot;
 
-const getAccountUsagePageIndexRaw = (state: RootState) => state.accounts.usage.filters.pageIndex;
+const selectAccountUsagePageIndexRaw = (state: RootState) => state.accounts.usage.filters.pageIndex;
 
-export const getAccountUsageListRequestParams = (state: RootState) =>
+export const selectAccountUsageListRequestParams = (state: RootState) =>
     state.accounts.usage.list.requestParams;
 
-export const getAccountUsageListLoading = (state: RootState) => state.accounts.usage.list.loading;
+export const selectAccountUsageListLoading = (state: RootState) =>
+    state.accounts.usage.list.loading;
 
-export const getAccountUsageListLoaded = (state: RootState) => state.accounts.usage.list.loaded;
+export const selectAccountUsageListLoaded = (state: RootState) => state.accounts.usage.list.loaded;
 
-export const getAccountUsageListError = (state: RootState) => state.accounts.usage.list.error;
+export const selectAccountUsageListError = (state: RootState) => state.accounts.usage.list.error;
 
-export const getAccountUsageListItems = (state: RootState) =>
+export const selectAccountUsageListItems = (state: RootState) =>
     state.accounts.usage.list.response?.items || [];
 
-export const getAccountUsageListFields = (state: RootState) =>
+export const selectAccountUsageListFields = (state: RootState) =>
     state.accounts.usage.list.response?.fields || [];
 
-export const getAccountUsageListMediums = (state: RootState) =>
+export const selectAccountUsageListMediums = (state: RootState) =>
     state.accounts.usage.list.response?.mediums || [];
 
-export const getAccountUsageListRowCount = (state: RootState) =>
+export const selectAccountUsageListRowCount = (state: RootState) =>
     state.accounts.usage.list.response?.row_count || 0;
 
-export const getAccountUsageTreeRequestParams = (state: RootState) =>
+export const selectAccountUsageTreeRequestParams = (state: RootState) =>
     state.accounts.usage.tree.requestParams;
 
-export const getAccountUsageTreeLoading = (state: RootState) => state.accounts.usage.tree.loading;
+export const selectAccountUsageTreeLoading = (state: RootState) =>
+    state.accounts.usage.tree.loading;
 
-export const getAccountUsageTreeLoaded = (state: RootState) => state.accounts.usage.tree.loaded;
+export const selectAccountUsageTreeLoaded = (state: RootState) => state.accounts.usage.tree.loaded;
 
-export const getAccountUsageTreeError = (state: RootState) => state.accounts.usage.tree.error;
+export const selectAccountUsageTreeError = (state: RootState) => state.accounts.usage.tree.error;
 
-export const getAccountUsageTreeItems = (state: RootState) =>
+export const selectAccountUsageTreeItems = (state: RootState) =>
     state.accounts.usage.tree.response?.items || [];
 
-export const getAccountUsageTreeFields = (state: RootState) =>
+export const selectAccountUsageTreeFields = (state: RootState) =>
     state.accounts.usage.tree.response?.fields || [];
 
-export const getAccountUsageTreeMediums = (state: RootState) =>
+export const selectAccountUsageTreeMediums = (state: RootState) =>
     state.accounts.usage.tree.response?.mediums || [];
 
-export const getAccountUsageTreeRowCount = (state: RootState) =>
+export const selectAccountUsageTreeRowCount = (state: RootState) =>
     state.accounts.usage.tree.response?.row_count || 0;
 
-export const getAccountUsageTreeItemsBasePath = (state: RootState) =>
+export const selectAccountUsageTreeItemsBasePath = (state: RootState) =>
     state.accounts.usage.tree.base_path;
 
-export const getAccountUsageListDiffRequestParams = (state: RootState) =>
+export const selectAccountUsageListDiffRequestParams = (state: RootState) =>
     state.accounts.usage.listDiff.requestParams;
 
-export const getAccountUsageListDiffLoading = (state: RootState) =>
+export const selectAccountUsageListDiffLoading = (state: RootState) =>
     state.accounts.usage.listDiff.loading;
 
-export const getAccountUsageListDiffLoaded = (state: RootState) =>
+export const selectAccountUsageListDiffLoaded = (state: RootState) =>
     state.accounts.usage.listDiff.loaded;
 
-export const getAccountUsageListDiffError = (state: RootState) =>
+export const selectAccountUsageListDiffError = (state: RootState) =>
     state.accounts.usage.listDiff.error;
 
-export const getAccountUsageListDiffItems = (state: RootState) =>
+export const selectAccountUsageListDiffItems = (state: RootState) =>
     state.accounts.usage.listDiff.response?.items || [];
 
-export const getAccountUsageListDiffFields = (state: RootState) =>
+export const selectAccountUsageListDiffFields = (state: RootState) =>
     state.accounts.usage.listDiff.response?.fields || [];
 
-export const getAccountUsageListDiffMediums = (state: RootState) =>
+export const selectAccountUsageListDiffMediums = (state: RootState) =>
     state.accounts.usage.listDiff.response?.mediums || [];
 
-export const getAccountUsageListDiffRowCount = (state: RootState) =>
+export const selectAccountUsageListDiffRowCount = (state: RootState) =>
     state.accounts.usage.listDiff.response?.row_count || 0;
 
-export const getAccountUsageTreeDiffRequestParams = (state: RootState) =>
+export const selectAccountUsageTreeDiffRequestParams = (state: RootState) =>
     state.accounts.usage.treeDiff.requestParams;
 
-export const getAccountUsageTreeDiffLoading = (state: RootState) =>
+export const selectAccountUsageTreeDiffLoading = (state: RootState) =>
     state.accounts.usage.treeDiff.loading;
 
-export const getAccountUsageTreeDiffLoaded = (state: RootState) =>
+export const selectAccountUsageTreeDiffLoaded = (state: RootState) =>
     state.accounts.usage.treeDiff.loaded;
 
-export const getAccountUsageTreeDiffError = (state: RootState) =>
+export const selectAccountUsageTreeDiffError = (state: RootState) =>
     state.accounts.usage.treeDiff.error;
 
-export const getAccountUsageTreeDiffItems = (state: RootState) =>
+export const selectAccountUsageTreeDiffItems = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.items || [];
 
-export const getAccountUsageTreeDiffFields = (state: RootState) =>
+export const selectAccountUsageTreeDiffFields = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.fields || [];
 
-export const getAccountUsageTreeDiffMediums = (state: RootState) =>
+export const selectAccountUsageTreeDiffMediums = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.mediums || [];
 
-export const getAccountUsageTreeDiffRowCount = (state: RootState) =>
+export const selectAccountUsageTreeDiffRowCount = (state: RootState) =>
     state.accounts.usage.treeDiff.response?.row_count || 0;
 
-export const getAccountUsageTreeDiffItemsBasePath = (state: RootState) =>
+export const selectAccountUsageTreeDiffItemsBasePath = (state: RootState) =>
     state.accounts.usage.treeDiff.base_path;
 
-export const isAccountsUsageDiffView = createSelector([getAccountUsageViewType], (viewType) => {
-    return viewType?.endsWith('-diff');
-});
+export const selectIsAccountsUsageDiffView = createSelector(
+    [selectAccountUsageViewType],
+    (viewType) => {
+        return viewType?.endsWith('-diff');
+    },
+);
 
-export const getAccountUsageTreeItemsBasePathSplitted = createSelector(
+export const selectAccountUsageTreeItemsBasePathSplitted = createSelector(
     [
-        getAccountUsageViewType,
-        getAccountUsageTreeItemsBasePath,
-        getAccountUsageTreeDiffItemsBasePath,
+        selectAccountUsageViewType,
+        selectAccountUsageTreeItemsBasePath,
+        selectAccountUsageTreeDiffItemsBasePath,
     ],
     (viewType, treePath, treeDiffPath) => {
         const path = viewType === 'tree-diff' ? treeDiffPath : treePath;
@@ -195,8 +202,8 @@ export const getAccountUsageTreeItemsBasePathSplitted = createSelector(
     },
 );
 
-export const getAccountUsageFieldFiltersRequestParameter = createSelector(
-    [getAccountUsageDateRangeFilter, getAccountUsageDateRangeTypeFilter],
+export const selectAccountUsageFieldFiltersRequestParameter = createSelector(
+    [selectAccountUsageDateRangeFilter, selectAccountUsageDateRangeTypeFilter],
     ({from, to}, dateRangeType: 'creation_time' | 'modification_time') => {
         const res = [];
 
@@ -220,12 +227,12 @@ export const getAccountUsageFieldFiltersRequestParameter = createSelector(
     },
 );
 
-export const getAccountUsagePageCount = createSelector(
+export const selectAccountUsagePageCount = createSelector(
     [
-        getAccountUsageViewType,
-        getAccountUsageListRowCount,
-        getAccountUsageTreeRowCount,
-        getAccountUsageListDiffRowCount,
+        selectAccountUsageViewType,
+        selectAccountUsageListRowCount,
+        selectAccountUsageTreeRowCount,
+        selectAccountUsageListDiffRowCount,
     ],
     (viewType, listRowCount, treeRowCount, listDiffRowCount) => {
         let rowCount = listRowCount;
@@ -238,15 +245,15 @@ export const getAccountUsagePageCount = createSelector(
     },
 );
 
-export const getAccountUsagePageIndex = createSelector(
-    [getAccountUsagePageIndexRaw],
+export const selectAccountUsagePageIndex = createSelector(
+    [selectAccountUsagePageIndexRaw],
     (pageIndex) => {
         return Math.max(0, Number(pageIndex));
     },
 );
 
-export const getAccountUsageSortStateByColumn = createSelector(
-    [getAccountUsageSortState],
+export const selectAccountUsageSortStateByColumn = createSelector(
+    [selectAccountUsageSortState],
     (sortState) => {
         return reduce_(
             sortState,
@@ -264,13 +271,13 @@ export const getAccountUsageSortStateByColumn = createSelector(
     },
 );
 
-export const getAccountUsageAvailableColumns = createSelector(
+export const selectAccountUsageAvailableColumns = createSelector(
     [
-        getAccountUsageViewType,
-        getAccountUsageListFields,
-        getAccountUsageTreeFields,
-        getAccountUsageListDiffFields,
-        getAccountUsageTreeDiffFields,
+        selectAccountUsageViewType,
+        selectAccountUsageListFields,
+        selectAccountUsageTreeFields,
+        selectAccountUsageListDiffFields,
+        selectAccountUsageTreeDiffFields,
     ],
     (viewType, listFields, treeFields, listDiffFields, treeDiffFields) => {
         switch (viewType) {
@@ -329,9 +336,9 @@ function firstNotEmpty<T = keyof AccountUsageDataItem>(a1: Array<T>, a2: Array<T
     return a2;
 }
 
-const getAccountUsageVisibleColumns = createSelector(
+const selectAccountUsageVisibleColumns = createSelector(
     [
-        getAccountUsageViewType,
+        selectAccountUsageViewType,
         selectSettingsAccountUsageColumnsTree,
         selectSettingsAccountUsageColumnsList,
         selectSettingsAccountUsageColumnsListFolders,
@@ -350,8 +357,8 @@ const getAccountUsageVisibleColumns = createSelector(
     },
 );
 
-export const getAccountUsageSelectableColumns = createSelector(
-    [getAccountUsageAvailableColumns],
+export const selectAccountUsageSelectableColumns = createSelector(
+    [selectAccountUsageAvailableColumns],
     (columns) => {
         return filter_(columns, (item) => !ACCOUNT_USAGE_UNAVAILABLE_FIELDS.has(item));
     },
@@ -366,8 +373,8 @@ export const ACCOUNT_USAGE_UNAVAILABLE_FIELDS = new Set([
     'direct_child_count',
 ]);
 
-export const getAccountUsageVisibleDataColumns = createSelector(
-    [getAccountUsageSelectableColumns, getAccountUsageVisibleColumns],
+export const selectAccountUsageVisibleDataColumns = createSelector(
+    [selectAccountUsageSelectableColumns, selectAccountUsageVisibleColumns],
     (selectableColumns, userColumns) => {
         const columns = new Set<string>(selectableColumns);
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/V_SoOQvJ7fjTwh
<!-- nda-end -->## Summary by Sourcery

Rename account usage selectors to use a `select*` naming convention and update all references across account usage UI, toolbar, columns, and actions.

Enhancements:
- Align account usage selector names with the `select*` convention for consistency across the Redux store and UI components.

Chores:
- Update all account usage-related components, thunks, and utilities to use the new selector names without changing behavior.