### PR TITLE
fix(Queries): do not disable the start until the controller responds …

### DIFF
--- a/packages/ui/src/shared/constants/settings-types.ts
+++ b/packages/ui/src/shared/constants/settings-types.ts
@@ -153,6 +153,7 @@ interface QueryTrackerSettings {
     'global::queryTracker::useNewGraphView': boolean;
     'global::queryTracker::graphAutoCenter': boolean;
     'global::queryTracker::suggestions': boolean;
+    'global::queryTracker::disableCliqueReadinessCheck': boolean;
     'global::queryTracker::lastEngine': QueryEngine;
     'global::queryTracker::tokens': QueryToken[];
 }

--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/i18n/en.json
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/i18n/en.json
@@ -14,5 +14,7 @@
   "context_query-assistant-description": "Use query assistant to autocomplete",
   "context_tab-accept-suggestion": "[Tab] - accept suggestion",
   "context_esc-decline-suggestion": "[Esc] - decline suggestion",
+  "field_disable-clique-readiness-check": "Disable clique readiness check",
+  "context_disable-clique-readiness-check-description": "The system will not block query execution even if the clique is inactive",
   "title_query-token": "Request tokens"
 }

--- a/packages/ui/src/ui/containers/SettingsPanel/queriesPage/index.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/queriesPage/index.tsx
@@ -86,6 +86,16 @@ export const queriesPage = ({cluster, hasQuerySuggestions}: Props) => {
                       ),
                   ]
                 : []),
+            makeItem(
+                'global::queryTracker::disableCliqueReadinessCheck',
+                i18n('field_disable-clique-readiness-check'),
+                'top',
+                <BooleanSettingItem
+                    settingKey="global::queryTracker::disableCliqueReadinessCheck"
+                    description={i18n('context_disable-clique-readiness-check-description')}
+                    oneLine
+                />,
+            ),
             makeItem('addQtTokenForm', i18n('title_query-token'), 'top', <LazyAddQueryTokenForm />),
             makeItem('existingQtTokenList', '', 'top', <LazyQueryTokenList />),
         ]),

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/CliqueDisabledBlock.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/CliqueDisabledBlock.tsx
@@ -1,0 +1,29 @@
+import React, {type FC} from 'react';
+import {Flex, Icon, Text} from '@gravity-ui/uikit';
+import {RoutedLink} from '../../../../../containers/RoutedLink/RoutedLink';
+import i18n from './i18n';
+import {useSelector} from '../../../../../store/redux-hooks';
+import {
+    selectQueryDraftCluster,
+    selectQueryDraftSettings,
+} from '../../../../../store/selectors/query-tracker/query';
+import TriangleExclamationIcon from '@gravity-ui/icons/svgs/triangle-exclamation.svg';
+
+export const CliqueDisabledBlock: FC = () => {
+    const queryCluster = useSelector(selectQueryDraftCluster);
+    const {clique} = useSelector(selectQueryDraftSettings);
+
+    return (
+        <>
+            <Flex gap={1} alignItems="center">
+                <Text color="danger">
+                    <Icon data={TriangleExclamationIcon} size={16} />
+                </Text>
+                <Text>{i18n('context_clique-inactive')}</Text>
+            </Flex>
+            <RoutedLink href={`/${queryCluster}/chyt/${clique}`} target="_blank">
+                {i18n('action_open-clique-page')}
+            </RoutedLink>
+        </>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/i18n/en.json
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "context_clique-inactive": "Clique is inactive",
+  "action_open-clique-page": "Open clique page"
+}

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/i18n/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:query-tracker.clique-disabled-block', dicts);

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/CliqueDisabledBlock/index.ts
@@ -1,0 +1,1 @@
+export {CliqueDisabledBlock} from './CliqueDisabledBlock';

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/QueryEditorView.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../../store/selectors/query-tracker/query';
 import {selectIsSupportedQtACO} from '../../../../store/selectors/query-tracker/queryAco';
 import {loadCliqueByCluster, runQuery} from '../../../../store/actions/query-tracker/query';
-import {Button, Flex, Icon, Text} from '@gravity-ui/uikit';
+import {Button, Flex, Icon} from '@gravity-ui/uikit';
 import playIcon from '../../../../assets/img/svg/play.svg';
 import {QueryEngine} from '../../../../../shared/constants/engines';
 import {QueryACOSelect} from '../../QueryACO/QueryACOSelect';
@@ -19,7 +19,7 @@ import cn from 'bem-cn-lite';
 import '../QueryEditorView.scss';
 import {QueryEditorMonaco} from '../QueryEditorMonaco';
 import i18n from './i18n';
-import TriangleExclamationIcon from '@gravity-ui/icons/svgs/triangle-exclamation.svg';
+import {CliqueDisabledBlock} from './CliqueDisabledBlock';
 
 const b = cn('yt-qt-query-editor-view');
 
@@ -110,7 +110,7 @@ export const QueryEditorView = memo<Props>(function QueryEditorView({
             <QueryEditorMonaco pathNavigation={pathNavigation} />
             <div className={b('actions')}>
                 <div className="query-run-action">
-                    <Flex gap={1} alignItems="center">
+                    <Flex gap={2} alignItems="center">
                         <Button
                             qa="qt-run"
                             view="action"
@@ -121,14 +121,7 @@ export const QueryEditorView = memo<Props>(function QueryEditorView({
                             {i18n('action_run')}
                         </Button>
 
-                        {runButtonDisabled && (
-                            <>
-                                <Text color="danger">
-                                    <Icon data={TriangleExclamationIcon} size={16} />
-                                </Text>
-                                <span>{i18n('tooltip_clique_inactive')}</span>
-                            </>
-                        )}
+                        {runButtonDisabled && <CliqueDisabledBlock />}
                     </Flex>
 
                     {isRunButtonActive && (

--- a/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/i18n/en.json
+++ b/packages/ui/src/ui/pages/query-tracker/QueryEditor/QueryEditorView/i18n/en.json
@@ -1,6 +1,5 @@
 {
   "action_run": "Run",
   "action_validate": "Validate",
-  "action_explain": "Explain",
-  "tooltip_clique_inactive": "Clique is inactive"
+  "action_explain": "Explain"
 }

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -9,6 +9,7 @@ import {
     isSingleProgress,
 } from '../../../types/query-tracker/api';
 import {
+    selectDisableCliqueReadinessCheck,
     selectSettingQueryTrackerStage,
     selectSettingQueryTrackerYQLAgentStage,
 } from '../settings/settings-ts';
@@ -66,10 +67,17 @@ export const selectIsQueryExecuted = (state: RootState): boolean => {
 export const selectCurrentQuery = (state: RootState) => selectQueryState(state).queryItem;
 
 export const selectIsQueryButtonActive = createSelector(
-    [selectQueryEngine, selectQueryDraftSettings, selectCliqueMap],
-    (engine, settings, cliqueMap) => {
+    [
+        selectQueryEngine,
+        selectQueryDraftSettings,
+        selectCliqueMap,
+        selectDisableCliqueReadinessCheck,
+    ],
+    (engine, settings, cliqueMap, disableCliqueReadinessCheck) => {
         const isChyt = engine === QueryEngine.CHYT;
         if (!isChyt) return true;
+
+        if (disableCliqueReadinessCheck) return true;
 
         const {clique, cluster} = settings;
         if (!clique || !cluster) return true;

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -20,6 +20,7 @@ import {selectQueryResults} from './queryResult';
 import {selectDefaultQueryACO, selectIsMultipleAco} from './queryAco';
 import {QueryEngine, QueryEnginesNames} from '../../../../shared/constants/engines';
 import {selectClusterSupportedEngines} from '../global';
+import isEmpty_ from 'lodash/isEmpty';
 
 const QT_STAGE = getQueryTrackerStage();
 const selectQueryState = (state: RootState) => state.queryTracker.query;
@@ -73,6 +74,10 @@ export const selectIsQueryButtonActive = createSelector(
         const {clique, cluster} = settings;
         if (!clique || !cluster) return true;
 
+        if (isEmpty_(cliqueMap)) {
+            return true;
+        }
+
         if (cluster in cliqueMap) {
             const chytList = cliqueMap[cluster]?.chyt;
             if (!chytList) {
@@ -82,7 +87,7 @@ export const selectIsQueryButtonActive = createSelector(
             const currentClique = chytList.find((i) => i.alias === clique);
             if (!currentClique) return false;
 
-            return currentClique.state === 'active';
+            return currentClique.state === 'active' && currentClique.health === 'good';
         }
 
         return false;

--- a/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
@@ -30,7 +30,6 @@ export const selectLastUserChoiceYqlVersion = createSelector(
         return data[`local::${settings?.cluster}::queryTracker::lastYqlVersion`];
     },
 );
-
 export const selectQueryTokens = createSelector([selectSettingsData], (data) => {
     return data['global::queryTracker::tokens'] || [];
 });

--- a/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-ts.ts
@@ -38,6 +38,10 @@ export const selectSettingsQueryTrackerGraphAutoCenter = createSelector(
     },
 );
 
+export const selectDisableCliqueReadinessCheck = createSelector(selectSettingsData, (data) => {
+    return data['global::queryTracker::disableCliqueReadinessCheck'] || false;
+});
+
 export const selectSettingsEditorVimMode = createSelector(selectSettingsData, (data) => {
     return data['global::editor::vimMode'] || false;
 });


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/vkiN4dmv7gNjuz
<!-- nda-end --> …[YTFRONT-5818]

## Summary by Sourcery

Improve CHYT clique handling in the query tracker by making the run button depend on clique health and providing both a configurable readiness check and clearer UI feedback when a clique is inactive.

New Features:
- Add a user setting to disable readiness checks for CHYT cliques when deciding if the query run button is enabled

Enhancements:
- Tighten query run button availability for CHYT by requiring both active state and good health for the selected clique
- Replace the inline inactive-clique warning in the query editor with a dedicated CliqueDisabledBlock component that includes a link to the clique page