### PR TITLE
fix(PreloadError): cluster name is not replaced [YTFRONT-5883]

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,4 +1,4 @@
-## YTsaurus platform interface
+## YTsaurus platform interface YTFRONT-5883
 
 User interface for a [YTsaurus platform](https://ytsaurus.tech) cluster.
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Y-HlXKon7gTSqQ
<!-- nda-end -->## Summary by Sourcery

Documentation:
- Adjust UI package README heading to mention the YTFRONT-5883 identifier.