### PR TITLE
chore(Accounts): show versioned resource usage [YTFRONT-5361]

### DIFF
--- a/packages/ui/src/shared/utils/toolkit/index.ts
+++ b/packages/ui/src/shared/utils/toolkit/index.ts
@@ -1,3 +1,4 @@
 export * from './assert';
+export * from './object';
 export * from './string';
 export * from './type';

--- a/packages/ui/src/shared/utils/toolkit/object/index.ts
+++ b/packages/ui/src/shared/utils/toolkit/object/index.ts
@@ -1,0 +1,1 @@
+export * from './objHasOwnProperty';

--- a/packages/ui/src/shared/utils/toolkit/object/objHasOwnProperty.ts
+++ b/packages/ui/src/shared/utils/toolkit/object/objHasOwnProperty.ts
@@ -1,0 +1,3 @@
+export const objHasOwnProperty = <T extends object>(obj: T, key: PropertyKey): key is keyof T => {
+    return Object.prototype.hasOwnProperty.call(obj, key);
+};

--- a/packages/ui/src/ui/components/ColumnHeader/ColumnHeader.tsx
+++ b/packages/ui/src/ui/components/ColumnHeader/ColumnHeader.tsx
@@ -45,20 +45,20 @@ export type HasSortColumn<T> =
           options: Array<ColumnInfo<T>>;
       } & Partial<Record<keyof Omit<ColumnInfo<T>, 'column' | 'title' | 'shortTitle'>, undefined>>);
 
+export type ColumnHeaderOnSort<T extends string = string> = (
+    column: T,
+    nextOrder: OrderType,
+    options: {currentOrder?: OrderType; multisort?: boolean},
+) => void;
+
 export type ColumnHeaderProps<T extends string = string> = PageCounterProps &
     HasSortColumn<T> & {
         className?: string;
         order?: OrderType;
         multisortIndex?: number;
         sortIconSize?: number;
-        onSort?: (
-            column: T,
-            nextOrder: OrderType,
-            options: {currentOrder?: OrderType; multisort?: boolean},
-        ) => void;
-
+        onSort?: ColumnHeaderOnSort<T>;
         loading?: boolean;
-
         align?: 'center' | 'left' | 'right';
     };
 

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/Header.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/Header.tsx
@@ -1,32 +1,37 @@
 import React, {useCallback} from 'react';
 
-import ColumnHeader from '../../../../../components/ColumnHeader/ColumnHeader';
+import ColumnHeader, {
+    type ColumnHeaderOnSort,
+} from '../../../../../components/ColumnHeader/ColumnHeader';
 import {setAccountUsageSortState} from '../../../../../store/actions/accounts/account-usage';
-import {type AccountUsageDataItem} from '../../../../../store/reducers/accounts/usage/account-usage-types';
+import {type AccountUsageField} from '../../../../../store/reducers/accounts/usage/account-usage-types';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {
     readableAccountUsageColumnName,
     selectAccountUsageSortStateByColumn,
 } from '../../../../../store/selectors/accounts/account-usage';
-import {type OrderType} from '../../../../../utils/sort-helpers';
+
+type OnSort = ColumnHeaderOnSort<AccountUsageField>;
 
 type Props = {
-    column: keyof AccountUsageDataItem;
+    column: AccountUsageField;
 };
 
 export const Header = ({column}: Props) => {
     const dispatch = useDispatch();
 
-    const sortOrder = useSelector(selectAccountUsageSortStateByColumn);
+    const sortState = useSelector(selectAccountUsageSortStateByColumn);
 
-    const onSort = useCallback(
-        (column: string, nextOrder: OrderType, opts: {multisort?: boolean}) => {
-            dispatch(setAccountUsageSortState({column, order: nextOrder}, opts.multisort));
+    const onSort = useCallback<OnSort>(
+        (columnName, nextOrder, options) => {
+            dispatch(
+                setAccountUsageSortState({column: columnName, order: nextOrder}, options.multisort),
+            );
         },
         [dispatch],
     );
 
-    const {order, multisortIndex} = sortOrder[column] || {};
+    const {order, multisortIndex} = sortState[column] || {};
 
     return (
         <ColumnHeader

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/UsageHeader.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/UsageHeader.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import {type AccountUsageField} from '../../../../../store/reducers/accounts/usage/account-usage-types';
+import {useSelector} from '../../../../../store/redux-hooks';
+import {selectAccountUsageViewType} from '../../../../../store/selectors/accounts/account-usage';
+
+import {useVersionedFieldName} from './useVersionedFieldName';
+import {Header} from './Header';
+import {VersionedHeader} from './VersionedHeader';
+
+type Props = {
+    column: AccountUsageField;
+};
+
+export const UsageHeader = ({column}: Props) => {
+    const viewType = useSelector(selectAccountUsageViewType);
+    const showVersionedHeader = !viewType?.endsWith('-diff');
+
+    const versionedField = useVersionedFieldName(column);
+
+    return showVersionedHeader && versionedField ? (
+        <VersionedHeader column={column} versionedColumn={versionedField} />
+    ) : (
+        <Header column={column} />
+    );
+};

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/VersionedHeader.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/VersionedHeader.tsx
@@ -1,0 +1,57 @@
+import React, {useCallback} from 'react';
+
+import ColumnHeader, {
+    type ColumnHeaderOnSort,
+} from '../../../../../components/ColumnHeader/ColumnHeader';
+import {setAccountUsageSortState} from '../../../../../store/actions/accounts/account-usage';
+import {
+    type AccountUsageField,
+    type AccountUsageVersionedField,
+} from '../../../../../store/reducers/accounts/usage/account-usage-types';
+import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
+import {
+    readableAccountUsageColumnName,
+    selectAccountUsageSortStateByColumn,
+} from '../../../../../store/selectors/accounts/account-usage';
+
+type OnSort = ColumnHeaderOnSort<AccountUsageField | AccountUsageVersionedField>;
+
+type Props = {
+    column: AccountUsageField;
+    versionedColumn: AccountUsageVersionedField;
+};
+
+export const VersionedHeader = ({column, versionedColumn}: Props) => {
+    const dispatch = useDispatch();
+
+    const sortState = useSelector(selectAccountUsageSortStateByColumn);
+
+    const onSort = useCallback<OnSort>(
+        (columnName, nextOrder, options) => {
+            dispatch(
+                setAccountUsageSortState({column: columnName, order: nextOrder}, options.multisort),
+            );
+        },
+        [dispatch],
+    );
+
+    const columnTitle = readableAccountUsageColumnName(column);
+
+    const versionedSortState = sortState[versionedColumn];
+    const activeColumn = versionedSortState ? versionedColumn : column;
+    const activeSortState = versionedSortState ?? sortState[column];
+
+    return (
+        <ColumnHeader
+            column={activeColumn}
+            title={columnTitle}
+            order={activeSortState?.order}
+            multisortIndex={activeSortState?.multisortIndex}
+            onSort={onSort}
+            options={[
+                {column, title: 'Committed'},
+                {column: versionedColumn, title: 'Uncommitted'},
+            ]}
+        />
+    );
+};

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useColumnsByPreset.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useColumnsByPreset.tsx
@@ -33,20 +33,21 @@ import {getIconNameForType} from '../../../../../utils/navigation/path-editor';
 
 import {assert} from '../../../../../../shared/utils/toolkit';
 import {AccountActionsField, type AccountRequestData} from '../AccountActionsField';
-import {useGetVersionedFieldValue} from './useGetVersionedFieldValue';
 import {DetailTableCell} from '../DetailTableCell';
 import i18n from '../i18n';
 
+import {useGetVersionedFieldValue} from './useGetVersionedFieldValue';
 import {Header} from './Header';
 import {PathHeader} from './PathHeader';
+import {UsageHeader} from './UsageHeader';
 import {block, getIconNameForViewType} from './utils';
 
 export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
     const dispatch = useDispatch();
 
+    const cluster = useSelector(selectCluster);
     const availableColumns = useSelector(selectAccountUsageAvailableColumns);
     const visibleColumns = useSelector(selectAccountUsageVisibleDataColumns);
-    const cluster = useSelector(selectCluster);
 
     const viewType = useSelector(selectAccountUsageViewType);
     assert(viewType, 'viewType must be defined');
@@ -80,6 +81,7 @@ export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
             },
             width: 50,
         });
+
         res.set('path', {
             name: 'path',
             header: <PathHeader />,
@@ -128,13 +130,13 @@ export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
 
         res.set('disk_space', {
             name: 'disk_space',
-            header: <Header column={'disk_space'} />,
+            header: <UsageHeader column="disk_space" />,
             sortable: false,
             render(item) {
                 return (
                     <DetailTableCell
                         value={item.row.disk_space}
-                        additionalValue={getVersionedFieldValue(item.row, 'disk_space')}
+                        versionedValue={getVersionedFieldValue(item.row, 'disk_space')}
                         viewType={viewType}
                         formatType="bytes"
                     />
@@ -146,13 +148,13 @@ export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
 
         res.set('master_memory', {
             name: 'Master mem',
-            header: <Header column={'master_memory'} />,
+            header: <UsageHeader column="master_memory" />,
             sortable: false,
             render(item) {
                 return (
                     <DetailTableCell
                         value={item.row.master_memory}
-                        additionalValue={getVersionedFieldValue(item.row, 'master_memory')}
+                        versionedValue={getVersionedFieldValue(item.row, 'master_memory')}
                         viewType={viewType}
                         formatType="bytes"
                     />
@@ -164,7 +166,7 @@ export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
 
         res.set('owner', {
             name: 'Owner',
-            header: <Header column={'owner'} />,
+            header: <Header column="owner" />,
             sortable: false,
             render(item) {
                 return item.row.owner ? <SubjectCard name={item.row.owner} /> : format.NO_VALUE;
@@ -177,13 +179,13 @@ export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
 
             res.set(name, {
                 name,
-                header: <Header column={name} />,
+                header: <UsageHeader column={name} />,
                 sortable: false,
                 render(item) {
                     return (
                         <DetailTableCell
                             value={Number(item.row[name])}
-                            additionalValue={getVersionedFieldValue(item.row, name)}
+                            versionedValue={getVersionedFieldValue(item.row, name)}
                             viewType={viewType}
                             formatType="bytes"
                         />
@@ -201,7 +203,7 @@ export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
 
             res.set(field, {
                 name: field,
-                header: <Header column={field} />,
+                header: <UsageHeader column={field} />,
                 sortable: false,
                 render(item) {
                     const value = item.row[field];
@@ -218,7 +220,7 @@ export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
                         return (
                             <DetailTableCell
                                 value={Number(value)}
-                                additionalValue={getVersionedFieldValue(item.row, field)}
+                                versionedValue={getVersionedFieldValue(item.row, field)}
                                 viewType={viewType}
                                 formatType="number"
                             />

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useColumnsByPreset.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useColumnsByPreset.tsx
@@ -20,35 +20,38 @@ import {
 import {makeRoutedURL} from '../../../../../store/location';
 import {
     type AccountUsageDataItem,
-    type MediumKeyTemplate,
-    type VersionedKeyTemplate,
+    type AccountUsageMediumKey,
 } from '../../../../../store/reducers/accounts/usage/account-usage-types';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {
     selectAccountUsageAvailableColumns,
-    selectAccountUsageTreeItemsBasePath,
     selectAccountUsageViewType,
     selectAccountUsageVisibleDataColumns,
 } from '../../../../../store/selectors/accounts/account-usage';
 import {selectCluster} from '../../../../../store/selectors/global';
 import {getIconNameForType} from '../../../../../utils/navigation/path-editor';
 
+import {assert} from '../../../../../../shared/utils/toolkit';
 import {AccountActionsField, type AccountRequestData} from '../AccountActionsField';
+import {useGetVersionedFieldValue} from './useGetVersionedFieldValue';
 import {DetailTableCell} from '../DetailTableCell';
 import i18n from '../i18n';
 
 import {Header} from './Header';
 import {PathHeader} from './PathHeader';
-import {block} from './utils';
+import {block, getIconNameForViewType} from './utils';
 
-export const useColumnsByPreset = (mediums: Array<string>) => {
+export const useColumnsByPreset = (mediums: AccountUsageMediumKey[]) => {
     const dispatch = useDispatch();
 
     const availableColumns = useSelector(selectAccountUsageAvailableColumns);
     const visibleColumns = useSelector(selectAccountUsageVisibleDataColumns);
     const cluster = useSelector(selectCluster);
+
     const viewType = useSelector(selectAccountUsageViewType);
-    const treePath = useSelector(selectAccountUsageTreeItemsBasePath);
+    assert(viewType, 'viewType must be defined');
+
+    const getVersionedFieldValue = useGetVersionedFieldValue();
 
     const handleAttributeButtonClick = useCallback(
         (accountData: AccountRequestData) => {
@@ -60,15 +63,11 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
     const columnsByName = useMemo(() => {
         const res: Map<string, Column<AccountUsageDataItem>> = new Map();
 
-        const iconName =
-            viewType === 'tree' || viewType === 'tree-diff'
-                ? ''
-                : viewType === 'list' || viewType === 'list-diff'
-                  ? 'list'
-                  : 'folders';
+        const iconName = getIconNameForViewType(viewType);
+
         res.set('type', {
             name: 'type',
-            header: iconName === '' ? null : <Icon awesome={iconName} />,
+            header: iconName ? <Icon awesome={iconName} /> : null,
             sortable: false,
             render(item) {
                 const {type, path, acl_status} = item.row;
@@ -135,7 +134,7 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
                 return (
                     <DetailTableCell
                         value={item.row.disk_space}
-                        additionalValue={item.row['versioned:disk_space']}
+                        additionalValue={getVersionedFieldValue(item.row, 'disk_space')}
                         viewType={viewType}
                         formatType="bytes"
                     />
@@ -144,6 +143,7 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
             align: 'right',
             width: 120,
         });
+
         res.set('master_memory', {
             name: 'Master mem',
             header: <Header column={'master_memory'} />,
@@ -152,7 +152,7 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
                 return (
                     <DetailTableCell
                         value={item.row.master_memory}
-                        additionalValue={item.row['versioned:master_memory']}
+                        additionalValue={getVersionedFieldValue(item.row, 'master_memory')}
                         viewType={viewType}
                         formatType="bytes"
                     />
@@ -161,32 +161,29 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
             align: 'right',
             width: 120,
         });
+
         res.set('owner', {
             name: 'Owner',
             header: <Header column={'owner'} />,
             sortable: false,
             render(item) {
-                return <SubjectCard name={item.row.owner} />;
+                return item.row.owner ? <SubjectCard name={item.row.owner} /> : format.NO_VALUE;
             },
             width: 120,
         });
 
         forEach_(mediums, (medium) => {
-            const name = `medium:${medium}` as MediumKeyTemplate;
-            const versionedName = `versioned:medium:${name}` as VersionedKeyTemplate;
+            const name = `medium:${medium}` as const;
 
             res.set(name, {
                 name,
                 header: <Header column={name} />,
                 sortable: false,
                 render(item) {
-                    const additionalValue =
-                        versionedName in item.row ? Number(item.row[versionedName]) : null;
-
                     return (
                         <DetailTableCell
                             value={Number(item.row[name])}
-                            additionalValue={additionalValue}
+                            additionalValue={getVersionedFieldValue(item.row, name)}
                             viewType={viewType}
                             formatType="bytes"
                         />
@@ -207,13 +204,10 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
                 header: <Header column={field} />,
                 sortable: false,
                 render(item) {
-                    const {[field]: value} = item.row;
-                    const additionalKey = `versioned:${field}` as VersionedKeyTemplate;
-                    const additionalValue =
-                        additionalKey in item.row ? Number(item.row[additionalKey]) : null;
+                    const value = item.row[field];
 
                     if (typeof value === 'boolean') {
-                        return value === undefined ? format.NO_VALUE : capitalize_(String(value));
+                        return capitalize_(String(value));
                     }
                     if (field.endsWith('_time')) {
                         return value === null || value === undefined
@@ -224,7 +218,7 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
                         return (
                             <DetailTableCell
                                 value={Number(value)}
-                                additionalValue={additionalValue}
+                                additionalValue={getVersionedFieldValue(item.row, field)}
                                 viewType={viewType}
                                 formatType="number"
                             />
@@ -237,7 +231,7 @@ export const useColumnsByPreset = (mediums: Array<string>) => {
         });
 
         return res;
-    }, [treePath, viewType, mediums, cluster, availableColumns, dispatch]);
+    }, [viewType, mediums, cluster, availableColumns, getVersionedFieldValue, dispatch]);
 
     return useMemo(() => {
         const res: Array<Column<AccountUsageDataItem>> = [];

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useGetVersionedFieldValue.ts
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useGetVersionedFieldValue.ts
@@ -1,0 +1,34 @@
+import {useCallback} from 'react';
+
+import {objHasOwnProperty} from '../../../../../../shared/utils/toolkit';
+import {
+    type AccountUsageDataItem,
+    type AccountUsageField,
+} from '../../../../../store/reducers/accounts/usage/account-usage-types';
+import {useSelector} from '../../../../../store/redux-hooks';
+import {selectAccountUsageVersionedFields} from '../../../../../store/selectors/accounts/account-usage';
+
+type Result = (item: AccountUsageDataItem, field: AccountUsageField) => number | null;
+
+export const useGetVersionedFieldValue = (): Result => {
+    const versionedFields = useSelector(selectAccountUsageVersionedFields);
+
+    return useCallback(
+        (item, field) => {
+            if (!versionedFields) {
+                return null;
+            }
+
+            const versionedField = objHasOwnProperty(versionedFields, field)
+                ? versionedFields[field]
+                : null;
+
+            if (!versionedField) {
+                return null;
+            }
+
+            return item[versionedField] ?? null;
+        },
+        [versionedFields],
+    );
+};

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useVersionedFieldName.ts
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/useVersionedFieldName.ts
@@ -1,0 +1,19 @@
+import {objHasOwnProperty} from '../../../../../../shared/utils/toolkit';
+import {
+    type AccountUsageField,
+    type AccountUsageVersionedField,
+} from '../../../../../store/reducers/accounts/usage/account-usage-types';
+import {useSelector} from '../../../../../store/redux-hooks';
+import {selectAccountUsageVersionedFields} from '../../../../../store/selectors/accounts/account-usage';
+
+export const useVersionedFieldName = (
+    field: AccountUsageField,
+): AccountUsageVersionedField | undefined => {
+    const versionedFields = useSelector(selectAccountUsageVersionedFields);
+
+    if (!versionedFields || !objHasOwnProperty(versionedFields, field)) {
+        return undefined;
+    }
+
+    return versionedFields[field];
+};

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/utils.ts
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/AccountUsageDetails/utils.ts
@@ -1,3 +1,18 @@
 import cn from 'bem-cn-lite';
 
+import {type AccountUsageViewType} from '../../../../../store/reducers/accounts/usage/accounts-usage-filters';
+import {type IconName} from '../../../../../components/Icon/Icon';
+
 export const block = cn('account-usage-details');
+
+export const getIconNameForViewType = (viewType: AccountUsageViewType): IconName | null => {
+    if (viewType === 'tree' || viewType === 'tree-diff') {
+        return null;
+    }
+
+    if (viewType === 'list' || viewType === 'list-diff') {
+        return 'list';
+    }
+
+    return 'folders';
+};

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/DetailTableCell.scss
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/DetailTableCell.scss
@@ -7,8 +7,4 @@
             color: var(--success-color);
         }
     }
-
-    &__alert-icon {
-        height: 14px;
-    }
 }

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/DetailTableCell.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/DetailTableCell.tsx
@@ -1,52 +1,49 @@
 import React, {type FC} from 'react';
-import {Flex, Icon, Tooltip} from '@gravity-ui/uikit';
+import {Flex, Text} from '@gravity-ui/uikit';
 import {type AccountUsageViewType} from '../../../../store/reducers/accounts/usage/accounts-usage-filters';
 import cn from 'bem-cn-lite';
 import format from '../../../../common/hammer/format';
-import CircleInfoIcon from '@gravity-ui/icons/svgs/circle-info.svg';
-import i18n from './i18n';
 import './DetailTableCell.scss';
 
 const block = cn('detail-table-cell');
 
-const getRenderSign = (value: number) => (!value || value < 0 ? '' : '+');
+const getRenderSign = (value: number) => {
+    return value <= 0 ? '' : '+';
+};
+
 const getDiffClass = (showDiff: boolean, sign: number) => {
     if (!showDiff || !sign) return undefined;
+
     return sign > 0 ? 'plus' : 'minus';
 };
 
 type Props = {
     value: number | null;
     additionalValue: number | null;
-    viewType?: AccountUsageViewType;
+    viewType: AccountUsageViewType;
     formatType: 'bytes' | 'number';
 };
 
 export const DetailTableCell: FC<Props> = ({value, additionalValue, viewType, formatType}) => {
-    const totalValue = additionalValue ? Number(value) + additionalValue : Number(value);
-    const showDiff = viewType?.endsWith('-diff');
+    const totalValue = (value ?? 0) + (additionalValue ?? 0);
+    const showDiff = viewType.endsWith('-diff');
     const sign = Math.sign(totalValue);
 
     const formatFn = formatType === 'bytes' ? format.Bytes : format.Number;
 
+    const valueClassName = block('value', {diff: getDiffClass(showDiff, sign)});
+
     return (
-        <Flex justifyContent="center" alignItems="center" gap={1} className={block()}>
-            <span className={block('value', {diff: getDiffClass(Boolean(showDiff), sign)})}>
+        <Flex direction="column" alignItems="flex-end" className={block()}>
+            <span className={valueClassName}>
                 {showDiff && getRenderSign(sign)}
                 {formatFn(totalValue)}
             </span>
-            {Boolean(additionalValue) && (
-                <Tooltip
-                    content={i18n('context_versioned-breakdown', {
-                        value: formatFn(value),
-                        additionalValue: formatFn(additionalValue),
-                    })}
-                    placement="top"
-                >
-                    <div tabIndex={0} className={block('alert-icon')}>
-                        <Icon data={CircleInfoIcon} size={14} />
-                    </div>
-                </Tooltip>
+
+            {additionalValue !== null && (
+                <Text variant="caption-2" color="secondary">
+                    {formatFn(value ?? 0)}, {formatFn(additionalValue)}
+                </Text>
             )}
         </Flex>
     );

--- a/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/DetailTableCell.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/detailed-usage/DetailTableCell.tsx
@@ -1,5 +1,6 @@
 import React, {type FC} from 'react';
 import {Flex, Text} from '@gravity-ui/uikit';
+import {MetaTable, type MetaTableItem, Tooltip} from '@ytsaurus/components';
 import {type AccountUsageViewType} from '../../../../store/reducers/accounts/usage/accounts-usage-filters';
 import cn from 'bem-cn-lite';
 import format from '../../../../common/hammer/format';
@@ -8,43 +9,63 @@ import './DetailTableCell.scss';
 const block = cn('detail-table-cell');
 
 const getRenderSign = (value: number) => {
-    return value <= 0 ? '' : '+';
+    return !value || value <= 0 ? '' : '+';
 };
 
-const getDiffClass = (showDiff: boolean, sign: number) => {
-    if (!showDiff || !sign) return undefined;
+const getValueClassName = (showDiff: boolean, sign: number) => {
+    let diff;
 
-    return sign > 0 ? 'plus' : 'minus';
+    if (showDiff && sign) {
+        diff = sign > 0 ? 'plus' : 'minus';
+    }
+
+    return block('value', {diff});
 };
 
 type Props = {
     value: number | null;
-    additionalValue: number | null;
+    versionedValue: number | null;
     viewType: AccountUsageViewType;
     formatType: 'bytes' | 'number';
 };
 
-export const DetailTableCell: FC<Props> = ({value, additionalValue, viewType, formatType}) => {
-    const totalValue = (value ?? 0) + (additionalValue ?? 0);
+export const DetailTableCell: FC<Props> = ({value, versionedValue, viewType, formatType}) => {
+    const totalValue = (value ?? 0) + (versionedValue ?? 0);
     const showDiff = viewType.endsWith('-diff');
     const sign = Math.sign(totalValue);
 
     const formatFn = formatType === 'bytes' ? format.Bytes : format.Number;
 
-    const valueClassName = block('value', {diff: getDiffClass(showDiff, sign)});
+    const valueClassName = getValueClassName(showDiff, sign);
 
-    return (
-        <Flex direction="column" alignItems="flex-end" className={block()}>
-            <span className={valueClassName}>
+    const formattedTotalValue = formatFn(totalValue);
+    const formattedValue = formatFn(value ?? 0);
+    const formattedVersionedValue = formatFn(versionedValue ?? 0);
+
+    const content = (
+        <Flex direction="column">
+            <div className={valueClassName}>
                 {showDiff && getRenderSign(sign)}
-                {formatFn(totalValue)}
-            </span>
+                {formattedTotalValue}
+            </div>
 
-            {additionalValue !== null && (
+            {versionedValue !== null && (
                 <Text variant="caption-2" color="secondary">
-                    {formatFn(value ?? 0)}, {formatFn(additionalValue)}
+                    {formattedValue}, {formattedVersionedValue}
                 </Text>
             )}
         </Flex>
     );
+
+    if (versionedValue === null) {
+        return content;
+    }
+
+    const tooltipItems: Array<MetaTableItem> = [
+        {key: 'totalValue', label: 'Total', value: totalValue},
+        {key: 'value', label: 'Committed', value},
+        {key: 'versionedValue', label: 'Uncommitted', value: versionedValue},
+    ];
+
+    return <Tooltip content={<MetaTable items={tooltipItems} />}>{content}</Tooltip>;
 };

--- a/packages/ui/src/ui/store/reducers/accounts/usage/account-usage-types.ts
+++ b/packages/ui/src/ui/store/reducers/accounts/usage/account-usage-types.ts
@@ -1,4 +1,122 @@
-export interface AccountUsageDataParams {
+export type AccountUsageMediumKey =
+    | 'cache'
+    | 'cloud'
+    | 'default'
+    | 'nvme_blobs'
+    | 'pigeons'
+    | 'samovar_journals'
+    | 'ssd_blobs'
+    | 'ssd_intermediate'
+    | 'ssd_journals'
+    | 'ssd_slots_physical'
+    | 'ssd_test';
+
+type AccountUsageVersionedKey =
+    | 'chunk_count'
+    | 'compressed_data_size'
+    | 'data_weight'
+    | 'direct_child_count'
+    | 'disk_space'
+    | 'erasure_disk_space'
+    | 'node_count'
+    | 'regular_disk_space'
+    | 'row_count'
+    | 'tablet_count'
+    | 'tablet_static_memory'
+    | 'uncompressed_data_size'
+    | `medium:${AccountUsageMediumKey}`;
+
+type AccountUsageMediumField = `medium:${AccountUsageMediumKey}`;
+
+export type AccountUsageField =
+    | 'access_time'
+    | 'account'
+    | 'approximate_row_count'
+    | 'chunk_count'
+    | 'chunk_host_cell_master_memory'
+    | 'compressed_data_size'
+    | 'creation_time'
+    | 'data_weight'
+    | 'depth'
+    | 'direct_child_count'
+    | 'disk_space'
+    | 'dynamic'
+    | 'erasure_disk_space'
+    | 'master_memory'
+    | 'modification_time'
+    | 'node_count'
+    | 'owner'
+    | 'path'
+    | 'path_patched'
+    | 'primary_medium'
+    | 'regular_disk_space'
+    | 'resource_usage'
+    | 'row_count'
+    | 'tablet_count'
+    | 'tablet_static_memory'
+    | 'type'
+    | 'uncompressed_data_size'
+    | 'versioned_resource_usage'
+    | AccountUsageMediumField;
+
+export type AccountUsageVersionedField<
+    K extends AccountUsageVersionedKey = AccountUsageVersionedKey,
+> = `versioned:${K}`;
+
+type AccountUsageBaseData = {
+    acl_status?: 'deny' | 'allow';
+
+    account: string;
+    path: string;
+    type: string;
+    owner: string | null;
+    creation_time: string | null;
+    modification_time: string | null;
+    access_time: string | null;
+
+    depth: number;
+    dynamic: boolean | null;
+    path_patched: string | null;
+    primary_medium: string | null;
+    approximate_row_count: number | null;
+
+    chunk_count: number;
+    chunk_host_cell_master_memory: number;
+    direct_child_count: number;
+    disk_space: number;
+    master_memory: number;
+    node_count: number;
+    tablet_count: number;
+    tablet_static_memory: number;
+
+    compressed_data_size: number | null;
+    data_weight: number | null;
+    erasure_disk_space: number | null;
+    regular_disk_space: number | null;
+    row_count: number | null;
+    uncompressed_data_size: number | null;
+
+    resource_usage: unknown;
+    versioned_resource_usage: unknown;
+};
+
+type AccountUsageMediumData = {
+    [K in AccountUsageMediumField]?: number | null;
+};
+
+type AccountUsageVersionedData = {
+    [K in AccountUsageVersionedKey as AccountUsageVersionedField<K>]?: number | null;
+};
+
+export type AccountUsageDataItem = AccountUsageBaseData &
+    AccountUsageMediumData &
+    AccountUsageVersionedData;
+
+type AccountUsageVersionedFields = {
+    [K in AccountUsageVersionedKey]: AccountUsageVersionedField<K>;
+};
+
+export type AccountUsageDataParams = {
     cluster: string;
     account: string;
 
@@ -7,7 +125,10 @@ export interface AccountUsageDataParams {
         size?: number; // 20
     };
 
-    sort_order?: Array<{field: string; desc?: boolean}>;
+    sort_order?: Array<{
+        field: string;
+        desc?: boolean;
+    }>;
 
     row_filter?: {
         owner?: string;
@@ -20,45 +141,12 @@ export interface AccountUsageDataParams {
             comparison: '<' | '>' | '==' | '<=' | '>=';
         }>;
     };
-}
+};
 
-export interface AccountUsageData {
-    fields: Array<keyof AccountUsageDataItem>;
-    mediums: Array<keyof AccountUsageDataItem>;
-
-    items: Array<AccountUsageDataItem>;
+export type AccountUsageData = {
+    fields: AccountUsageField[];
+    mediums: AccountUsageMediumKey[];
+    versioned_fields?: AccountUsageVersionedFields;
+    items: AccountUsageDataItem[];
     row_count: number;
-}
-
-type MediumKey = 'default' | 'cache' | string;
-
-export type MediumKeyTemplate = `medium:${MediumKey}`;
-export type VersionedKeyTemplate = `versioned:medium:${MediumKey}`;
-
-export type AccountUsageDataItem = {
-    acl_status?: 'deny' | 'allow';
-
-    account: string;
-    direct_child_count: number;
-    path: string;
-    type: string;
-    owner: string;
-    creation_time: string;
-    modification_time: string;
-
-    chunk_count: number;
-    disk_space: number;
-    master_memory: number;
-    node_count: number;
-    tablet_count: 0;
-    tablet_static_memory: 0;
-    'versioned:master_memory': null | number;
-    'versioned:chunk_count': null | number;
-    'versioned:direct_child_count': null | number;
-    'versioned:disk_space': null | number;
-    'versioned:node_count': null | number;
-    'versioned:recursive_versioned_resource_usage': null | number;
-    'versioned:tablet_count': null | number;
-    'versioned:tablet_static_memory': null | number;
-} & Record<`medium:${MediumKey}`, null | number> &
-    Record<`versioned:medium:${MediumKey}`, null | number>;
+};

--- a/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
+++ b/packages/ui/src/ui/store/selectors/accounts/account-usage.ts
@@ -14,7 +14,7 @@ import {
     selectSettingsAccountUsageColumnsTree,
 } from '../../../store/selectors/settings/settings-ts';
 import format from '../../../common/hammer/format';
-import {type AccountUsageDataItem} from '../../../store/reducers/accounts/usage/account-usage-types';
+import {type AccountUsageField} from '../../../store/reducers/accounts/usage/account-usage-types';
 
 const ACCOUNT_USAGE_COLUMN_TITLE: Record<string, string> = {
     approximate_row_count: '~Row count',
@@ -169,6 +169,47 @@ export const selectAccountUsageTreeDiffRowCount = (state: RootState) =>
 export const selectAccountUsageTreeDiffItemsBasePath = (state: RootState) =>
     state.accounts.usage.treeDiff.base_path;
 
+export const selectAccountUsageListVersionedFields = (state: RootState) =>
+    state.accounts.usage.list.response?.versioned_fields;
+
+export const selectAccountUsageTreeVersionedFields = (state: RootState) =>
+    state.accounts.usage.tree.response?.versioned_fields;
+
+export const selectAccountUsageListDiffVersionedFields = (state: RootState) =>
+    state.accounts.usage.listDiff.response?.versioned_fields;
+
+export const selectAccountUsageTreeDiffVersionedFields = (state: RootState) =>
+    state.accounts.usage.treeDiff.response?.versioned_fields;
+
+export const selectAccountUsageVersionedFields = createSelector(
+    [
+        selectAccountUsageViewType,
+        selectAccountUsageListVersionedFields,
+        selectAccountUsageTreeVersionedFields,
+        selectAccountUsageListDiffVersionedFields,
+        selectAccountUsageTreeDiffVersionedFields,
+    ],
+    (viewType, listFields, treeFields, listDiffFields, treeDiffFields) => {
+        switch (viewType) {
+            case 'list':
+            case 'list-plus-folders':
+                return listFields;
+
+            case 'list-diff':
+            case 'list-plus-folders-diff':
+                return listDiffFields;
+
+            case 'tree':
+                return treeFields;
+
+            case 'tree-diff':
+                return treeDiffFields;
+        }
+
+        return undefined;
+    },
+);
+
 export const selectIsAccountsUsageDiffView = createSelector(
     [selectAccountUsageViewType],
     (viewType) => {
@@ -296,7 +337,7 @@ export const selectAccountUsageAvailableColumns = createSelector(
     },
 );
 
-const defaultTreeColumns: Array<keyof AccountUsageDataItem> = [
+const defaultTreeColumns: AccountUsageField[] = [
     'owner',
     'disk_space',
     'medium:default',
@@ -305,9 +346,9 @@ const defaultTreeColumns: Array<keyof AccountUsageDataItem> = [
     'chunk_count',
     'node_count',
     'modification_time',
-] as any;
+];
 
-const defaultListColumns: Array<keyof AccountUsageDataItem> = [
+const defaultListColumns: AccountUsageField[] = [
     'owner',
     'disk_space',
     'medium:default',
@@ -315,9 +356,9 @@ const defaultListColumns: Array<keyof AccountUsageDataItem> = [
     'medium:nvme_blobs',
     'chunk_count',
     'modification_time',
-] as any;
+];
 
-const defaultListFoldersColumns: Array<keyof AccountUsageDataItem> = [
+const defaultListFoldersColumns: AccountUsageField[] = [
     'owner',
     'disk_space',
     'medium:default',
@@ -326,9 +367,9 @@ const defaultListFoldersColumns: Array<keyof AccountUsageDataItem> = [
     'chunk_count',
     'node_count',
     'modification_time',
-] as any;
+];
 
-function firstNotEmpty<T = keyof AccountUsageDataItem>(a1: Array<T>, a2: Array<T>): Array<T> {
+function firstNotEmpty<T = AccountUsageField>(a1: T[], a2: T[]): T[] {
     if (a1?.length) {
         return a1;
     }

--- a/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
@@ -5,7 +5,7 @@ import {selectSettingsData} from './settings-base';
 import {selectClusterNS, selectGetSetting} from '../../../store/selectors/settings';
 import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
 import {type AccountUsageViewType} from '../../../store/reducers/accounts/usage/accounts-usage-filters';
-import {type AccountUsageDataItem} from '../../../store/reducers/accounts/usage/account-usage-types';
+import {type AccountUsageField} from '../../../store/reducers/accounts/usage/account-usage-types';
 import {type ActiveJobTypesMap} from '../../../store/actions/settings/settings';
 import {type RootState} from '../../../store/reducers';
 import {NODE_TYPE} from '../../../../shared/constants/system';
@@ -120,21 +120,21 @@ export const selectSettingsAccountUsageViewType = createSelector(
 
 export const selectSettingsAccountUsageColumnsTree = createSelector(
     selectGetSetting,
-    (getSetting): Array<keyof AccountUsageDataItem> => {
+    (getSetting): AccountUsageField[] => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_TREE, NAMESPACES.ACCOUNTS);
     },
 );
 
 export const selectSettingsAccountUsageColumnsList = createSelector(
     selectGetSetting,
-    (getSetting): Array<keyof AccountUsageDataItem> => {
+    (getSetting): AccountUsageField[] => {
         return getSetting(SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_LIST, NAMESPACES.ACCOUNTS);
     },
 );
 
 export const selectSettingsAccountUsageColumnsListFolders = createSelector(
     selectGetSetting,
-    (getSetting): Array<keyof AccountUsageDataItem> => {
+    (getSetting): AccountUsageField[] => {
         return getSetting(
             SettingName.ACCOUNTS.ACCOUNTS_USAGE_COLUMNS_LIST_FOLDERS,
             NAMESPACES.ACCOUNTS,


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/LItwvK9k7fkNRt
<!-- nda-end -->         ## Summary by Sourcery

Add support for versioned resource usage fields in account usage data and surface them in the detailed usage UI, including combined values and enhanced sorting.

New Features:
- Expose versioned resource usage metadata for account usage items, including per-medium and versioned numeric fields.
- Display combined committed and uncommitted usage values in account details cells with a breakdown tooltip.
- Provide dedicated headers and sort controls for versioned usage fields, allowing separate sorting by committed and uncommitted values.

Enhancements:
- Refine account usage type definitions to use explicit field unions and structured versioned field mappings.
- Improve detailed usage table headers and icons based on view type, and adjust owner rendering for missing values.
- Introduce reusable toolkit utilities for safe object property checks and shared object helpers.