### PR TITLE
chore(Pages): add i18n [YTFRONT-5069]

### DIFF
--- a/packages/ui/src/ui/containers/AppNavigation/AppNavigation.scss
+++ b/packages/ui/src/ui/containers/AppNavigation/AppNavigation.scss
@@ -16,6 +16,7 @@
         overflow: auto;
         min-width: 250px;
         overflow-x: hidden;
+        height: 100%;
     }
 
     [class*='gn-split-pane'] {

--- a/packages/ui/src/ui/containers/AppNavigation/PagesEditorPanel.tsx
+++ b/packages/ui/src/ui/containers/AppNavigation/PagesEditorPanel.tsx
@@ -44,7 +44,6 @@ export function PagesEditorPanel() {
             renderItem={(item) => <PagesEditorListItem {...item} onClick={handleClick} />}
             itemHeight={40}
             onSortEnd={handleSort}
-            virtualized
         />
     );
 }

--- a/packages/ui/src/ui/pages/app-pages/app-pages.ts
+++ b/packages/ui/src/ui/pages/app-pages/app-pages.ts
@@ -1,8 +1,8 @@
-import {registerPageIcon} from './constants/slideoutMenu';
-import {type UIFactoryClusterPageInfo} from './UIFactory';
+import {registerPageIcon} from '.../../constants/slideoutMenu';
+import {type UIFactoryClusterPageInfo} from '../../UIFactory';
 
 // TODO: use { Page } from constants/index.js
-import {Page} from './constants';
+import {Page} from '../../constants';
 
 export interface HeaderItem {
     id: string;

--- a/packages/ui/src/ui/pages/app-pages/app-pages.ts
+++ b/packages/ui/src/ui/pages/app-pages/app-pages.ts
@@ -1,8 +1,9 @@
-import {registerPageIcon} from '.../../constants/slideoutMenu';
+import {registerPageIcon} from '../../constants/slideoutMenu';
 import {type UIFactoryClusterPageInfo} from '../../UIFactory';
 
 // TODO: use { Page } from constants/index.js
 import {Page} from '../../constants';
+import i18n from './i18n';
 
 export interface HeaderItem {
     id: string;
@@ -11,99 +12,146 @@ export interface HeaderItem {
     hidden?: boolean;
 }
 
-const pages: Array<HeaderItem> = [
+export const APP_PAGES: Array<HeaderItem> = [
     {
         id: Page.NAVIGATION,
-        name: 'Navigation',
+        get name() {
+            return i18n('title_navigation');
+        },
         header: true,
     },
     {
         id: Page.FLOWS,
-        name: 'Flow pipelines',
+        get name() {
+            return i18n('title_flow-pipelines');
+        },
         hidden: true,
     },
     {
         id: Page.OPERATIONS,
-        name: 'Operations',
+        get name() {
+            return i18n('title_operations');
+        },
         header: true,
     },
     {
         id: Page.SCHEDULING,
-        name: 'Scheduling',
+        get name() {
+            return i18n('title_scheduling');
+        },
     },
     {
         id: Page.COMPONENTS,
-        name: 'Components',
+        get name() {
+            return i18n('title_components');
+        },
     },
     {
         id: Page.DASHBOARD,
-        name: 'Dashboard',
+        get name() {
+            return i18n('title_dashboard');
+        },
         header: true,
     },
     {
         id: Page.ACCOUNTS,
-        name: 'Accounts',
+        get name() {
+            return i18n('title_accounts');
+        },
     },
     {
         id: Page.TABLET_CELL_BUNDLES,
-        name: 'Bundles',
+        get name() {
+            return i18n('title_bundles');
+        },
     },
     {
         id: Page.GROUPS,
-        name: 'Groups',
+        get name() {
+            return i18n('title_groups');
+        },
     },
     {
         id: Page.USERS,
-        name: 'Users',
+        get name() {
+            return i18n('title_users');
+        },
     },
     {
         id: Page.PATH_VIEWER,
-        name: 'Path Viewer',
+        get name() {
+            return i18n('title_path-viewer');
+        },
     },
     {
         id: Page.JOB,
-        name: 'Job',
+        get name() {
+            return i18n('title_job');
+        },
         hidden: true,
     },
     {
         id: Page.TABLET,
-        name: 'Tablet',
+        get name() {
+            return i18n('title_tablet');
+        },
         hidden: true,
     },
     {
         id: Page.BAN,
-        name: 'Banned',
+        get name() {
+            return i18n('title_banned');
+        },
         hidden: true,
     },
     {
         id: Page.SYSTEM,
-        name: 'System',
+        get name() {
+            return i18n('title_system');
+        },
         header: true,
     },
     {
         id: Page.VERSIONS,
-        name: 'Versions',
+        get name() {
+            return i18n('title_versions');
+        },
     },
     {
         id: Page.QUERIES,
-        name: 'Queries',
+        get name() {
+            return i18n('title_queries');
+        },
     },
     {
         id: Page.CHYT,
-        name: 'Cliques',
+        get name() {
+            return i18n('title_cliques');
+        },
     },
 ];
 
-export function registerExtraPage({pageId, title, svgIcon}: UIFactoryClusterPageInfo) {
-    const page = pages.find(({id}) => id === pageId);
+export function registerExtraPage(item: UIFactoryClusterPageInfo) {
+    const {pageId, title, svgIcon} = item;
+    const page = APP_PAGES.find(({id}) => id === pageId);
     if (page) {
         throw new Error(`Cannot register an item with duplicated pageId: ${pageId}`);
     }
-    pages.push({id: pageId, name: title});
+    const res = {id: pageId, name: title};
+    copyDescriptor(item, 'title', res, 'name');
+    APP_PAGES.push(res);
 
     if (svgIcon) {
         registerPageIcon(pageId, svgIcon);
     }
 }
 
-export default pages;
+function copyDescriptor<
+    SrcT extends object,
+    SrcK extends keyof SrcT,
+    DstT extends Record<DstK, SrcT[SrcK]>,
+    DstK extends string,
+>(src: SrcT, srcKey: SrcK, dst: DstT, dstKey: DstK) {
+    const descriptor = Object.getOwnPropertyDescriptor(src, srcKey);
+    Object.defineProperty(dst, dstKey, descriptor!);
+}

--- a/packages/ui/src/ui/pages/app-pages/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/app-pages/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/app-pages/i18n/en.json
+++ b/packages/ui/src/ui/pages/app-pages/i18n/en.json
@@ -1,0 +1,20 @@
+{
+  "title_navigation": "Navigation",
+  "title_flow-pipelines": "Flow pipelines",
+  "title_operations": "Operations",
+  "title_scheduling": "Scheduling",
+  "title_components": "Components",
+  "title_dashboard": "Dashboard",
+  "title_accounts": "Accounts",
+  "title_bundles": "Bundles",
+  "title_groups": "Groups",
+  "title_users": "Users",
+  "title_path-viewer": "Path Viewer",
+  "title_job": "Job",
+  "title_tablet": "Tablet",
+  "title_banned": "Banned",
+  "title_system": "System",
+  "title_versions": "Versions",
+  "title_queries": "Queries",
+  "title_cliques": "Cliques"
+}

--- a/packages/ui/src/ui/pages/app-pages/i18n/index.ts
+++ b/packages/ui/src/ui/pages/app-pages/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:app-pages', dicts);

--- a/packages/ui/src/ui/store/reducers/index.main.ts
+++ b/packages/ui/src/ui/store/reducers/index.main.ts
@@ -34,7 +34,7 @@ import chaosCellBundleEditor from './chaos_cell_bundles/tablet-cell-bundle-edito
 import {manageTokens} from './manage-tokens';
 import executeBatch from '../../store/reducers/execute-batch';
 import UIFactory, {type UIFactoryClusterPageInfo} from '../../UIFactory';
-import {registerExtraPage} from '../../pages';
+import {registerExtraPage} from '../../pages/app-pages/app-pages';
 import {registerLocationParameters} from '../../store/location';
 import {registerHeaderLink} from '../../containers/ClustersMenu/header-links-items';
 import {queryTracker} from './query-tracker';

--- a/packages/ui/src/ui/store/reducers/slideoutMenu.js
+++ b/packages/ui/src/ui/store/reducers/slideoutMenu.js
@@ -2,7 +2,7 @@ import forEach_ from 'lodash/forEach';
 
 import hammer from '../../common/hammer';
 import {JOIN_MENU_ITEMS, SPLIT_MENU_ITEMS} from '../../constants';
-import pages from '../../pages';
+import {APP_PAGES} from '../../pages/app-pages/app-pages';
 
 function prepareClusters(clustersObj) {
     const sortByClusterName = (clusterA, clusterB) => {
@@ -15,7 +15,7 @@ function prepareClusters(clustersObj) {
 
 export const initialState = {
     pages: {
-        all: pages,
+        all: APP_PAGES,
         recent: [],
         rest: [],
     },


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/mL6Eq-m67gHbBn
<!-- nda-end --> ## Summary by Sourcery

Introduce an i18n-enabled app pages registry and wire it into navigation and menu state.

New Features:
- Add a centralized APP_PAGES registry with i18n-based titles and support for registering extra pages at runtime.

Enhancements:
- Update slideout menu state to consume the new APP_PAGES registry instead of the legacy pages list.
- Adjust AppNavigation layout styles to make the side panel fill available height and simplify the pages editor list virtualization settings.