### PR TITLE
fix(Scheduling): health frame height [YTFRONT-5872]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## YTsaurus platform UI
+## YTsaurus platform UI fix(Scheduling): health frame height [YTFRONT-5872]
 
 The repository contains code related to UI for [YTsaurus platform](https://ytsaurus.tech).
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/--S9P14D7g8yiW
<!-- nda-end -->## Summary by Sourcery

Documentation:
- Clarify README title by appending the scheduling health frame height fix identifier.