### PR TITLE
feat(Operation): add ACL tab [YTFRONT-5158]

### DIFF
--- a/packages/ui/src/shared/constants/yt-api-id.ts
+++ b/packages/ui/src/shared/constants/yt-api-id.ts
@@ -104,6 +104,8 @@ export const enum YTApiId {
 
     listOperations = 'listOperations',
 
+    operationGetRuntimeParameters = 'operationGetRuntimeParameters',
+    operationUpdateRuntimeParameters = 'operationUpdateRuntimeParameters',
     operationGetJobs = 'operationGetJobs',
     operationIntermediateResourceUsage = 'operationIntermediateResourceUsage',
     operationIsEphemeral = 'operationIsEphemeral',

--- a/packages/ui/src/ui/UIFactory/default-ui-factory.tsx
+++ b/packages/ui/src/ui/UIFactory/default-ui-factory.tsx
@@ -260,6 +260,10 @@ export const defaultUIFactory: UIFactory = {
         return <DefaultSubjectLinkLazy {...props} />;
     },
 
+    fetchSubejectNames() {
+        return Promise.resolve(new Map());
+    },
+
     makeSupportContent(_x, makeContent) {
         const {reportBugUrl} = uiSettings;
         if (!reportBugUrl) {

--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -417,6 +417,10 @@ export interface UIFactory {
     }): React.ReactNode;
 
     renderSubjectCard(props: SubjectCardProps): React.ReactNode;
+    fetchSubejectNames(params: {
+        cluster: string;
+        subjects: Array<Pick<SubjectCardProps, 'name' | 'type'>>;
+    }): Promise<Map<string, {title: string; internal?: boolean; url?: string; isTvm?: boolean}>>;
 
     makeSupportContent(
         params: {login: string; cluster?: string; buttonToWrap?: React.ReactNode},

--- a/packages/ui/src/ui/constants/acl.ts
+++ b/packages/ui/src/ui/constants/acl.ts
@@ -17,6 +17,7 @@ export const IdmObjectType = {
     TABLET_CELL_BUNDLE: 'tablet_cell_bundle',
     ACCESS_CONTROL_OBJECT: 'access_control_object',
     UI_EFFECTIVE_ACL: 'ui_effective_acl',
+    OPERATION: 'operation',
 } as const;
 
 export const REGISTER_QUEUE_CONSUMER = 'register_queue_consumer';
@@ -128,6 +129,16 @@ export const PERMISSIONS_SETTINGS: Record<IdmKindType, PermissionSettings> = {
         allowInheritAcl: false,
         allowInheritResponsibles: false,
         allowDeleteWithoutRevisionCheck: true,
+    },
+    [IdmObjectType.OPERATION]: {
+        permissionTypes: ['read', 'manage', 'administer'],
+        permissionsToRequest: [['read'], ['manage'], ['administer']],
+        allowBossApprovals: false,
+        allowReadApprovers: false,
+        allowAuditors: false,
+        allowInheritAcl: false,
+        allowInheritResponsibles: false,
+        allowDeleteWithoutRevisionCheck: false,
     },
 };
 

--- a/packages/ui/src/ui/constants/operations/detail.ts
+++ b/packages/ui/src/ui/constants/operations/detail.ts
@@ -21,6 +21,7 @@ export const Tab = {
     PERFORMANCE: 'performance',
     INCARNATIONS: 'incarnations',
     LOGS: 'logs',
+    ACL: 'acl'
 } as const;
 
 export type OperationTabType = ValueOf<typeof Tab>;

--- a/packages/ui/src/ui/containers/ACL/ACL-types.ts
+++ b/packages/ui/src/ui/containers/ACL/ACL-types.ts
@@ -1,7 +1,5 @@
-import {
-    type ObjectPermissionRowWithExpand,
-    type PreparedApprover,
-} from '../../store/selectors/acl/acl';
+import {ObjectPermissionRowWithExpand} from '../../utils/acl/acl-aggregate';
+import {type PreparedApprover} from '../../store/selectors/acl/acl';
 
 export type ApproverRow = PreparedApprover & {
     aggregated_row_access_predicates?: Array<string>;

--- a/packages/ui/src/ui/containers/ACL/ACL-types.ts
+++ b/packages/ui/src/ui/containers/ACL/ACL-types.ts
@@ -1,0 +1,13 @@
+import {
+    type ObjectPermissionRowWithExpand,
+    type PreparedApprover,
+} from '../../store/selectors/acl/acl';
+
+export type ApproverRow = PreparedApprover & {
+    aggregated_row_access_predicates?: Array<string>;
+    expanded?: boolean;
+};
+export type PermissionsRow = ObjectPermissionRowWithExpand & {
+    aggregated_row_access_predicates?: Array<string>;
+    expanded?: boolean;
+};

--- a/packages/ui/src/ui/containers/ACL/ACL.scss
+++ b/packages/ui/src/ui/containers/ACL/ACL.scss
@@ -16,127 +16,11 @@
         }
     }
 
-    &__object-permissions {
-        #{$acl}__permissions {
-            display: flex;
-            align-items: baseline;
-
-            .elements-text {
-                white-space: normal;
-            }
-
-            &_type_allow {
-                .icon {
-                    color: var(--success-color);
-                    margin-right: 4px;
-                    padding: 0 5px;
-                }
-            }
-
-            &_type_deny {
-                .icon {
-                    color: var(--danger-color);
-                    margin-right: 7px;
-                }
-            }
-        }
-
-        #{$acl}__subjects {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-
-            .icon {
-                margin-left: 16px;
-            }
-        }
-    }
-
     &__acl-actions {
         flex-grow: 1;
         justify-content: end;
     }
 
-    &__row {
-        &-transparent {
-            opacity: 0.5;
-        }
-
-        &_depriving {
-            opacity: 0.5;
-            background-color: var(--danger-background);
-        }
-        &_approved,
-        &_requested {
-            opacity: 0.5;
-            background-color: var(--g-color-base-misc-light);
-        }
-    }
-
-    & &__table-item {
-        box-sizing: border-box;
-        padding-left: 4px;
-        padding-right: 4px;
-
-        &_type_expand {
-            padding-left: 2px;
-            padding-right: 2px;
-        }
-
-        &_type_subjects {
-            max-width: 320px;
-            .yt-subject-link {
-                display: flex;
-            }
-            .yc-popover {
-                display: block;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-        }
-
-        &_type_permissions {
-            max-width: 320px;
-        }
-
-        &_type_approve-type {
-            width: calc(270px + 160px);
-        }
-
-        &_type_inheritance-mode {
-            width: 160px;
-            max-width: 200px;
-        }
-
-        &_type_actions {
-            width: 85px;
-
-            .g-button {
-                margin-top: -4px;
-                margin-bottom: -4px;
-            }
-        }
-
-        &_type_columns {
-            width: 575px;
-            white-space: normal;
-        }
-    }
-
-    &__subject-with-tvm {
-        flex-grow: 1;
-        display: flex;
-        align-items: baseline;
-        justify-content: space-between;
-    }
-
-    &__row_unrecognized {
-        background-color: var(--g-color-base-danger-light);
-
-        &:hover {
-            --hover-background: var(--g-color-base-danger-light-hover);
-        }
-    }
 
     &__meta-item {
         margin-bottom: 20px;
@@ -154,22 +38,8 @@
         margin-left: 1ex;
     }
 
-    &__action-label {
-        text-align: center;
-        min-width: 5ex;
-        margin-right: 1ex;
-        font-weight: unset;
-        flex-shrink: 0;
-    }
-
     .data-table__row:not(:last-child) {
         border-bottom: 1px solid var(--g-color-line-generic);
-    }
-
-    &__subject {
-        &_level_1 {
-            padding-left: 28px;
-        }
     }
 
     &__toolbar {
@@ -189,16 +59,5 @@
 
     &__sync-with-col-groups {
         visibility: hidden;
-    }
-
-    &__inherited {
-        padding-right: 8px;
-        &_hidden {
-            visibility: hidden;
-        }
-    }
-
-    &__inherited-icon {
-        vertical-align: middle;
     }
 }

--- a/packages/ui/src/ui/containers/ACL/ACL.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL.tsx
@@ -1,43 +1,29 @@
-import {type Column} from '@gravity-ui/react-data-table';
-import {ClipboardButton, Flex, Icon, Loader} from '@gravity-ui/uikit';
-import {Tooltip} from '@ytsaurus/components';
+import {Flex, Loader} from '@gravity-ui/uikit';
 import cn from 'bem-cn-lite';
 import compact_ from 'lodash/compact';
 import React, {Component, Fragment} from 'react';
-import aclInheritedSvg from '../../assets/img/svg/acl-inherited.svg';
-import hammer from '../../common/hammer';
-import {DataTableYT} from '../../components/DataTableYT';
-import ErrorBoundary from '../../containers/ErrorBoundary/ErrorBoundary';
-import {ExpandButton} from '../../components/ExpandButton';
-import Label from '../../components/Label';
-import LoadDataHandler from '../../containers/LoadDataHandler/LoadDataHandler';
 import {
     SegmentControl,
     type SegmentControlItem,
 } from '../../components/SegmentControl/SegmentControl';
-import {SubjectCard} from '../../components/SubjectLink/SubjectLink';
-import WithStickyToolbar from '../../components/WithStickyToolbar/WithStickyToolbar';
 import {isIdmAclAvailable} from '../../config';
 import {AclMode, IdmObjectType} from '../../constants/acl';
+import ErrorBoundary from '../../containers/ErrorBoundary/ErrorBoundary';
+import LoadDataHandler from '../../containers/LoadDataHandler/LoadDataHandler';
 import withVisible, {type WithVisibleProps} from '../../hocs/withVisible';
-import {
-    type ObjectPermissionRowWithExpand,
-    type PreparedApprover,
-} from '../../store/selectors/acl/acl';
 import UIFactory, {type AclRoleActionsType} from '../../UIFactory';
 import {type PreparedRole, isGranted} from '../../utils/acl';
-import {type PreparedAclSubject} from '../../utils/acl/acl-types';
 import {type ACLReduxProps} from './ACL-connect-helpers';
+import {type ApproverRow, type PermissionsRow} from './ACL-types';
 import './ACL.scss';
 import {AclActions} from './AclActions/AclActions';
-import {AclColumnsCell} from './AclColumnsCell';
 import {AclModeControl} from './AclModeControl';
+import {AclTableWithToolbar} from './AclTableWithToolbar/AclTableWithToolbar';
 import ApproversFilters from './ApproversFilters/ApproversFilters';
 import ColumnGroups from './ColumnGroups/ColumnGroups';
 import DeletePermissionModal from './DeletePermissionModal/DeletePermissionModal';
+import {getAclColumns} from './hooks/use-acl-columns/use-acl-columns';
 import i18n from './i18n';
-import i18nPermissionValues from './i18n-permission-values';
-import {InheritanceMessage} from './InheritanceMessage/InheritanceMessage';
 import {MyPermissions} from './MyPermissinos/MyPermissions';
 import ObjectPermissionsFilters from './ObjectPermissionsFilters/ObjectPermissionsFilters';
 import {RowGroups} from './RowGroups/RowGroups';
@@ -45,15 +31,6 @@ import {RowGroups} from './RowGroups/RowGroups';
 const block = cn('navigation-acl');
 
 type Props = ACLReduxProps & WithVisibleProps & {className?: string};
-
-type ApproverRow = PreparedApprover & {
-    aggregated_row_access_predicates?: Array<string>;
-    expanded?: boolean;
-};
-type PermissionsRow = ObjectPermissionRowWithExpand & {
-    aggregated_row_access_predicates?: Array<string>;
-    expanded?: boolean;
-};
 
 class ACL extends Component<Props> {
     static tableColumns = {
@@ -106,67 +83,6 @@ class ACL extends Component<Props> {
         },
     };
 
-    // eslint-disable-next-line react/sort-comp
-    static renderSubjectLink(item: PreparedAclSubject | PreparedApprover | PermissionsRow) {
-        const {internal} = item;
-        if (internal) {
-            const [subject] = item.subjects;
-            const [type] = item.types ?? [];
-            return (
-                <SubjectCard
-                    name={subject!}
-                    type={type === 'group' ? 'group' : 'user'}
-                    internal
-                    showIcon
-                />
-            );
-        }
-
-        if (item.subjectType === 'user') {
-            const {subjectUrl} = item;
-            const username = item.subjects[0];
-            return <SubjectCard url={subjectUrl} name={username as string} showIcon />;
-        }
-
-        if (item.subjectType === 'tvm') {
-            const tvmId = item.subjects[0];
-            const {name} = item.tvmInfo ?? {};
-
-            const text = `${name} (${tvmId})`;
-            return (
-                <div className={block('subject-with-tvm')}>
-                    <SubjectCard url={item.subjectUrl} name={text} type="tvm" showIcon />
-                    <Label text="TVM" />
-                </div>
-            );
-        }
-
-        const {name, url, group} = item.groupInfo || {};
-        const {group_type} = item;
-        return (
-            <Tooltip
-                content={
-                    group && (
-                        <React.Fragment>
-                            idm-group:{group}
-                            <span className={block('copy-idm-group')}>
-                                <ClipboardButton text={`idm-group:${group}`} size="s" />
-                            </span>
-                        </React.Fragment>
-                    )
-                }
-            >
-                <SubjectCard
-                    name={name ?? group!}
-                    url={url}
-                    type="group"
-                    groupType={group_type}
-                    showIcon
-                />
-            </Tooltip>
-        );
-    }
-
     state = {
         deleteItem: {} as {key?: string},
     };
@@ -186,171 +102,6 @@ class ACL extends Component<Props> {
         }
     }
 
-    getColumnsTemplates<T extends ApproverRow | PermissionsRow>({
-        hasInherited,
-        mode,
-    }: {
-        hasInherited?: boolean;
-        mode: 'responsible' | 'permissions';
-    }) {
-        const openDeleteModal = this.handleDeletePermissionClick;
-        const {idmKind, toggleExpandAclSubject} = this.props;
-        return {
-            expand: {
-                name: '',
-                align: 'right',
-                className: block('table-item', {type: 'expand'}),
-                render({row}) {
-                    const expanded = 'expanded' in row ? row.expanded : undefined;
-                    return expanded === undefined ? null : (
-                        <ExpandButton
-                            inline
-                            expanded={expanded}
-                            toggleExpanded={() => {
-                                toggleExpandAclSubject(row.subjects[0]);
-                            }}
-                            qa="acl-expand"
-                        />
-                    );
-                },
-                width: 36,
-            } as Column<T>,
-            subjects: {
-                name: i18n('field_subjects'),
-                align: 'left',
-                className: block('table-item', {type: 'subjects'}),
-                render({row}) {
-                    const {requestPermissionsFlags = {}} = UIFactory.getAclApi();
-
-                    const {inheritedFrom} = row;
-
-                    const level = 'level' in row ? row.level : undefined;
-                    return (
-                        <Flex className={block('subject', {level: String(level)})} wrap gap={1}>
-                            {Boolean(hasInherited) && (
-                                <Tooltip
-                                    content={<InheritanceMessage data={inheritedFrom} />}
-                                    placement={['top-start']}
-                                >
-                                    <div className={block('inherited', {hidden: !row.inherited})}>
-                                        <Icon
-                                            className={block('inherited-icon')}
-                                            data={aclInheritedSvg}
-                                            size={16}
-                                        />
-                                    </div>
-                                </Tooltip>
-                            )}
-                            <Flex grow wrap gap={1}>
-                                {ACL.renderSubjectLink(row)}
-                            </Flex>
-                            {Object.keys(requestPermissionsFlags).map((key, index) => {
-                                const flagInfo = requestPermissionsFlags[key];
-                                return (
-                                    <React.Fragment key={index}>
-                                        {flagInfo.renderIcon(row)}
-                                    </React.Fragment>
-                                );
-                            })}
-                        </Flex>
-                    );
-                },
-            } as Column<T>,
-            permissions: {
-                name: i18n('field_permissions'),
-                align: 'left',
-                className: block('table-item', {type: 'permissions'}),
-                render({row}) {
-                    const action = row.action === 'deny' ? 'deny' : 'allow';
-                    const theme = action === 'deny' ? 'danger' : 'success';
-
-                    return (
-                        <div className={block('permissions', {type: row.action})}>
-                            <Label className={block('action-label')} theme={theme}>
-                                {i18nPermissionValues(`action_${action}`)}
-                            </Label>
-                            <AclColumnsCell
-                                withQoutes
-                                items={row.permissions?.map((item) =>
-                                    i18nPermissionValues(`value_${item}`),
-                                )}
-                                expanadable={'expanded' in row}
-                            />
-                        </div>
-                    );
-                },
-            } as Column<T>,
-            inheritance_mode: {
-                name: i18n('field_inheritance-mode'),
-                render({row}) {
-                    const {inheritance_mode: mode} = row;
-                    return mode === undefined
-                        ? hammer.format.NO_VALUE
-                        : i18nPermissionValues(`inheritance_mode_${mode}`);
-                },
-                align: 'left',
-                className: block('table-item', {type: 'inheritance-mode'}),
-            } as Column<T>,
-            actions: {
-                name: 'actions',
-                header: '',
-                align: 'right',
-                className: block('table-item', {type: 'actions'}),
-                render({row}) {
-                    const expanded = 'expanded' in row ? row.expanded : undefined;
-                    const RoleActions = UIFactory.getComponentForAclRoleActions();
-                    return expanded !== undefined
-                        ? null
-                        : RoleActions !== undefined && (
-                              <RoleActions
-                                  mode={mode}
-                                  role={row}
-                                  idmKind={idmKind}
-                                  onDelete={openDeleteModal}
-                              />
-                          );
-                },
-            } as Column<T>,
-            approve_type: {
-                name: i18n('field_type'),
-                align: 'left',
-                className: block('table-item', {type: 'approve-type'}),
-                render({row}) {
-                    return hammer.format['Readable'](row.type);
-                },
-            } as Column<T>,
-            columns: {
-                name: i18n('field_private-columns'),
-                align: 'left',
-                className: block('table-item', {type: 'columns'}),
-                render({row}) {
-                    return <AclColumnsCell items={row.columns} expanadable={'expanded' in row} />;
-                },
-            } as Column<T>,
-            row_access_predicate: {
-                name: i18n('field_row-access-predicate'),
-                align: 'left',
-                className: block('table-item', {type: 'row-access-predicate'}),
-                render({row}) {
-                    const expandable = 'expanded' in row;
-                    const {row_access_predicate, aggregated_row_access_predicates} = row;
-                    return (
-                        <AclColumnsCell
-                            items={
-                                expandable
-                                    ? aggregated_row_access_predicates
-                                    : row_access_predicate
-                                      ? [row_access_predicate]
-                                      : []
-                            }
-                            expanadable={expandable}
-                        />
-                    );
-                },
-            } as Column<T>,
-        };
-    }
-
     handleDeletePermissionClick = (deleteItem: AclRoleActionsType) => {
         const {handleShow} = this.props;
         this.setState({deleteItem}, handleShow);
@@ -361,58 +112,28 @@ class ACL extends Component<Props> {
         this.setState({deleteItem: {}}, handleClose);
     };
 
-    rowClassNameByFlags<T extends ApproverRow | PermissionsRow>(item: T) {
-        const {
-            isUnrecognized: unrecognized,
-            isDepriving: depriving,
-            isRequested: requested,
-            isApproved: approved,
-            isMissing: missing,
-        } = item;
-        return block('row', {
-            unrecognized: unrecognized || missing,
-            depriving,
-            requested,
-            approved,
-        });
-    }
-
     renderApprovers() {
-        const {hasApprovers, approversFiltered, loaded} = this.props;
-        const tableColumns = (['subjects', 'approve_type', 'actions'] as const).map(
-            (name) =>
-                this.getColumnsTemplates<ApproverRow>({hasInherited: true, mode: 'responsible'})[
-                    name
-                ],
-        );
+        const {hasApprovers, approversFiltered, loaded, idmKind, toggleExpandAclSubject} =
+            this.props;
+
+        const tableColumns = getAclColumns<ApproverRow>(['subjects', 'approve_type', 'actions'], {
+            idmKind,
+            mode: 'responsible',
+            hasInherited: true,
+            onDeletePermission: this.handleDeletePermissionClick,
+            onExpandAclSubject: toggleExpandAclSubject,
+        });
         return (
             hasApprovers && (
-                <ErrorBoundary>
-                    <div className={block('approvers')}>
-                        <div className="elements-heading elements-heading_size_xs">
-                            {i18n('title_responsibles')}
-                        </div>
-                        <WithStickyToolbar
-                            topMargin="none"
-                            toolbar={<ApproversFilters />}
-                            bottomMargin="regular"
-                            content={
-                                <DataTableYT
-                                    data={approversFiltered}
-                                    loaded={loaded}
-                                    noItemsText={i18n('alert_no-responsibles')}
-                                    columns={tableColumns}
-                                    theme={'yt-borderless'}
-                                    rowClassName={this.rowClassNameByFlags}
-                                    settings={{
-                                        sortable: false,
-                                        displayIndices: false,
-                                    }}
-                                />
-                            }
-                        />
-                    </div>
-                </ErrorBoundary>
+                <AclTableWithToolbar
+                    className={block('approvers')}
+                    title={i18n('title_responsibles')}
+                    toolbar={<ApproversFilters />}
+                    noItemsText={i18n('alert_no-responsibles')}
+                    items={approversFiltered}
+                    loaded={loaded}
+                    columns={tableColumns}
+                />
             )
         );
     }
@@ -457,15 +178,7 @@ class ACL extends Component<Props> {
     }
 
     renderObjectPermissions() {
-        const {
-            aclMode,
-            loaded,
-            loading,
-            idmKind,
-            columnsFilter,
-            updateAclFilters,
-            userPermissionsAccessColumns,
-        } = this.props;
+        const {loaded, loading, idmKind, toggleExpandAclSubject} = this.props;
 
         const {
             title,
@@ -474,47 +187,42 @@ class ACL extends Component<Props> {
             noItemsText,
         } = this.getObjectPermissionsDetails();
 
-        const tableColumns: Array<Column<PermissionsRow>> = columns.map(
-            (name) =>
-                this.getColumnsTemplates<PermissionsRow>({hasInherited, mode: 'permissions'})[name],
-        );
+        const tableColumns = getAclColumns<PermissionsRow>(columns, {
+            idmKind,
+            hasInherited,
+            mode: 'permissions',
+            onDeletePermission: this.handleDeletePermissionClick,
+            onExpandAclSubject: toggleExpandAclSubject,
+        });
 
         return (
-            <ErrorBoundary>
-                <div className={block('object-permissions')}>
-                    <div className="elements-heading elements-heading_size_xs">{title}</div>
-                    <WithStickyToolbar
-                        topMargin="none"
-                        bottomMargin="regular"
-                        toolbar={
-                            <ObjectPermissionsFilters
-                                {...{
-                                    aclMode,
-                                    idmKind,
-                                    columnsFilter,
-                                    updateAclFilters,
-                                    userPermissionsAccessColumns,
-                                }}
-                            />
-                        }
-                        content={
-                            <DataTableYT
-                                noItemsText={noItemsText}
-                                data={items}
-                                loading={loading}
-                                loaded={loaded}
-                                columns={tableColumns}
-                                theme={'yt-borderless'}
-                                rowClassName={this.rowClassNameByFlags}
-                                settings={{
-                                    sortable: false,
-                                    displayIndices: false,
-                                }}
-                            />
-                        }
-                    />
-                </div>
-            </ErrorBoundary>
+            <AclTableWithToolbar
+                className={block('object-permissions')}
+                title={title}
+                noItemsText={noItemsText}
+                items={items}
+                loading={loading}
+                loaded={loaded}
+                columns={tableColumns}
+                toolbar={this.renderObjectPermissionsToolbar()}
+            />
+        );
+    }
+
+    renderObjectPermissionsToolbar() {
+        const {aclMode, idmKind, columnsFilter, updateAclFilters, userPermissionsAccessColumns} =
+            this.props;
+
+        return (
+            <ObjectPermissionsFilters
+                {...{
+                    aclMode,
+                    idmKind,
+                    columnsFilter,
+                    updateAclFilters,
+                    userPermissionsAccessColumns,
+                }}
+            />
         );
     }
 

--- a/packages/ui/src/ui/containers/ACL/ACL.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL.tsx
@@ -113,15 +113,12 @@ class ACL extends Component<Props> {
     };
 
     renderApprovers() {
-        const {hasApprovers, approversFiltered, loaded, idmKind, toggleExpandAclSubject} =
-            this.props;
+        const {hasApprovers, approversFiltered, loaded, toggleExpandAclSubject} = this.props;
 
         const tableColumns = getAclColumns<ApproverRow>(['subjects', 'approve_type', 'actions'], {
-            idmKind,
-            mode: 'responsible',
             hasInherited: true,
-            onDeletePermission: this.handleDeletePermissionClick,
             onExpandAclSubject: toggleExpandAclSubject,
+            renderRoleActions: this.renderRoleActions.bind(this, 'responsible'),
         });
         return (
             hasApprovers && (
@@ -178,7 +175,7 @@ class ACL extends Component<Props> {
     }
 
     renderObjectPermissions() {
-        const {loaded, loading, idmKind, toggleExpandAclSubject} = this.props;
+        const {loaded, loading, toggleExpandAclSubject} = this.props;
 
         const {
             title,
@@ -188,11 +185,9 @@ class ACL extends Component<Props> {
         } = this.getObjectPermissionsDetails();
 
         const tableColumns = getAclColumns<PermissionsRow>(columns, {
-            idmKind,
             hasInherited,
-            mode: 'permissions',
-            onDeletePermission: this.handleDeletePermissionClick,
             onExpandAclSubject: toggleExpandAclSubject,
+            renderRoleActions: this.renderRoleActions.bind(this, 'permissions'),
         });
 
         return (
@@ -208,6 +203,22 @@ class ACL extends Component<Props> {
             />
         );
     }
+
+    renderRoleActions = (mode: 'responsible' | 'permissions', {row}: {row: AclRoleActionsType}) => {
+        const {idmKind} = this.props;
+        const expanded = 'expanded' in row ? row.expanded : undefined;
+        const RoleActions = UIFactory.getComponentForAclRoleActions();
+        return expanded !== undefined
+            ? null
+            : RoleActions !== undefined && (
+                  <RoleActions
+                      mode={mode}
+                      role={row}
+                      idmKind={idmKind}
+                      onDelete={this.handleDeletePermissionClick}
+                  />
+              );
+    };
 
     renderObjectPermissionsToolbar() {
         const {aclMode, idmKind, columnsFilter, updateAclFilters, userPermissionsAccessColumns} =

--- a/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.scss
+++ b/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.scss
@@ -1,0 +1,21 @@
+.yt-acl-table-with-toolbar {
+    &__row {
+        &_depriving {
+            opacity: 0.5;
+            background-color: var(--danger-background);
+        }
+        &_approved,
+        &_requested {
+            opacity: 0.5;
+            background-color: var(--g-color-base-misc-light);
+        }
+
+        &_unrecognized {
+            background-color: var(--g-color-base-danger-light);
+
+            &:hover {
+                --hover-background: var(--g-color-base-danger-light-hover);
+            }
+        }
+    }
+}

--- a/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.tsx
+++ b/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.tsx
@@ -1,0 +1,84 @@
+import {type Column} from '@gravity-ui/react-data-table';
+import cn from 'bem-cn-lite';
+import React from 'react';
+import {DataTableYT} from '../../../components/DataTableYT';
+import WithStickyToolbar from '../../../components/WithStickyToolbar/WithStickyToolbar';
+import ErrorBoundary from '../../../containers/ErrorBoundary/ErrorBoundary';
+import './AclTableWithToolbar.scss';
+
+const block = cn('yt-acl-table-with-toolbar');
+
+type Props<T> = {
+    className: string;
+    title: string;
+    noItemsText: string;
+    items: Array<T>;
+    loading?: boolean;
+    loaded: boolean;
+    columns: Array<Column<T>>;
+
+    toolbar: React.ReactNode;
+};
+
+export function AclTableWithToolbar<T extends AclFlags>({
+    className,
+    title,
+    noItemsText,
+    items,
+    loading,
+    loaded,
+    columns,
+    toolbar,
+}: Props<T>) {
+    return (
+        <ErrorBoundary>
+            <div className={block(null, className)}>
+                <div className="elements-heading elements-heading_size_xs">{title}</div>
+                <WithStickyToolbar
+                    topMargin="none"
+                    bottomMargin="regular"
+                    toolbar={toolbar}
+                    content={
+                        <DataTableYT
+                            noItemsText={noItemsText}
+                            data={items}
+                            loading={loading}
+                            loaded={loaded}
+                            columns={columns}
+                            theme={'yt-borderless'}
+                            rowClassName={rowClassNameByFlags}
+                            settings={{
+                                sortable: false,
+                                displayIndices: false,
+                            }}
+                        />
+                    }
+                />
+            </div>
+        </ErrorBoundary>
+    );
+}
+
+type AclFlags = {
+    isUnrecognized?: boolean;
+    isDepriving?: boolean;
+    isRequested?: boolean;
+    isApproved?: boolean;
+    isMissing?: boolean;
+};
+
+function rowClassNameByFlags(item: AclFlags) {
+    const {
+        isUnrecognized: unrecognized,
+        isDepriving: depriving,
+        isRequested: requested,
+        isApproved: approved,
+        isMissing: missing,
+    } = item;
+    return block('row', {
+        unrecognized: unrecognized || missing,
+        depriving,
+        requested,
+        approved,
+    });
+}

--- a/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.tsx
+++ b/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {DataTableYT} from '../../../components/DataTableYT';
 import WithStickyToolbar from '../../../components/WithStickyToolbar/WithStickyToolbar';
 import ErrorBoundary from '../../../containers/ErrorBoundary/ErrorBoundary';
+import {AclFlags} from '../../../utils/acl/acl-types';
 import './AclTableWithToolbar.scss';
 
 const block = cn('yt-acl-table-with-toolbar');
@@ -58,14 +59,6 @@ export function AclTableWithToolbar<T extends AclFlags>({
         </ErrorBoundary>
     );
 }
-
-type AclFlags = {
-    isUnrecognized?: boolean;
-    isDepriving?: boolean;
-    isRequested?: boolean;
-    isApproved?: boolean;
-    isMissing?: boolean;
-};
 
 function rowClassNameByFlags(item: AclFlags) {
     const {

--- a/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.tsx
+++ b/packages/ui/src/ui/containers/ACL/AclTableWithToolbar/AclTableWithToolbar.tsx
@@ -9,7 +9,7 @@ import './AclTableWithToolbar.scss';
 const block = cn('yt-acl-table-with-toolbar');
 
 type Props<T> = {
-    className: string;
+    className?: string;
     title: string;
     noItemsText: string;
     items: Array<T>;

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
@@ -1,11 +1,11 @@
 import cn from 'bem-cn-lite';
 import map_ from 'lodash/map';
 import React from 'react';
-import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import Filter from '../../../components/Filter/Filter';
 import Select from '../../../components/Select/Select';
 import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import {AclMode} from '../../../constants/acl';
+import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {selectObjectPermissionsTypesList} from '../../../store/selectors/acl/acl';
 import {
     selectAclRowAccessPredicateFilter,

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsFilters.tsx
@@ -1,8 +1,6 @@
 import cn from 'bem-cn-lite';
-import map_ from 'lodash/map';
 import React from 'react';
 import Filter from '../../../components/Filter/Filter';
-import Select from '../../../components/Select/Select';
 import {Toolbar} from '../../../components/WithStickyToolbar/Toolbar/Toolbar';
 import {AclMode} from '../../../constants/acl';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
@@ -14,9 +12,10 @@ import {
 } from '../../../store/selectors/acl/acl-filters';
 import {type ACLReduxProps} from '../ACL-connect-helpers';
 import {ColumnGroupsFilter} from '../ColumnGroups/ColumnGroups';
-import i18nPermissionValues from '../i18n-permission-values';
 import i18n from './i18n';
 import './ObjectPermissionsFilters.scss';
+import {ObjectPermissionsSelectFilter} from './ObjectPermissionsSelectFilter/ObjectPermissionsSelectFilter';
+import {ObjectPermissionsSubjectFilter} from './ObjectPermissionsSubjectFilter/ObejctPermissionsSubjectFilter';
 
 const block = cn('object-permissions-filters');
 
@@ -44,19 +43,16 @@ export default function ObjectPermissionsFilters({
             itemsToWrap={[
                 {
                     node: (
-                        <Filter
+                        <ObjectPermissionsSubjectFilter
                             className={block('filter')}
-                            placeholder={i18n('context_filter-by-subject')}
-                            onChange={(value: string) => {
+                            value={subjectFilter}
+                            onUpdate={(value: string) => {
                                 dispatch(
                                     updateAclFilters({
                                         objectSubject: value,
                                     }),
                                 );
                             }}
-                            value={subjectFilter}
-                            size="m"
-                            autofocus={false}
                         />
                     ),
                 },
@@ -73,15 +69,9 @@ export default function ObjectPermissionsFilters({
                             />
                         ),
                         [AclMode.MAIN_PERMISSIONS]: (
-                            <Select
+                            <ObjectPermissionsSelectFilter
                                 className={block('filter')}
-                                multiple
-                                placeholder={i18n('context_filter-placeholder')}
                                 value={selectedPermissons}
-                                items={map_(permissionList, (p) => ({
-                                    value: p,
-                                    text: i18nPermissionValues(`value_${p}`),
-                                }))}
                                 onUpdate={(value: string[]) => {
                                     dispatch(
                                         updateAclFilters({
@@ -89,9 +79,7 @@ export default function ObjectPermissionsFilters({
                                         }),
                                     );
                                 }}
-                                label={i18n('field_permissions')}
-                                maxVisibleValuesTextLength={60}
-                                width="auto"
+                                permissionList={permissionList}
                             />
                         ),
                         [AclMode.ROW_GROUPS_PERMISSIONS]: (

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/ObjectPermissionsSelectFilter.tsx
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/ObjectPermissionsSelectFilter.tsx
@@ -1,0 +1,32 @@
+import map_ from 'lodash/map';
+import React from 'react';
+import Select from '../../../../components/Select/Select';
+import {YTPermissionTypeUI} from '../../../../utils/acl/acl-api';
+import i18nPermissionValues from '../../i18n-permission-values';
+import i18n from './i18n';
+
+type Props = {
+    value: YTPermissionTypeUI[];
+    onUpdate: (value: YTPermissionTypeUI[]) => void;
+    permissionList: ReadonlyArray<YTPermissionTypeUI>;
+    className: string;
+};
+
+export function ObjectPermissionsSelectFilter({value, onUpdate, permissionList, className}: Props) {
+    return (
+        <Select
+            className={className}
+            multiple
+            placeholder={i18n('context_filter-placeholder')}
+            value={value}
+            items={map_(permissionList, (p) => ({
+                value: p,
+                text: i18nPermissionValues(`value_${p}`),
+            }))}
+            onUpdate={onUpdate}
+            label={i18n('field_permissions')}
+            maxVisibleValuesTextLength={60}
+            width="auto"
+        />
+    );
+}

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/i18n/dicts.ts
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/i18n/en.json
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "context_filter-placeholder": "filter",
+  "field_permissions": "Permissions"
+}

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/i18n/index.ts
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:acl-object-permissions-select-filter', dicts);

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/ObejctPermissionsSubjectFilter.tsx
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/ObejctPermissionsSubjectFilter.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Filter from '../../../../components/Filter/Filter';
+import i18n from './i18n';
+
+type Props = {
+    value: string;
+    onUpdate: (value: string) => void;
+    className?: string;
+};
+
+export function ObjectPermissionsSubjectFilter({value, onUpdate, className}: Props) {
+    return (
+        <Filter
+            className={className}
+            placeholder={i18n('context_filter-by-subject')}
+            onChange={onUpdate}
+            value={value}
+            size="m"
+            autofocus={false}
+        />
+    );
+}

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/i18n/dicts.ts
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/i18n/en.json
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "context_filter-by-subject": "Filter by subject"
+}

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/i18n/index.ts
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:acl-object-subject-filter', dicts);

--- a/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/i18n/en.json
+++ b/packages/ui/src/ui/containers/ACL/ObjectPermissionsFilters/i18n/en.json
@@ -1,6 +1,4 @@
 {
-  "context_filter-by-subject": "Filter by subject",
   "context_filter-placeholder": "filter",
-  "field_permissions": "Permissions",
   "context_filter-by-predicate": "Filter by predicate"
 }

--- a/packages/ui/src/ui/containers/ACL/RequestPermissions/RequestPermissions.tsx
+++ b/packages/ui/src/ui/containers/ACL/RequestPermissions/RequestPermissions.tsx
@@ -69,6 +69,7 @@ export interface Props extends WithVisibleProps {
     columnGroups?: Array<AclColumnGroup>;
     rowGroups?: Array<AclRowGroup>;
     aclMode?: AclMode;
+    fields?: ReadonlyArray<RequestPermissionsFieldsNames>;
 }
 
 type FormValues = {
@@ -110,6 +111,7 @@ function RequestPermissions(props: Props) {
         columnGroups,
         rowGroups,
         buttonProps,
+        fields,
         /*denyColumns,*/
     } = props;
 
@@ -271,7 +273,7 @@ function RequestPermissions(props: Props) {
 
     const dialogFields = useMemo(() => {
         let flagsIndex = -1;
-        const res = requestPermissionsFields.reduce(
+        const res = (fields ?? requestPermissionsFields).reduce(
             (acc, field) => {
                 let allowField;
                 switch (aclMode) {

--- a/packages/ui/src/ui/containers/ACL/RequestPermissions/i18n/en.json
+++ b/packages/ui/src/ui/containers/ACL/RequestPermissions/i18n/en.json
@@ -9,6 +9,7 @@
   "field_current_pool": "Current pool",
   "field_current_tablet_cell_bundle": "Current bundle",
   "field_current_access_control_object": "Current ACO",
+  "field_current_operation": "Current operation",
   "field_permissions": "Permissions",
   "field_read-columns": "Read columns",
   "field_read-column-group": "Read column group",

--- a/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/i18n/dicts.ts
+++ b/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/i18n/en.json
+++ b/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/i18n/en.json
@@ -1,0 +1,8 @@
+{
+  "field_private-columns": "Private columns",
+  "field_type": "Type",
+  "field_subjects": "Subjects",
+  "field_permissions": "Permissions",
+  "field_inheritance-mode": "Inheritance mode",
+  "field_row-access-predicate": "Row access predicate"
+}

--- a/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/i18n/index.ts
+++ b/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:acl-columns', dicts);

--- a/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/use-acl-columns.scss
+++ b/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/use-acl-columns.scss
@@ -1,0 +1,118 @@
+.yt-acl-columns {
+    &__table-item {
+        --data-table-cell-border-padding: 4px;
+        --data-table-cell-horizontal-padding: 4px;
+
+        box-sizing: border-box;
+
+        &_type_expand {
+            padding-left: 2px;
+            padding-right: 2px;
+        }
+
+        &_type_subjects {
+            max-width: 320px;
+            .yt-subject-link {
+                display: flex;
+            }
+            .yc-popover {
+                display: block;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+
+        &_type_permissions {
+            max-width: 320px;
+        }
+
+        &_type_approve-type {
+            width: calc(270px + 160px);
+        }
+
+        &_type_inheritance-mode {
+            width: 160px;
+            max-width: 200px;
+        }
+
+        &_type_actions {
+            width: 85px;
+
+            .g-button {
+                margin-top: -4px;
+                margin-bottom: -4px;
+            }
+        }
+
+        &_type_columns {
+            width: 575px;
+            white-space: normal;
+        }
+    }
+
+    table &__permissions {
+        display: flex;
+        align-items: baseline;
+
+        .elements-text {
+            white-space: normal;
+        }
+
+        &_type_allow {
+            .icon {
+                color: var(--success-color);
+                margin-right: 4px;
+                padding: 0 5px;
+            }
+        }
+
+        &_type_deny {
+            .icon {
+                color: var(--danger-color);
+                margin-right: 7px;
+            }
+        }
+    }
+
+    table &__subjects {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        .icon {
+            margin-left: 16px;
+        }
+    }
+
+    &__subject {
+        &_level_1 {
+            padding-left: 28px;
+        }
+    }
+
+    &__subject-with-tvm {
+        flex-grow: 1;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+    }
+
+    &__inherited {
+        padding-right: 8px;
+        &_hidden {
+            visibility: hidden;
+        }
+    }
+
+    &__inherited-icon {
+        vertical-align: middle;
+    }
+
+    &__action-label {
+        text-align: center;
+        min-width: 5ex;
+        margin-right: 1ex;
+        font-weight: unset;
+        flex-shrink: 0;
+    }
+}

--- a/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/use-acl-columns.tsx
+++ b/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/use-acl-columns.tsx
@@ -1,0 +1,273 @@
+import {type Column} from '@gravity-ui/react-data-table';
+import {Flex, Icon} from '@gravity-ui/uikit';
+import {ClipboardButton, Tooltip} from '@ytsaurus/components';
+import cn from 'bem-cn-lite';
+import React from 'react';
+import aclInheritedSvg from '../../../../assets/img/svg/acl-inherited.svg';
+import format from '../../../../common/hammer/format';
+import {ExpandButton} from '../../../../components/ExpandButton/ExpandButton';
+import Label from '../../../../components/Label';
+import {SubjectCard} from '../../../../components/SubjectLink/SubjectLink';
+import {useMemoizedIfEqual} from '../../../../hooks';
+import UIFactory, {type AclRoleActionsType} from '../../../../UIFactory';
+import {type IdmKindType} from '../../../../utils/acl/acl-types';
+import {type ApproverRow, type PermissionsRow} from '../../ACL-types';
+import {AclColumnsCell} from '../../AclColumnsCell';
+import i18nPermissionValues from '../../i18n-permission-values';
+import {InheritanceMessage} from '../../InheritanceMessage/InheritanceMessage';
+import i18n from './i18n';
+import './use-acl-columns.scss';
+
+const block = cn('yt-acl-columns');
+
+export function useAclColumns<T extends ApproverRow | PermissionsRow>(
+    names: ReadonlyArray<AclColumnName>,
+    params: UseAclColumnParams,
+) {
+    const [paramsMemo, namesMemo] = useMemoizedIfEqual(params, names);
+
+    return React.useMemo(() => {
+        return getAclColumns<T>(namesMemo, paramsMemo);
+    }, [paramsMemo, namesMemo]);
+}
+
+export type UseAclColumnParams = {
+    idmKind: IdmKindType;
+    hasInherited?: boolean;
+    mode: 'responsible' | 'permissions';
+    onDeletePermission: (item: AclRoleActionsType) => void;
+    onExpandAclSubject: (item?: string | number) => void;
+};
+
+export function getAclColumns<T extends ApproverRow | PermissionsRow>(
+    names: ReadonlyArray<AclColumnName>,
+    params: UseAclColumnParams,
+) {
+    const availableColumns = getColumnsTemplates<T>(params);
+    return names.map((name) => availableColumns[name]);
+}
+
+export type AclColumnName = keyof ReturnType<typeof getColumnsTemplates>;
+
+function getColumnsTemplates<T extends ApproverRow | PermissionsRow>({
+    mode,
+    idmKind,
+    hasInherited,
+    onDeletePermission,
+    onExpandAclSubject,
+}: UseAclColumnParams) {
+    return {
+        expand: {
+            name: '',
+            align: 'right',
+            className: block('table-item', {type: 'expand'}),
+            render({row}) {
+                const expanded = 'expanded' in row ? row.expanded : undefined;
+                return expanded === undefined ? null : (
+                    <ExpandButton
+                        inline
+                        expanded={expanded}
+                        toggleExpanded={() => {
+                            onExpandAclSubject(row.subjects[0]);
+                        }}
+                        qa="acl-expand"
+                    />
+                );
+            },
+            width: 36,
+        } as Column<T>,
+        subjects: {
+            name: i18n('field_subjects'),
+            align: 'left',
+            className: block('table-item', {type: 'subjects'}),
+            render({row}) {
+                const {requestPermissionsFlags = {}} = UIFactory.getAclApi();
+
+                const {inheritedFrom} = row;
+
+                const level = 'level' in row ? row.level : undefined;
+                return (
+                    <Flex className={block('subject', {level: String(level)})} wrap gap={1}>
+                        {Boolean(hasInherited) && (
+                            <Tooltip
+                                content={<InheritanceMessage data={inheritedFrom} />}
+                                placement={['top-start']}
+                            >
+                                <div className={block('inherited', {hidden: !row.inherited})}>
+                                    <Icon
+                                        className={block('inherited-icon')}
+                                        data={aclInheritedSvg}
+                                        size={16}
+                                    />
+                                </div>
+                            </Tooltip>
+                        )}
+                        <Flex grow wrap gap={1}>
+                            {renderSubjectLink(row)}
+                        </Flex>
+                        {Object.keys(requestPermissionsFlags).map((key, index) => {
+                            const flagInfo = requestPermissionsFlags[key];
+                            return (
+                                <React.Fragment key={index}>
+                                    {flagInfo.renderIcon(row)}
+                                </React.Fragment>
+                            );
+                        })}
+                    </Flex>
+                );
+            },
+        } as Column<T>,
+        permissions: {
+            name: i18n('field_permissions'),
+            align: 'left',
+            className: block('table-item', {type: 'permissions'}),
+            render({row}) {
+                const action = row.action === 'deny' ? 'deny' : 'allow';
+                const theme = action === 'deny' ? 'danger' : 'success';
+
+                return (
+                    <div className={block('permissions', {type: row.action})}>
+                        <Label className={block('action-label')} theme={theme}>
+                            {i18nPermissionValues(`action_${action}`)}
+                        </Label>
+                        <AclColumnsCell
+                            withQoutes
+                            items={row.permissions?.map((item) =>
+                                i18nPermissionValues(`value_${item}`),
+                            )}
+                            expanadable={'expanded' in row}
+                        />
+                    </div>
+                );
+            },
+        } as Column<T>,
+        inheritance_mode: {
+            name: i18n('field_inheritance-mode'),
+            render({row}) {
+                const {inheritance_mode: mode} = row;
+                return mode === undefined
+                    ? format.NO_VALUE
+                    : i18nPermissionValues(`inheritance_mode_${mode}`);
+            },
+            align: 'left',
+            className: block('table-item', {type: 'inheritance-mode'}),
+        } as Column<T>,
+        actions: {
+            name: 'actions',
+            header: '',
+            align: 'right',
+            className: block('table-item', {type: 'actions'}),
+            render({row}) {
+                const expanded = 'expanded' in row ? row.expanded : undefined;
+                const RoleActions = UIFactory.getComponentForAclRoleActions();
+                return expanded !== undefined
+                    ? null
+                    : RoleActions !== undefined && (
+                          <RoleActions
+                              mode={mode}
+                              role={row}
+                              idmKind={idmKind}
+                              onDelete={onDeletePermission}
+                          />
+                      );
+            },
+        } as Column<T>,
+        approve_type: {
+            name: i18n('field_type'),
+            align: 'left',
+            className: block('table-item', {type: 'approve-type'}),
+            render({row}) {
+                return format['Readable'](row.type);
+            },
+        } as Column<T>,
+        columns: {
+            name: i18n('field_private-columns'),
+            align: 'left',
+            className: block('table-item', {type: 'columns'}),
+            render({row}) {
+                return <AclColumnsCell items={row.columns} expanadable={'expanded' in row} />;
+            },
+        } as Column<T>,
+        row_access_predicate: {
+            name: i18n('field_row-access-predicate'),
+            align: 'left',
+            className: block('table-item', {type: 'row-access-predicate'}),
+            render({row}) {
+                const expandable = 'expanded' in row;
+                const {row_access_predicate, aggregated_row_access_predicates} = row;
+                return (
+                    <AclColumnsCell
+                        items={
+                            expandable
+                                ? aggregated_row_access_predicates
+                                : row_access_predicate
+                                  ? [row_access_predicate]
+                                  : []
+                        }
+                        expanadable={expandable}
+                    />
+                );
+            },
+        } as Column<T>,
+    };
+}
+
+function renderSubjectLink(item: ApproverRow | PermissionsRow) {
+    const {internal} = item;
+    if (internal) {
+        const [subject] = item.subjects;
+        const [type] = item.types ?? [];
+        return (
+            <SubjectCard
+                name={subject!}
+                type={type === 'group' ? 'group' : 'user'}
+                internal
+                showIcon
+            />
+        );
+    }
+
+    if (item.subjectType === 'user') {
+        const {subjectUrl} = item;
+        const username = item.subjects[0];
+        return <SubjectCard url={subjectUrl} name={username as string} showIcon />;
+    }
+
+    if (item.subjectType === 'tvm') {
+        const tvmId = item.subjects[0];
+        const {name} = item.tvmInfo ?? {};
+
+        const text = `${name} (${tvmId})`;
+        return (
+            <div className={block('subject-with-tvm')}>
+                <SubjectCard url={item.subjectUrl} name={text} type="tvm" showIcon />
+                <Label text="TVM" />
+            </div>
+        );
+    }
+
+    const {name, url, group} = item.groupInfo || {};
+    const {group_type} = item;
+    return (
+        <Tooltip
+            content={
+                group && (
+                    <React.Fragment>
+                        idm-group:{group}
+                        <span className={block('copy-idm-group')}>
+                            <ClipboardButton text={`idm-group:${group}`} size="s" />
+                        </span>
+                    </React.Fragment>
+                )
+            }
+        >
+            <SubjectCard
+                name={name ?? group!}
+                url={url}
+                type="group"
+                groupType={group_type}
+                showIcon
+            />
+        </Tooltip>
+    );
+}

--- a/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/use-acl-columns.tsx
+++ b/packages/ui/src/ui/containers/ACL/hooks/use-acl-columns/use-acl-columns.tsx
@@ -10,7 +10,6 @@ import Label from '../../../../components/Label';
 import {SubjectCard} from '../../../../components/SubjectLink/SubjectLink';
 import {useMemoizedIfEqual} from '../../../../hooks';
 import UIFactory, {type AclRoleActionsType} from '../../../../UIFactory';
-import {type IdmKindType} from '../../../../utils/acl/acl-types';
 import {type ApproverRow, type PermissionsRow} from '../../ACL-types';
 import {AclColumnsCell} from '../../AclColumnsCell';
 import i18nPermissionValues from '../../i18n-permission-values';
@@ -32,11 +31,9 @@ export function useAclColumns<T extends ApproverRow | PermissionsRow>(
 }
 
 export type UseAclColumnParams = {
-    idmKind: IdmKindType;
+    renderRoleActions: (params: {row: AclRoleActionsType}) => React.ReactNode;
     hasInherited?: boolean;
-    mode: 'responsible' | 'permissions';
-    onDeletePermission: (item: AclRoleActionsType) => void;
-    onExpandAclSubject: (item?: string | number) => void;
+    onExpandAclSubject?: (item?: string | number) => void;
 };
 
 export function getAclColumns<T extends ApproverRow | PermissionsRow>(
@@ -50,10 +47,8 @@ export function getAclColumns<T extends ApproverRow | PermissionsRow>(
 export type AclColumnName = keyof ReturnType<typeof getColumnsTemplates>;
 
 function getColumnsTemplates<T extends ApproverRow | PermissionsRow>({
-    mode,
-    idmKind,
+    renderRoleActions,
     hasInherited,
-    onDeletePermission,
     onExpandAclSubject,
 }: UseAclColumnParams) {
     return {
@@ -62,6 +57,10 @@ function getColumnsTemplates<T extends ApproverRow | PermissionsRow>({
             align: 'right',
             className: block('table-item', {type: 'expand'}),
             render({row}) {
+                if (!onExpandAclSubject) {
+                    return null;
+                }
+
                 const expanded = 'expanded' in row ? row.expanded : undefined;
                 return expanded === undefined ? null : (
                     <ExpandButton
@@ -158,18 +157,7 @@ function getColumnsTemplates<T extends ApproverRow | PermissionsRow>({
             align: 'right',
             className: block('table-item', {type: 'actions'}),
             render({row}) {
-                const expanded = 'expanded' in row ? row.expanded : undefined;
-                const RoleActions = UIFactory.getComponentForAclRoleActions();
-                return expanded !== undefined
-                    ? null
-                    : RoleActions !== undefined && (
-                          <RoleActions
-                              mode={mode}
-                              role={row}
-                              idmKind={idmKind}
-                              onDelete={onDeletePermission}
-                          />
-                      );
+                return renderRoleActions({row});
             },
         } as Column<T>,
         approve_type: {

--- a/packages/ui/src/ui/containers/ACL/i18n/en.json
+++ b/packages/ui/src/ui/containers/ACL/i18n/en.json
@@ -1,10 +1,5 @@
 {
-  "field_private-columns": "Private columns",
-  "field_type": "Type",
-  "field_subjects": "Subjects",
   "field_permissions": "Permissions",
-  "field_inheritance-mode": "Inheritance mode",
-  "field_row-access-predicate": "Row access predicate",
   "field_inherit-acl": "Inherit ACL",
   "field_boss-approval": "Boss approval",
   "field_inherit-responsibles": "Inherit responsibles",

--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -77,6 +77,7 @@ import {type OperationPool, type OperationStates} from '../selectors';
 import './OperationDetail.scss';
 import {JobsTimeline} from './tabs/JobsTimeline';
 import OperationDetailsMonitor from './tabs/monitor/OperationDetailsMonitor';
+import {OperationAclLazy} from './tabs/acl/lazy';
 
 const detailBlock = cn('operation-detail');
 
@@ -388,6 +389,9 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
                 title: operationPerformanceUrlTemplate?.title,
                 routed: false,
             },
+            [Tab.ACL]: {
+                show: true,
+            },
         };
 
         if (monitorTabUrlTemplate) {
@@ -486,6 +490,7 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
                         }
                     />
                     <Route path={`${path}/${Tab.LOGS}`} render={UIFactory.renderOperationLogsTab} />
+                    <Route path={`${path}/${Tab.ACL}`} component={OperationAclLazy} />
                     <Route path={`${path}/:tab`} component={Placeholder} />
                     <Redirect from={url} to={`${path}/${DEFAULT_TAB}`} />
                 </Switch>

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -1,15 +1,62 @@
 import React from 'react';
+import {YTError} from '../../../../../../../@types/types';
+import {PermissionsRow} from '../../../../../../containers/ACL/ACL-types';
 import {AclTableWithToolbar} from '../../../../../../containers/ACL/AclTableWithToolbar/AclTableWithToolbar';
+import {useAclColumns} from '../../../../../../containers/ACL/hooks/use-acl-columns/use-acl-columns';
+import {YTErrorBlock} from '../../../../../../containers/Block/Block';
+import {useMemoizedIfEqual} from '../../../../../../hooks';
+import {useSelector} from '../../../../../../store/redux-hooks';
+import {selectOperationAcl} from '../../../../../../store/selectors/operations/operation-acl';
+import {splitSubjects} from '../../../../../../utils/acl';
+import {internalAclWithTypes} from '../../../../../../utils/acl/acl-api';
 
 export function OperationAcl() {
-    return (
+    const {items = [], loading, error} = useOperationAcl();
+
+    const columns = useAclColumns(['subjects', 'permissions', 'actions'], {
+        renderRoleActions: () => null,
+    });
+
+    return error ? (
+        <YTErrorBlock error={error} />
+    ) : (
         <AclTableWithToolbar
             title={'Operation permissions'}
             noItemsText={'No data to display'}
-            items={[]}
-            loaded={true}
-            columns={[]}
+            items={items}
+            loading={loading}
+            loaded={!loading}
+            columns={columns}
             toolbar={<div />}
         />
     );
+}
+
+function useOperationAcl() {
+    const acl = useSelector(selectOperationAcl);
+
+    const [aclMemo] = useMemoizedIfEqual(acl);
+
+    const [result, setResult] = React.useState<{
+        loading?: boolean;
+        error?: YTError;
+        items?: Array<PermissionsRow>;
+    }>({loading: false});
+    React.useEffect(() => {
+        if (!aclMemo.length) {
+            return;
+        }
+
+        setResult({loading: true});
+        internalAclWithTypes(splitSubjects(aclMemo)).then(
+            (items) => {
+                setResult({items});
+            },
+            (error) => {
+                setResult({error});
+            },
+        );
+    }, [aclMemo]);
+
+    return result;
 }

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -13,15 +13,26 @@ import {useSelector} from '../../../../../../store/redux-hooks';
 import {selectCluster} from '../../../../../../store/selectors/global/cluster';
 import {selectOperationAcl} from '../../../../../../store/selectors/operations/operation-acl';
 import {permissionsFilterPredicate, subjectFilterPredicate} from '../../../../../../utils/acl';
+import {aggregateBySubject} from '../../../../../../utils/acl/acl-aggregate';
 import {getOperationAclSplitted} from '../../../../../../utils/acl/acl-operation';
 import {OperationAclDeleteButton} from './OperationAclDeleteButton/OperationAclDeleteButton';
 import {OperationAclToolbar} from './OperationAclToolbar/OperationAclToolbar';
 
 export function OperationAcl() {
-    const {items = [], loading, error, noItemsText} = useOperationAcl();
+    const {expandedItems, onExpandAclSubject} = useExpandedItems();
+    const {items = [], hasExpandable, loading, error, noItemsText} = useOperationAcl(expandedItems);
 
-    const columns = useAclColumns(['subjects', 'permissions', 'actions'], {
+    const columnNames = React.useMemo(() => {
+        if (hasExpandable) {
+            return ['expand', 'subjects', 'permissions', 'actions'] as const;
+        } else {
+            return ['subjects', 'permissions', 'actions'] as const;
+        }
+    }, [hasExpandable]);
+
+    const columns = useAclColumns(columnNames, {
         renderRoleActions: ({row}) => <OperationAclDeleteButton row={row} />,
+        onExpandAclSubject,
     });
 
     return error ? (
@@ -39,7 +50,28 @@ export function OperationAcl() {
     );
 }
 
-function useOperationAcl() {
+function useExpandedItems() {
+    const [expandedItems, setExpandedItems] = React.useState(new Set<string | number>());
+    const onExpandAclSubject = React.useCallback(
+        (subject?: string | number) => {
+            if (!subject) {
+                return;
+            }
+            const newItems = new Set(expandedItems);
+
+            if (expandedItems.has(subject)) {
+                newItems.delete(subject);
+            } else {
+                newItems.add(subject);
+            }
+            setExpandedItems(newItems);
+        },
+        [expandedItems],
+    );
+    return {expandedItems, onExpandAclSubject};
+}
+
+function useOperationAcl(expandedItems: Set<string | number>) {
     const cluster = useSelector(selectCluster);
     const acl = useSelector(selectOperationAcl);
 
@@ -71,7 +103,7 @@ function useOperationAcl() {
 
     return {
         ...result,
-        items,
+        ...aggregateBySubject(items, expandedItems),
         noItemsText: filtered ? 'No data to display due to filters' : undefined,
     };
 }

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -11,16 +11,16 @@ import {
 } from '../../../../../../store/reducers/operations/acl-filters';
 import {useSelector} from '../../../../../../store/redux-hooks';
 import {selectOperationAcl} from '../../../../../../store/selectors/operations/operation-acl';
-import {permissionsFilterPredicate, splitSubjects} from '../../../../../../utils/acl';
-import {internalAclWithTypes} from '../../../../../../utils/acl/acl-api';
+import {permissionsFilterPredicate} from '../../../../../../utils/acl';
 import {getOperationAclSplitted} from '../../../../../../utils/acl/acl-operation';
+import {OperationAclDeleteButton} from './OperationAclDeleteButton/OperationAclDeleteButton';
 import {OperationAclToolbar} from './OperationAclToolbar/OperationAclToolbar';
 
 export function OperationAcl() {
     const {items = [], loading, error, noItemsText} = useOperationAcl();
 
     const columns = useAclColumns(['subjects', 'permissions', 'actions'], {
-        renderRoleActions: () => null,
+        renderRoleActions: ({row}) => <OperationAclDeleteButton row={row} />,
     });
 
     return error ? (

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -5,14 +5,18 @@ import {AclTableWithToolbar} from '../../../../../../containers/ACL/AclTableWith
 import {useAclColumns} from '../../../../../../containers/ACL/hooks/use-acl-columns/use-acl-columns';
 import {YTErrorBlock} from '../../../../../../containers/Block/Block';
 import {useMemoizedIfEqual} from '../../../../../../hooks';
+import {
+    getPermissionsFilter,
+    getSubjectFilter,
+} from '../../../../../../store/reducers/operations/acl-filters';
 import {useSelector} from '../../../../../../store/redux-hooks';
 import {selectOperationAcl} from '../../../../../../store/selectors/operations/operation-acl';
-import {splitSubjects} from '../../../../../../utils/acl';
+import {permissionsFilterPredicate, splitSubjects} from '../../../../../../utils/acl';
 import {internalAclWithTypes} from '../../../../../../utils/acl/acl-api';
 import {OperationAclToolbar} from './OperationAclToolbar/OperationAclToolbar';
 
 export function OperationAcl() {
-    const {items = [], loading, error} = useOperationAcl();
+    const {items = [], loading, error, noItemsText} = useOperationAcl();
 
     const columns = useAclColumns(['subjects', 'permissions', 'actions'], {
         renderRoleActions: () => null,
@@ -23,7 +27,7 @@ export function OperationAcl() {
     ) : (
         <AclTableWithToolbar
             title={'Operation permissions'}
-            noItemsText={'No data to display'}
+            noItemsText={noItemsText ?? 'No data to display'}
             items={items}
             loading={loading}
             loaded={!loading}
@@ -59,5 +63,41 @@ function useOperationAcl() {
         );
     }, [aclMemo]);
 
-    return result;
+    const items = useFilteredItems(result.items ?? []);
+    const filtered = items.length < (result.items?.length ?? 0);
+
+    return {
+        ...result,
+        items,
+        noItemsText: filtered ? 'No data to display due to filters' : undefined,
+    };
+}
+
+function useFilteredItems(items: Array<PermissionsRow>) {
+    const subjectFilter = useSelector(getSubjectFilter);
+    const permissionsFilter = useSelector(getPermissionsFilter);
+
+    const predicates = React.useMemo(() => {
+        const predicates: Array<(item: PermissionsRow) => boolean> = [];
+
+        if (subjectFilter) {
+            predicates.push((item) => {
+                const [first] = item.subjects;
+                return String(first).toLowerCase().includes(subjectFilter.toLowerCase());
+            });
+        }
+
+        if (permissionsFilter.length) {
+            const permissionsFilterSet = new Set(permissionsFilter);
+            predicates.push(
+                (item) => permissionsFilterPredicate(item, permissionsFilterSet) ?? false,
+            );
+        }
+
+        return predicates;
+    }, [subjectFilter, permissionsFilter]);
+
+    return React.useMemo(() => {
+        return items?.filter((item) => predicates.every((predicate) => predicate(item)));
+    }, [items, predicates]);
 }

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -17,6 +17,7 @@ import {aggregateBySubject} from '../../../../../../utils/acl/acl-aggregate';
 import {getOperationAclSplitted} from '../../../../../../utils/acl/acl-operation';
 import {OperationAclDeleteButton} from './OperationAclDeleteButton/OperationAclDeleteButton';
 import {OperationAclToolbar} from './OperationAclToolbar/OperationAclToolbar';
+import i18n from './i18n';
 
 export function OperationAcl() {
     const {expandedItems, onExpandAclSubject} = useExpandedItems();
@@ -39,8 +40,8 @@ export function OperationAcl() {
         <YTErrorBlock error={error} />
     ) : (
         <AclTableWithToolbar
-            title={'Operation permissions'}
-            noItemsText={noItemsText ?? 'No data to display'}
+            title={i18n('title_operation-permissions')}
+            noItemsText={noItemsText ?? i18n('alert_no-data')}
             items={items}
             loading={loading}
             loaded={!loading}
@@ -104,7 +105,7 @@ function useOperationAcl(expandedItems: Set<string | number>) {
     return {
         ...result,
         ...aggregateBySubject(items, expandedItems),
-        noItemsText: filtered ? 'No data to display due to filters' : undefined,
+        noItemsText: filtered ? i18n('alert_no-data-filters') : undefined,
     };
 }
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {YTError} from '../../../../../../../@types/types';
-import {PermissionsRow} from '../../../../../../containers/ACL/ACL-types';
+import {type YTError} from '../../../../../../../@types/types';
+import {type PermissionsRow} from '../../../../../../containers/ACL/ACL-types';
 import {AclTableWithToolbar} from '../../../../../../containers/ACL/AclTableWithToolbar/AclTableWithToolbar';
 import {useAclColumns} from '../../../../../../containers/ACL/hooks/use-acl-columns/use-acl-columns';
 import {YTErrorBlock} from '../../../../../../containers/Block/Block';
@@ -13,6 +13,7 @@ import {useSelector} from '../../../../../../store/redux-hooks';
 import {selectOperationAcl} from '../../../../../../store/selectors/operations/operation-acl';
 import {permissionsFilterPredicate, splitSubjects} from '../../../../../../utils/acl';
 import {internalAclWithTypes} from '../../../../../../utils/acl/acl-api';
+import {getOperationAclSplitted} from '../../../../../../utils/acl/acl-operation';
 import {OperationAclToolbar} from './OperationAclToolbar/OperationAclToolbar';
 
 export function OperationAcl() {
@@ -53,7 +54,7 @@ function useOperationAcl() {
         }
 
         setResult({loading: true});
-        internalAclWithTypes(splitSubjects(aclMemo)).then(
+        getOperationAclSplitted(aclMemo).then(
             (items) => {
                 setResult({items});
             },
@@ -78,10 +79,10 @@ function useFilteredItems(items: Array<PermissionsRow>) {
     const permissionsFilter = useSelector(getPermissionsFilter);
 
     const predicates = React.useMemo(() => {
-        const predicates: Array<(item: PermissionsRow) => boolean> = [];
+        const res: Array<(item: PermissionsRow) => boolean> = [];
 
         if (subjectFilter) {
-            predicates.push((item) => {
+            res.push((item) => {
                 const [first] = item.subjects;
                 return String(first).toLowerCase().includes(subjectFilter.toLowerCase());
             });
@@ -89,12 +90,10 @@ function useFilteredItems(items: Array<PermissionsRow>) {
 
         if (permissionsFilter.length) {
             const permissionsFilterSet = new Set(permissionsFilter);
-            predicates.push(
-                (item) => permissionsFilterPredicate(item, permissionsFilterSet) ?? false,
-            );
+            res.push((item) => permissionsFilterPredicate(item, permissionsFilterSet) ?? false);
         }
 
-        return predicates;
+        return res;
     }, [subjectFilter, permissionsFilter]);
 
     return React.useMemo(() => {

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -9,6 +9,7 @@ import {useSelector} from '../../../../../../store/redux-hooks';
 import {selectOperationAcl} from '../../../../../../store/selectors/operations/operation-acl';
 import {splitSubjects} from '../../../../../../utils/acl';
 import {internalAclWithTypes} from '../../../../../../utils/acl/acl-api';
+import {OperationAclToolbar} from './OperationAclToolbar/OperationAclToolbar';
 
 export function OperationAcl() {
     const {items = [], loading, error} = useOperationAcl();
@@ -27,7 +28,7 @@ export function OperationAcl() {
             loading={loading}
             loaded={!loading}
             columns={columns}
-            toolbar={<div />}
+            toolbar={<OperationAclToolbar />}
         />
     );
 }

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {AclTableWithToolbar} from '../../../../../../containers/ACL/AclTableWithToolbar/AclTableWithToolbar';
+
+export function OperationAcl() {
+    return (
+        <AclTableWithToolbar
+            title={'Operation permissions'}
+            noItemsText={'No data to display'}
+            items={[]}
+            loaded={true}
+            columns={[]}
+            toolbar={<div />}
+        />
+    );
+}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAcl.tsx
@@ -10,8 +10,9 @@ import {
     getSubjectFilter,
 } from '../../../../../../store/reducers/operations/acl-filters';
 import {useSelector} from '../../../../../../store/redux-hooks';
+import {selectCluster} from '../../../../../../store/selectors/global/cluster';
 import {selectOperationAcl} from '../../../../../../store/selectors/operations/operation-acl';
-import {permissionsFilterPredicate} from '../../../../../../utils/acl';
+import {permissionsFilterPredicate, subjectFilterPredicate} from '../../../../../../utils/acl';
 import {getOperationAclSplitted} from '../../../../../../utils/acl/acl-operation';
 import {OperationAclDeleteButton} from './OperationAclDeleteButton/OperationAclDeleteButton';
 import {OperationAclToolbar} from './OperationAclToolbar/OperationAclToolbar';
@@ -39,6 +40,7 @@ export function OperationAcl() {
 }
 
 function useOperationAcl() {
+    const cluster = useSelector(selectCluster);
     const acl = useSelector(selectOperationAcl);
 
     const [aclMemo] = useMemoizedIfEqual(acl);
@@ -54,7 +56,7 @@ function useOperationAcl() {
         }
 
         setResult({loading: true});
-        getOperationAclSplitted(aclMemo).then(
+        getOperationAclSplitted(cluster, aclMemo).then(
             (items) => {
                 setResult({items});
             },
@@ -82,10 +84,7 @@ function useFilteredItems(items: Array<PermissionsRow>) {
         const res: Array<(item: PermissionsRow) => boolean> = [];
 
         if (subjectFilter) {
-            res.push((item) => {
-                const [first] = item.subjects;
-                return String(first).toLowerCase().includes(subjectFilter.toLowerCase());
-            });
+            res.push((item) => subjectFilterPredicate(item, subjectFilter));
         }
 
         if (permissionsFilter.length) {

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclAddButton/OperationAclAddButton.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclAddButton/OperationAclAddButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import RequestPermissions from '../../../../../../../containers/ACL/RequestPermissions/RequestPermissions';
+import {selectOperationId} from '../../../../../../../store/selectors/operations/operation';
+import {useDispatch, useSelector} from '../../../../../../../store/redux-hooks';
+import {selectCluster} from '../../../../../../../store/selectors/global/cluster';
+import {requestPermissions} from '../../../../../../../store/actions/acl';
+import {getOperation} from '../../../../../../../store/actions/operations/detail';
+
+export function OperationAclAddButton() {
+    const dispatch = useDispatch();
+    const cluster = useSelector(selectCluster);
+    const id = useSelector(selectOperationId);
+
+    return (
+        <RequestPermissions
+            idmKind={'operation'}
+            path={id}
+            cluster={cluster}
+            requestPermissions={async ({values}) => {
+                await dispatch(requestPermissions({values, idmKind: 'operation'}));
+                dispatch(getOperation(id));
+            }}
+            cancelRequestPermissions={() => Promise.resolve()}
+            fields={['path', 'permissions', 'subjects'] as const}
+        />
+    );
+}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/OperationAclDeleteButton.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/OperationAclDeleteButton.tsx
@@ -1,0 +1,52 @@
+import TrashBinIcon from '@gravity-ui/icons/svgs/trash-bin.svg';
+import {Button, Icon} from '@gravity-ui/uikit';
+import React from 'react';
+import {AclRoleActionsType} from '../../../../../../../UIFactory';
+import DeletePermissionModal from '../../../../../../../containers/ACL/DeletePermissionModal/DeletePermissionModal';
+import {
+    type DeletePemissionsParams,
+    deletePermissions,
+} from '../../../../../../../store/actions/acl';
+import {getOperation} from '../../../../../../../store/actions/operations/detail';
+import {useDispatch, useSelector} from '../../../../../../../store/redux-hooks';
+import {selectOperationId} from '../../../../../../../store/selectors/operations/operation';
+
+type Props = {
+    row: AclRoleActionsType;
+};
+
+export function OperationAclDeleteButton({row}: Props) {
+    const dispatch = useDispatch();
+    const operationId = useSelector(selectOperationId);
+    const [visible, setVisible] = React.useState(false);
+    return (
+        <>
+            <Button onClick={() => setVisible(true)} view="flat" title="Delete">
+                <Icon color="secondary" data={TrashBinIcon} />
+            </Button>
+            <DeletePermissionModal
+                visible={visible}
+                handleClose={() => setVisible(false)}
+                idmKind="operation"
+                path={operationId}
+                itemToDelete={row}
+                deletePermissions={async ({
+                    idmKind,
+                    path,
+                    itemToDelete,
+                    roleKey,
+                }: DeletePemissionsParams) => {
+                    await dispatch(
+                        deletePermissions({
+                            idmKind,
+                            path,
+                            itemToDelete,
+                            roleKey,
+                        }),
+                    );
+                    dispatch(getOperation(operationId));
+                }}
+            />
+        </>
+    );
+}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/OperationAclDeleteButton.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/OperationAclDeleteButton.tsx
@@ -1,7 +1,8 @@
 import TrashBinIcon from '@gravity-ui/icons/svgs/trash-bin.svg';
 import {Button, Icon} from '@gravity-ui/uikit';
 import React from 'react';
-import {AclRoleActionsType} from '../../../../../../../UIFactory';
+import {type AclRoleActionsType} from '../../../../../../../UIFactory';
+import i18n from './i18n';
 import DeletePermissionModal from '../../../../../../../containers/ACL/DeletePermissionModal/DeletePermissionModal';
 import {
     type DeletePemissionsParams,
@@ -21,7 +22,7 @@ export function OperationAclDeleteButton({row}: Props) {
     const [visible, setVisible] = React.useState(false);
     return (
         <>
-            <Button onClick={() => setVisible(true)} view="flat" title="Delete">
+            <Button onClick={() => setVisible(true)} view="flat" title={i18n('action_delete')}>
                 <Icon color="secondary" data={TrashBinIcon} />
             </Button>
             <DeletePermissionModal

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/i18n/en.json
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "action_delete": "Delete"
+}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/i18n/index.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclDeleteButton/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:operation-acl-delete-button', dicts);

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclToolbar/OperationAclToolbar.scss
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclToolbar/OperationAclToolbar.scss
@@ -1,0 +1,5 @@
+.yt-operation-acl-toolbar {
+    &__filter {
+        width: 100%;
+    }
+}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclToolbar/OperationAclToolbar.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclToolbar/OperationAclToolbar.tsx
@@ -1,0 +1,58 @@
+import cn from 'bem-cn-lite';
+import React from 'react';
+import {Toolbar} from '../../../../../../../components/WithStickyToolbar/Toolbar/Toolbar';
+import {ObjectPermissionsSelectFilter} from '../../../../../../../containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSelectFilter/ObjectPermissionsSelectFilter';
+import {ObjectPermissionsSubjectFilter} from '../../../../../../../containers/ACL/ObjectPermissionsFilters/ObjectPermissionsSubjectFilter/ObejctPermissionsSubjectFilter';
+import {
+    getPermissionsFilter,
+    getSubjectFilter,
+    setPermissionsFilter,
+    setSubjectFilter,
+} from '../../../../../../../store/reducers/operations/acl-filters';
+import {useDispatch, useSelector} from '../../../../../../../store/redux-hooks';
+import './OperationAclToolbar.scss';
+
+const block = cn('yt-operation-acl-toolbar');
+
+const OPERATION_PERMISSIONS = ['read', 'manage', 'administer'] as const;
+
+export function OperationAclToolbar() {
+    const dispatch = useDispatch();
+
+    const subjectFilter = useSelector(getSubjectFilter);
+    const permissionsFilter = useSelector(getPermissionsFilter);
+
+    return (
+        <Toolbar
+            className={block()}
+            itemsToWrap={[
+                {
+                    node: (
+                        <ObjectPermissionsSubjectFilter
+                            className={block('filter')}
+                            onUpdate={(value) => {
+                                dispatch(setSubjectFilter({subjectFilter: value}));
+                            }}
+                            value={subjectFilter}
+                        />
+                    ),
+                    width: 250,
+                },
+                {
+                    shrinkable: true,
+                    node: (
+                        <ObjectPermissionsSelectFilter
+                            className={block('filter')}
+                            value={permissionsFilter}
+                            onUpdate={(value) => {
+                                dispatch(setPermissionsFilter({permissionsFilter: value}));
+                            }}
+                            permissionList={OPERATION_PERMISSIONS}
+                        />
+                    ),
+                    width: 400,
+                },
+            ]}
+        />
+    );
+}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclToolbar/OperationAclToolbar.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/OperationAclToolbar/OperationAclToolbar.tsx
@@ -10,17 +10,19 @@ import {
     setSubjectFilter,
 } from '../../../../../../../store/reducers/operations/acl-filters';
 import {useDispatch, useSelector} from '../../../../../../../store/redux-hooks';
+import UIFactory from '../../../../../../../UIFactory';
+import {OperationAclAddButton} from '../OperationAclAddButton/OperationAclAddButton';
 import './OperationAclToolbar.scss';
 
 const block = cn('yt-operation-acl-toolbar');
-
-const OPERATION_PERMISSIONS = ['read', 'manage', 'administer'] as const;
 
 export function OperationAclToolbar() {
     const dispatch = useDispatch();
 
     const subjectFilter = useSelector(getSubjectFilter);
     const permissionsFilter = useSelector(getPermissionsFilter);
+
+    const {permissionTypes} = UIFactory.getAclPermissionsSettings()['operation'];
 
     return (
         <Toolbar
@@ -47,11 +49,12 @@ export function OperationAclToolbar() {
                             onUpdate={(value) => {
                                 dispatch(setPermissionsFilter({permissionsFilter: value}));
                             }}
-                            permissionList={OPERATION_PERMISSIONS}
+                            permissionList={permissionTypes}
                         />
                     ),
                     width: 400,
                 },
+                {node: <OperationAclAddButton />},
             ]}
         />
     );

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/i18n/en.json
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/i18n/en.json
@@ -1,0 +1,5 @@
+{
+  "title_operation-permissions": "Operation permissions",
+  "alert_no-data": "No data to display",
+  "alert_no-data-filters": "No data to display due to filters"
+}

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/i18n/index.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/OperationAcl/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:operation-acl', dicts);

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/lazy.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/acl/lazy.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+import withLazyLoading from '../../../../../hocs/withLazyLoading';
+
+export const OperationAclLazy = withLazyLoading(
+    React.lazy(async () => {
+        return {
+            default: (
+                await import(/* webpackChunkName: 'operation-acl' */ './OperationAcl/OperationAcl')
+            ).OperationAcl,
+        };
+    }),
+);

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/__stories__/mocks.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/incarnations/__stories__/mocks.ts
@@ -18,6 +18,7 @@ export const operationData: OperationDetailSuccessActionData = {
         inIntermediateState: () => false,
         successfullyCompleted: () => true,
         computePools: () => {},
+        getAcl: () => [],
     },
     actions: [],
     details: {

--- a/packages/ui/src/ui/pages/operations/selectors.ts
+++ b/packages/ui/src/ui/pages/operations/selectors.ts
@@ -1,15 +1,14 @@
 import map_ from 'lodash/map';
-
 import moment from 'moment';
-
-import ypath from '../../common/thor/ypath';
-import hammer from '../../common/hammer';
 import {createSelector} from 'reselect';
-import {remoteInputUrl} from '../../utils/operations/tabs/details/specification/specification';
-import {type FIX_MY_TYPE} from '../../types';
+import {type CypressNodeRaw} from '../../../shared/yt-types';
+import hammer from '../../common/hammer';
+import ypath from '../../common/thor/ypath';
 import {type RootState} from '../../store/reducers';
 import {type JobsState} from '../../store/reducers/operations/jobs/jobs';
-import {type CypressNodeRaw} from '../../../shared/yt-types';
+import {type FIX_MY_TYPE} from '../../types';
+import {ACE, AclFlags} from '../../utils/acl/acl-types';
+import {remoteInputUrl} from '../../utils/operations/tabs/details/specification/specification';
 
 export interface OperationPoolResourceLimits {
     cpu?: number;
@@ -314,6 +313,10 @@ export class DetailedOperationSelector extends OperationSelector {
         }
 
         this.live_preview = ypath.getValue(progress, '/live_preview');
+    }
+
+    getAcl() {
+        return ypath.getValue(this.$attributes, '/runtime_parameters/acl') as Array<ACE & AclFlags>;
     }
 
     getLivePreviewPath(

--- a/packages/ui/src/ui/store/actions/acl.ts
+++ b/packages/ui/src/ui/store/actions/acl.ts
@@ -56,6 +56,7 @@ async function getPathToCheckPermissions(
     poolTree?: string,
 ) {
     switch (idmKind) {
+        case IdmObjectType.OPERATION:
         case IdmObjectType.ACCESS_CONTROL_OBJECT:
         case IdmObjectType.UI_EFFECTIVE_ACL:
         case IdmObjectType.PATH:

--- a/packages/ui/src/ui/store/actions/acl.ts
+++ b/packages/ui/src/ui/store/actions/acl.ts
@@ -149,6 +149,13 @@ export function loadAclData(
     };
 }
 
+export type DeletePemissionsParams = {
+    idmKind: IdmKindType;
+    path: string;
+    roleKey: string;
+    itemToDelete: PreparedAclSubject;
+};
+
 export function deletePermissions(
     {
         roleKey,

--- a/packages/ui/src/ui/store/location.main.ts
+++ b/packages/ui/src/ui/store/location.main.ts
@@ -107,6 +107,7 @@ import {
 } from './reducers/flow/url-mapping';
 
 import {FlowTab} from './reducers/flow/filters';
+import {operationAclFiltersParams} from './reducers/operations/url-mapping';
 
 // prettier-ignore
 export const getMainLocations = (): Array<[string, PathParameters]> => [
@@ -137,6 +138,7 @@ export const getMainLocations = (): Array<[string, PathParameters]> => [
     ],
     [`/*/${Page.OPERATIONS}/*/${OperationTab.JOBS}`, [jobsParams, getJobsPreparedState]],
     [`/*/${Page.OPERATIONS}/*/${OperationTab.JOBS_MONITOR}`, [prometheusDashboardParams]],
+    [`/*/${Page.OPERATIONS}/*/${OperationTab.ACL}`, [operationAclFiltersParams]],
 
     [`/*/${Page.ACCOUNTS}/${AccountsTab.GENERAL}`, [accountsParams, getAccountsPreparedState]],
     [`/*/${Page.ACCOUNTS}/${AccountsTab.USAGE}`, [accountUsageParams, getAccountsUsageState]],

--- a/packages/ui/src/ui/store/reducers/acl/acl.ts
+++ b/packages/ui/src/ui/store/reducers/acl/acl.ts
@@ -90,6 +90,7 @@ const initialState: AclState = {
     [IdmObjectType.ACCOUNT]: {...aclDefaults},
     [IdmObjectType.POOL]: {...aclDefaults},
     [IdmObjectType.TABLET_CELL_BUNDLE]: {...aclDefaults},
+    [IdmObjectType.OPERATION]: {...aclDefaults},
 };
 
 function modifyFieldState(state: AclState, field: IdmKindType, fieldData: Partial<AclKindState>) {

--- a/packages/ui/src/ui/store/reducers/operations/acl-filters.ts
+++ b/packages/ui/src/ui/store/reducers/operations/acl-filters.ts
@@ -1,0 +1,44 @@
+import {type PayloadAction, createSlice} from '@reduxjs/toolkit';
+import {type RootState} from '..';
+import {YTPermissionTypeUI} from '../../../utils/acl/acl-api';
+
+type OperationAclFiltersState = {
+    subjectFilter: string;
+    permissionsFilter: Array<YTPermissionTypeUI>;
+};
+
+export const initialState: OperationAclFiltersState = {
+    subjectFilter: '',
+    permissionsFilter: [],
+};
+
+const aclFiltersSlice = createSlice({
+    name: 'acl-filters',
+    initialState,
+    reducers: {
+        setSubjectFilter: (
+            state,
+            {payload}: PayloadAction<Pick<OperationAclFiltersState, 'subjectFilter'>>,
+        ) => ({
+            ...state,
+            ...payload,
+        }),
+        setPermissionsFilter: (
+            state,
+            {payload}: PayloadAction<Pick<OperationAclFiltersState, 'permissionsFilter'>>,
+        ) => ({
+            ...state,
+            ...payload,
+        }),
+    },
+    selectors: {
+        getSubjectFilter: (state) => state.subjectFilter,
+        getPermissionsFilter: (state) => state.permissionsFilter,
+    },
+});
+
+export const aclFilters = aclFiltersSlice.reducer;
+export const {setSubjectFilter, setPermissionsFilter} = aclFiltersSlice.actions;
+export const {getSubjectFilter, getPermissionsFilter} = aclFiltersSlice.getSelectors(
+    (state: RootState) => state.operations.aclFilters,
+);

--- a/packages/ui/src/ui/store/reducers/operations/index.ts
+++ b/packages/ui/src/ui/store/reducers/operations/index.ts
@@ -9,6 +9,7 @@ import jobsOperationIncarnations from './jobs/jobs-operation-incarnations';
 import jobsMonitor from './jobs/jobs-monitor';
 import {jobsTimelineReducer} from './jobs/jobs-timeline-slice';
 import {incarnations} from './incarnations';
+import {aclFilters} from './acl-filters';
 
 export default combineReducers({
     page,
@@ -20,4 +21,5 @@ export default combineReducers({
     jobsOperationIncarnations,
     incarnations,
     jobsTimeline: jobsTimelineReducer,
+    aclFilters,
 });

--- a/packages/ui/src/ui/store/reducers/operations/url-mapping.ts
+++ b/packages/ui/src/ui/store/reducers/operations/url-mapping.ts
@@ -1,0 +1,14 @@
+import {type LocationParameters} from '../../../store/location';
+import {initialState} from './acl-filters';
+
+export const operationAclFiltersParams: LocationParameters = {
+    subject: {
+        stateKey: 'operations.aclFilters.subjectFilter',
+        initialState: initialState.subjectFilter,
+    },
+    permissions: {
+        stateKey: 'operations.aclFilters.permissionsFilter',
+        initialState: initialState.permissionsFilter,
+        type: 'array',
+    },
+};

--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -4,13 +4,12 @@ import compact_ from 'lodash/compact';
 import filter_ from 'lodash/filter';
 import flatten_ from 'lodash/flatten';
 import forEach_ from 'lodash/forEach';
-import isEqual_ from 'lodash/isEqual';
 import map_ from 'lodash/map';
-import partition_ from 'lodash/partition';
 import sortBy_ from 'lodash/sortBy';
 import uniq_ from 'lodash/uniq';
 
 import {concatByAnd} from '../../../common/hammer/predicate';
+import {type RootState} from '../../../store/reducers';
 import {
     selectAclFilterColumnGroupName,
     selectAclFilterColumns,
@@ -21,16 +20,15 @@ import {
     selectObjectSubjectFilter,
 } from '../../../store/selectors/acl/acl-filters';
 import UIFactory from '../../../UIFactory';
-import {type RootState} from '../../../store/reducers';
-import {type IdmKindType, type PreparedAclSubject} from '../../../utils/acl/acl-types';
-import {type YTPermissionTypeUI} from '../../../utils/acl/acl-api';
 import {
-    HasSplitted,
     permissionsFilterPredicate,
     splitSubjects,
     subjectFilterPredicate,
     type PreparedRole,
 } from '../../../utils/acl';
+import {aggregateBySubject, ObjectPermissionsRow} from '../../../utils/acl/acl-aggregate';
+import {type YTPermissionTypeUI} from '../../../utils/acl/acl-api';
+import {type IdmKindType, type PreparedAclSubject} from '../../../utils/acl/acl-types';
 import {calculateLoadingStatus} from '../../../utils/utils';
 
 export type PreparedAclSubjectColumn = Omit<PreparedAclSubject, 'type'> & {type: 'columns'};
@@ -103,8 +101,6 @@ function FilterBySubject<
     const lowerNameFilter = subjectFilter.toLowerCase();
     return filter_(items, (item) => subjectFilterPredicate(item, lowerNameFilter));
 }
-
-type ObjectPermissionsRow = PreparedAclSubject & HasSplitted;
 
 export const selectAllObjectPermissionsFiltered = createSelector(
     [
@@ -205,162 +201,6 @@ export const selectObjectPermissionsAggregated = createSelector(
         );
     },
 );
-
-type ObjectPermissionsRowAggregated = ObjectPermissionsRow & {
-    expanded?: boolean;
-    level?: number;
-    expandable?: boolean;
-    aggregated_row_access_predicates?: Array<string>;
-};
-
-class AggregateBySubject {
-    aggrKey: string;
-    subject: ObjectPermissionsRow['subjects'][number];
-    inherited: boolean;
-
-    allPermissions = new Set<YTPermissionTypeUI>();
-    columns = new Set<string>();
-    rowAccessPredicates = new Set<string>();
-    first: ObjectPermissionsRowAggregated;
-    children = new Array<ObjectPermissionsRowAggregated>();
-
-    constructor(first: AggregateBySubject['first']) {
-        if (first.subjects.length > 1) {
-            throw new Error(
-                `Unexpected behavior: more than one subject occured: ${first.subjects.join(',')}`,
-            );
-        }
-
-        this.aggrKey = aggregationKey(first);
-        this.inherited = Boolean(first.inherited);
-        this.subject = first.subjects[0];
-        this.first = {...first};
-        this.add(first);
-    }
-
-    add(item: ObjectPermissionsRow) {
-        const aggrKey = aggregationKey(item);
-        if (this.aggrKey !== aggrKey) {
-            throw new Error(
-                `Unexpected behavior: aggregation keys are not queal: ${this.aggrKey} !== ${aggrKey}`,
-            );
-        }
-
-        if (item.subjects.length > 1) {
-            throw new Error(
-                `Unexpected behavior: item.subjects.length > 1: ${JSON.stringify(item)}`,
-            );
-        }
-
-        const child = {...item, permissions: [...(item.permissions ?? [])]};
-        this.children.push(child);
-
-        child.permissions?.sort();
-        child.permissions?.forEach((p) => {
-            this.allPermissions.add(p);
-        });
-        item.columns?.forEach((column) => this.columns.add(column));
-
-        if (item.row_access_predicate) {
-            this.rowAccessPredicates.add(item.row_access_predicate);
-        }
-
-        this.first.isMissing ||= Boolean(item.isMissing);
-        this.first.isUnrecognized ||= Boolean(item.isUnrecognized);
-        this.first.isApproved ||= Boolean(item.isApproved);
-        this.first.isRequested ||= Boolean(item.isRequested);
-    }
-
-    getItems(expanded: boolean): {
-        items: AggregateBySubject['children'];
-        hasExpandable?: boolean;
-        hasDenyAction?: boolean;
-        hasInherited?: boolean;
-    } {
-        const hasInherited = this.inherited;
-        if (this.children.length === 1) {
-            return {items: this.children, hasInherited};
-        }
-
-        const first: typeof this.first = {
-            ...this.first,
-            aggregated_row_access_predicates: [...this.rowAccessPredicates].sort(),
-            level: 0,
-            expanded,
-        };
-        first.permissions = [...this.allPermissions].sort();
-        first.columns = [...this.columns].sort();
-
-        let hasDenyAction = false;
-        const items = !expanded
-            ? [first]
-            : [
-                  first,
-                  ...sortBy_(this.children, ['inheritance_mode', 'permissions']).map((i) => {
-                      hasDenyAction ||= i.action === 'deny';
-                      return {...i, level: 1};
-                  }),
-              ];
-
-        this.children.forEach((i) => {
-            if (i.inheritance_mode !== first.inheritance_mode) {
-                first.inheritance_mode = undefined;
-            }
-            if (!isEqual_(this.first.inheritedFrom, i.inheritedFrom)) {
-                first.inheritedFrom = undefined;
-            }
-        });
-
-        return {items, hasExpandable: true, hasDenyAction, hasInherited};
-    }
-}
-
-export type ObjectPermissionRowWithExpand = AggregateBySubject['children'][number];
-
-function aggregationKey(item: ObjectPermissionsRow) {
-    const {
-        inherited,
-        subjects: [subject],
-    } = item;
-    return `subject:${subject}_inherited:${Boolean(inherited)}`;
-}
-
-function aggregateBySubject(
-    objPermissions: Array<ObjectPermissionsRow>,
-    expandedSubjects: Set<string | number>,
-) {
-    const aggregated: Record<string, AggregateBySubject> = {};
-
-    objPermissions.forEach((item) => {
-        const aggKey = aggregationKey(item);
-        const dst = aggregated[aggKey];
-        if (!dst) {
-            aggregated[aggKey] = new AggregateBySubject(item);
-        } else {
-            dst.add(item);
-        }
-    });
-
-    const res = Object.values(aggregated).reduce(
-        (acc, item) => {
-            const {items, hasExpandable, hasInherited} = item.getItems(
-                expandedSubjects.has(item.subject),
-            );
-            acc.items = acc.items.concat(items);
-            acc.hasExpandable ||= hasExpandable;
-            acc.hasInherited ||= hasInherited;
-            return acc;
-        },
-        {items: []} as ReturnType<AggregateBySubject['getItems']>,
-    );
-
-    const [inherited, other] = partition_(res.items, (item) => item.inherited);
-
-    return {
-        ...res,
-        items: [...inherited, ...other],
-    };
-}
 
 export const selectAllObjectPermissionsOrderedByStatus = createSelector(
     [selectAllObjectPermissions],

--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -25,7 +25,7 @@ import UIFactory from '../../../UIFactory';
 import {type RootState} from '../../../store/reducers';
 import {type IdmKindType, type PreparedAclSubject} from '../../../utils/acl/acl-types';
 import {type YTPermissionTypeUI} from '../../../utils/acl/acl-api';
-import {type PreparedRole} from '../../../utils/acl';
+import {HasSplitted, splitSubjects, type PreparedRole} from '../../../utils/acl';
 import {calculateLoadingStatus} from '../../../utils/utils';
 
 export type PreparedAclSubjectColumn = Omit<PreparedAclSubject, 'type'> & {type: 'columns'};
@@ -90,26 +90,6 @@ export const selectObjectPermissionsTypesList = (idmKind: IdmKindType) => {
         },
     );
 };
-
-type HasSplitted = {
-    isSplitted?: boolean;
-    subjectIndex?: number;
-};
-
-function splitSubjects<T extends {subjects: Array<unknown>}>(items: Array<T>) {
-    const res: Array<T & HasSplitted> = [];
-    forEach_(items, (item) => {
-        const {subjects} = item;
-        if (subjects && subjects.length > 1) {
-            forEach_(subjects, (subject, index) => {
-                res.push({...item, subjects: [subject], isSplitted: true, subjectIndex: index});
-            });
-        } else {
-            res.push(item);
-        }
-    });
-    return res;
-}
 
 function subjectFilterPredicate<
     T extends {subjectType?: unknown; groupInfo?: unknown; subjects: Array<unknown>},

--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -25,7 +25,7 @@ import UIFactory from '../../../UIFactory';
 import {type RootState} from '../../../store/reducers';
 import {type IdmKindType, type PreparedAclSubject} from '../../../utils/acl/acl-types';
 import {type YTPermissionTypeUI} from '../../../utils/acl/acl-api';
-import {HasSplitted, splitSubjects, type PreparedRole} from '../../../utils/acl';
+import {HasSplitted, permissionsFilterPredicate, splitSubjects, type PreparedRole} from '../../../utils/acl';
 import {calculateLoadingStatus} from '../../../utils/utils';
 
 export type PreparedAclSubjectColumn = Omit<PreparedAclSubject, 'type'> & {type: 'columns'};
@@ -116,17 +116,6 @@ function FilterBySubject<
     const lowerNameFilter = subjectFilter.toLowerCase();
     return filter_(items, (item) => subjectFilterPredicate(item, lowerNameFilter));
 }
-
-const permissionsFilterPredicate = (item: PreparedAclSubject, filter: Set<YTPermissionTypeUI>) => {
-    const {permissions} = item;
-    let foundCount = 0;
-    return permissions?.some((p) => {
-        if (filter.has(p)) {
-            foundCount++;
-        }
-        return foundCount >= filter.size;
-    });
-};
 
 type ObjectPermissionsRow = PreparedAclSubject & HasSplitted;
 

--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -7,7 +7,6 @@ import forEach_ from 'lodash/forEach';
 import isEqual_ from 'lodash/isEqual';
 import map_ from 'lodash/map';
 import partition_ from 'lodash/partition';
-import some_ from 'lodash/some';
 import sortBy_ from 'lodash/sortBy';
 import uniq_ from 'lodash/uniq';
 
@@ -25,7 +24,13 @@ import UIFactory from '../../../UIFactory';
 import {type RootState} from '../../../store/reducers';
 import {type IdmKindType, type PreparedAclSubject} from '../../../utils/acl/acl-types';
 import {type YTPermissionTypeUI} from '../../../utils/acl/acl-api';
-import {HasSplitted, permissionsFilterPredicate, splitSubjects, type PreparedRole} from '../../../utils/acl';
+import {
+    HasSplitted,
+    permissionsFilterPredicate,
+    splitSubjects,
+    subjectFilterPredicate,
+    type PreparedRole,
+} from '../../../utils/acl';
 import {calculateLoadingStatus} from '../../../utils/utils';
 
 export type PreparedAclSubjectColumn = Omit<PreparedAclSubject, 'type'> & {type: 'columns'};
@@ -90,24 +95,6 @@ export const selectObjectPermissionsTypesList = (idmKind: IdmKindType) => {
         },
     );
 };
-
-function subjectFilterPredicate<
-    T extends {subjectType?: unknown; groupInfo?: unknown; subjects: Array<unknown>},
->(item: T, filter: string) {
-    const {subjectType, groupInfo} = item;
-    if (subjectType === 'group') {
-        return some_(Object.entries(groupInfo ?? {}), ([key, value]) => {
-            let str: string | undefined = String(value);
-            if (key === 'url') {
-                if (str[str.length - 1] === '/') str = str.slice(0, -1);
-                str = str.split('/').pop();
-            }
-            return -1 !== str?.toLowerCase().indexOf(filter);
-        });
-    }
-    const value = String(item.subjects[0] ?? '');
-    return -1 !== value.toLowerCase().indexOf(filter);
-}
 
 function FilterBySubject<
     T extends {subjectType?: unknown; groupInfo?: unknown; subjects: Array<unknown>},

--- a/packages/ui/src/ui/store/selectors/operations/operation-acl.ts
+++ b/packages/ui/src/ui/store/selectors/operations/operation-acl.ts
@@ -1,0 +1,5 @@
+import {type RootState} from '../../../store/reducers';
+
+export const selectOperationAcl = (state: RootState) => {
+    return state.operations.detail.operation?.getAcl() ?? [];
+};

--- a/packages/ui/src/ui/utils/acl/acl-aggregate.ts
+++ b/packages/ui/src/ui/utils/acl/acl-aggregate.ts
@@ -1,0 +1,192 @@
+import isEqual_ from 'lodash/isEqual';
+import map_ from 'lodash/map';
+import partition_ from 'lodash/partition';
+import sortBy_ from 'lodash/sortBy';
+
+import {HasSplitted, type PreparedRole} from '../../utils/acl';
+import {type YTPermissionTypeUI} from '../../utils/acl/acl-api';
+import {type PreparedAclSubject} from '../../utils/acl/acl-types';
+
+export type PreparedAclSubjectColumn = Omit<PreparedAclSubject, 'type'> & {type: 'columns'};
+
+function prepareApprovers(
+    approvers: Array<PreparedRole> | undefined,
+    type: 'read_approver' | 'responsible' | 'auditor',
+) {
+    return map_(approvers, (subject) => {
+        const extra = {
+            type,
+            subjects: [subject.value],
+            subjectType: subject.type === 'users' ? ('user' as const) : ('group' as const),
+            groupInfo:
+                subject.type === 'groups'
+                    ? {name: subject.group_name, url: subject.url, group: subject.group}
+                    : undefined,
+            action: undefined,
+        };
+        return {
+            ...subject,
+            ...extra,
+        };
+    });
+}
+
+export type ObjectPermissionsRow = PreparedAclSubject & HasSplitted;
+
+export type PreparedApprover = ReturnType<typeof prepareApprovers>[number];
+
+type ObjectPermissionsRowAggregated = ObjectPermissionsRow & {
+    expanded?: boolean;
+    level?: number;
+    expandable?: boolean;
+    aggregated_row_access_predicates?: Array<string>;
+};
+
+class AggregateBySubject {
+    aggrKey: string;
+    subject: ObjectPermissionsRow['subjects'][number];
+    inherited: boolean;
+
+    allPermissions = new Set<YTPermissionTypeUI>();
+    columns = new Set<string>();
+    rowAccessPredicates = new Set<string>();
+    first: ObjectPermissionsRowAggregated;
+    children = new Array<ObjectPermissionsRowAggregated>();
+
+    constructor(first: AggregateBySubject['first']) {
+        if (first.subjects.length > 1) {
+            throw new Error(
+                `Unexpected behavior: more than one subject occured: ${first.subjects.join(',')}`,
+            );
+        }
+
+        this.aggrKey = aggregationKey(first);
+        this.inherited = Boolean(first.inherited);
+        this.subject = first.subjects[0];
+        this.first = {...first};
+        this.add(first);
+    }
+
+    add(item: ObjectPermissionsRow) {
+        const aggrKey = aggregationKey(item);
+        if (this.aggrKey !== aggrKey) {
+            throw new Error(
+                `Unexpected behavior: aggregation keys are not queal: ${this.aggrKey} !== ${aggrKey}`,
+            );
+        }
+
+        if (item.subjects.length > 1) {
+            throw new Error(
+                `Unexpected behavior: item.subjects.length > 1: ${JSON.stringify(item)}`,
+            );
+        }
+
+        const child = {...item, permissions: [...(item.permissions ?? [])]};
+        this.children.push(child);
+
+        child.permissions?.sort();
+        child.permissions?.forEach((p) => {
+            this.allPermissions.add(p);
+        });
+        item.columns?.forEach((column) => this.columns.add(column));
+
+        if (item.row_access_predicate) {
+            this.rowAccessPredicates.add(item.row_access_predicate);
+        }
+
+        this.first.isMissing ||= Boolean(item.isMissing);
+        this.first.isUnrecognized ||= Boolean(item.isUnrecognized);
+        this.first.isApproved ||= Boolean(item.isApproved);
+        this.first.isRequested ||= Boolean(item.isRequested);
+    }
+
+    getItems(expanded: boolean): {
+        items: AggregateBySubject['children'];
+        hasExpandable?: boolean;
+        hasDenyAction?: boolean;
+        hasInherited?: boolean;
+    } {
+        const hasInherited = this.inherited;
+        if (this.children.length === 1) {
+            return {items: this.children, hasInherited};
+        }
+
+        const first: typeof this.first = {
+            ...this.first,
+            aggregated_row_access_predicates: [...this.rowAccessPredicates].sort(),
+            level: 0,
+            expanded,
+        };
+        first.permissions = [...this.allPermissions].sort();
+        first.columns = [...this.columns].sort();
+
+        let hasDenyAction = false;
+        const items = !expanded
+            ? [first]
+            : [
+                  first,
+                  ...sortBy_(this.children, ['inheritance_mode', 'permissions']).map((i) => {
+                      hasDenyAction ||= i.action === 'deny';
+                      return {...i, level: 1};
+                  }),
+              ];
+
+        this.children.forEach((i) => {
+            if (i.inheritance_mode !== first.inheritance_mode) {
+                first.inheritance_mode = undefined;
+            }
+            if (!isEqual_(this.first.inheritedFrom, i.inheritedFrom)) {
+                first.inheritedFrom = undefined;
+            }
+        });
+
+        return {items, hasExpandable: true, hasDenyAction, hasInherited};
+    }
+}
+
+export type ObjectPermissionRowWithExpand = AggregateBySubject['children'][number];
+
+function aggregationKey(item: ObjectPermissionsRow) {
+    const {
+        inherited,
+        subjects: [subject],
+    } = item;
+    return `subject:${subject}_inherited:${Boolean(inherited)}`;
+}
+
+export function aggregateBySubject(
+    objPermissions: Array<ObjectPermissionsRow>,
+    expandedSubjects: Set<string | number>,
+) {
+    const aggregated: Record<string, AggregateBySubject> = {};
+
+    objPermissions.forEach((item) => {
+        const aggKey = aggregationKey(item);
+        const dst = aggregated[aggKey];
+        if (!dst) {
+            aggregated[aggKey] = new AggregateBySubject(item);
+        } else {
+            dst.add(item);
+        }
+    });
+
+    const res = Object.values(aggregated).reduce(
+        (acc, item) => {
+            const {items, hasExpandable, hasInherited} = item.getItems(
+                expandedSubjects.has(item.subject),
+            );
+            acc.items = acc.items.concat(items);
+            acc.hasExpandable ||= hasExpandable;
+            acc.hasInherited ||= hasInherited;
+            return acc;
+        },
+        {items: []} as ReturnType<AggregateBySubject['getItems']>,
+    );
+
+    const [inherited, other] = partition_(res.items, (item) => item.inherited);
+
+    return {
+        ...res,
+        items: [...inherited, ...other],
+    };
+}

--- a/packages/ui/src/ui/utils/acl/acl-api.ts
+++ b/packages/ui/src/ui/utils/acl/acl-api.ts
@@ -24,6 +24,7 @@ import {YTApiId, ytApiV3, ytApiV3Id} from '../../rum/rum-wrap-api';
 import UIFactory from '../../UIFactory';
 import {unquote} from '../../utils/string';
 import {YSON_AS_TEXT, prettyPrintSafe} from '../../utils/unipika';
+import {addOperationAcl} from './acl-operation';
 import {
     type ACE,
     type ACLResponsible,
@@ -32,6 +33,7 @@ import {
     type IdmKindType,
     type PreparedAclData,
     type PreparedAclSubject,
+    type Subject,
     type UpdateAclParams,
     type UpdateResponse,
 } from './acl-types';
@@ -224,6 +226,18 @@ export function checkPermissions(
 }
 
 export function requestPermissions(params: RequestPermissionParams): Promise<UpdateResponse> {
+    if (params.kind === 'operation') {
+        return addOperationAcl({
+            operation_id: params.path,
+            toAdd: params.roles_grouped.map(({permissions = [], subject}) => {
+                return {
+                    permissions,
+                    subjects: [prepareAceSubject(subject)],
+                };
+            }),
+        });
+    }
+
     const {roles_grouped, sysPath, kind} = params;
     const aclAttr = getAclAttr(kind);
     const batchParams: ExecuteBatchParams = {
@@ -252,6 +266,16 @@ export function requestPermissions(params: RequestPermissionParams): Promise<Upd
         }
         return results;
     });
+}
+
+function prepareAceSubject(item: Subject) {
+    if ('group' in item) {
+        return item.group;
+    } else if ('user' in item) {
+        return item.user;
+    } else {
+        return `tvm:${item.tvm_id}`;
+    }
 }
 
 export function updateAclAttributes(_cluster: string, path: string, params: UpdateAclParams) {

--- a/packages/ui/src/ui/utils/acl/acl-operation.ts
+++ b/packages/ui/src/ui/utils/acl/acl-operation.ts
@@ -1,12 +1,52 @@
 import isEqual_ from 'lodash/isEqual';
 import {type YTPermissionType} from '../../../shared/yt-types';
+import {SubjectCardProps} from '../../components/SubjectLink/SubjectLink';
 import {YTApiId, ytApiV3Id} from '../../rum/rum-wrap-api';
+import UIFactory from '../../UIFactory';
 import {internalAclWithTypes} from './acl-api';
-import {type ACE, type AclFlags, type PreparedAclSubject} from './acl-types';
+import {TypedAclSubject, type ACE, type AclFlags, type PreparedAclSubject} from './acl-types';
 import {splitSubjects} from './index';
 
-export async function getOperationAclSplitted(acl: Array<ACE & AclFlags>) {
-    return internalAclWithTypes(splitSubjects(acl, {addAclIndex: true}));
+export async function getOperationAclSplitted(cluster: string, acl: Array<ACE & AclFlags>) {
+    return internalAclWithTypes(acl).then(async (acl) => {
+        const subjects = acl.reduce(
+            (acc, item) => {
+                item.subjects.forEach((s, index) => {
+                    const type = item.types[index];
+                    acc.push({name: s, type});
+                });
+                return acc;
+            },
+            [] as Array<Pick<SubjectCardProps, 'name' | 'type'>>,
+        );
+
+        const titles = await UIFactory.fetchSubejectNames({cluster, subjects});
+        return splitSubjects(acl, {addAclIndex: true}).map((item) => {
+            const {title, url, internal, isTvm} = titles.get(item.subjects[0]) ?? {};
+
+            if (!title) {
+                return item;
+            }
+
+            const {
+                subjects: [subject],
+                types: [type],
+            } = item;
+            let aclSubject: TypedAclSubject;
+            if (isTvm) {
+                aclSubject = {subjectType: 'tvm', tvmInfo: {name: title}, subjectUrl: url};
+            } else if (type === 'group') {
+                aclSubject = {subjectType: 'group', groupInfo: {name: title, group: subject, url}};
+            } else {
+                aclSubject = {subjectType: 'user', subjectUrl: url};
+            }
+            return {
+                ...item,
+                ...aclSubject,
+                internal: internal ?? item.internal,
+            };
+        });
+    });
 }
 
 export async function addOperationAcl({

--- a/packages/ui/src/ui/utils/acl/acl-operation.ts
+++ b/packages/ui/src/ui/utils/acl/acl-operation.ts
@@ -36,7 +36,10 @@ export async function getOperationAclSplitted(cluster: string, acl: Array<ACE & 
             if (isTvm) {
                 aclSubject = {subjectType: 'tvm', tvmInfo: {name: title}, subjectUrl: url};
             } else if (type === 'group') {
-                aclSubject = {subjectType: 'group', groupInfo: {name: title, group: subject, url}};
+                aclSubject = {
+                    subjectType: 'group',
+                    groupInfo: {name: title, group: subject, url},
+                };
             } else {
                 aclSubject = {subjectType: 'user', subjectUrl: url};
             }

--- a/packages/ui/src/ui/utils/acl/acl-operation.ts
+++ b/packages/ui/src/ui/utils/acl/acl-operation.ts
@@ -1,0 +1,42 @@
+import {type YTPermissionType} from '../../../shared/yt-types';
+import {YTApiId, ytApiV3Id} from '../../rum/rum-wrap-api';
+import {internalAclWithTypes} from './acl-api';
+import {type ACE, type AclFlags, type PreparedAclSubject} from './acl-types';
+import {splitSubjects} from './index';
+
+export async function getOperationAclSplitted(acl: Array<ACE & AclFlags>) {
+    return internalAclWithTypes(splitSubjects(acl, {addAclIndex: true}));
+}
+
+export async function addOperationAcl({
+    operation_id,
+    toAdd,
+}: {
+    operation_id: string;
+    toAdd: Array<{subjects: Array<string>; permissions: Array<YTPermissionType>}>;
+}) {
+    const {runtime_parameters: {acl = []} = {}} = await ytApiV3Id.getOperation(
+        YTApiId.operationGetRuntimeParameters,
+        {
+            operation_id,
+            include_scheduler: true,
+            attributes: ['runtime_parameters'],
+        },
+    );
+
+    toAdd.forEach(({permissions, subjects}) => {
+        acl.push({
+            permissions,
+            subjects,
+            action: 'allow',
+            inheritance_mode: 'object_and_descendants',
+        });
+    });
+
+    return ytApiV3Id.updateOperationParameters(YTApiId.operationUpdateRuntimeParameters, {
+        operation_id,
+        _parameters: {
+            acl,
+        },
+    });
+}

--- a/packages/ui/src/ui/utils/acl/acl-operation.ts
+++ b/packages/ui/src/ui/utils/acl/acl-operation.ts
@@ -1,3 +1,4 @@
+import isEqual_ from 'lodash/isEqual';
 import {type YTPermissionType} from '../../../shared/yt-types';
 import {YTApiId, ytApiV3Id} from '../../rum/rum-wrap-api';
 import {internalAclWithTypes} from './acl-api';
@@ -39,4 +40,62 @@ export async function addOperationAcl({
             acl,
         },
     });
+}
+
+export async function removeOperationAcl({
+    operation_id,
+    item,
+}: {
+    operation_id: string;
+    item: PreparedAclSubject;
+}) {
+    const {runtime_parameters: {acl = []} = {}} = await ytApiV3Id.getOperation(
+        YTApiId.operationGetRuntimeParameters,
+        {
+            operation_id,
+            include_scheduler: true,
+            attributes: ['runtime_parameters'],
+        },
+    );
+
+    const {aclIndex = -1, subjectIndex = -1} = item;
+    const toRemove = acl[aclIndex];
+
+    if (!toRemove || !isEqual(item, toRemove)) {
+        throw new Error('Item to remove not found');
+    }
+
+    if (subjectIndex >= 0) {
+        acl[aclIndex].subjects.splice(subjectIndex, 1);
+    } else {
+        acl.splice(aclIndex, 1);
+    }
+
+    return ytApiV3Id.updateOperationParameters(YTApiId.operationUpdateRuntimeParameters, {
+        operation_id,
+        _parameters: {
+            acl,
+        },
+    });
+}
+
+function isEqual(item: PreparedAclSubject, ace: ACE) {
+    function pickFields({
+        action,
+        permissions,
+        inheritance_mode,
+        subjects,
+    }: Partial<Record<'permissions' | 'inheritance_mode' | 'subjects' | 'action', unknown>>) {
+        return {action, permissions, inheritance_mode, subjects};
+    }
+
+    const {subjects, subjectIndex = -1} = item;
+    if (subjectIndex >= 0) {
+        return isEqual_(
+            {...pickFields(item), subjects: [subjects[subjectIndex]]},
+            {...pickFields(ace), subjects: [ace.subjects[subjectIndex]]},
+        );
+    }
+
+    return isEqual_(pickFields(item), pickFields(ace));
 }

--- a/packages/ui/src/ui/utils/acl/acl-types.ts
+++ b/packages/ui/src/ui/utils/acl/acl-types.ts
@@ -8,7 +8,8 @@ export type IdmKindType =
     | 'account'
     | 'pool'
     | 'tablet_cell_bundle'
-    | 'access_control_object';
+    | 'access_control_object'
+    | 'operation';
 
 export interface Group {
     members?: Array<Subject>;

--- a/packages/ui/src/ui/utils/acl/acl-types.ts
+++ b/packages/ui/src/ui/utils/acl/acl-types.ts
@@ -73,20 +73,16 @@ export interface Role {
     deprive_after_days?: number;
 }
 
-export type RoleConverted = ResponsibleType & {
-    idmLink?: string;
-    inherited?: boolean;
-    isApproved?: boolean;
-    isDepriving?: boolean;
-    isMissing?: boolean;
-    isRequested?: boolean;
-    isUnrecognized?: boolean;
-    key?: string;
-    role_type?: string;
-    state?: string;
-    text: string;
-    group?: string;
-};
+export type RoleConverted = ResponsibleType &
+    AclFlags & {
+        idmLink?: string;
+        inherited?: boolean;
+        key?: string;
+        role_type?: string;
+        state?: string;
+        text: string;
+        group?: string;
+    };
 
 export interface ResponsibleSettingsV2 {
     responsible: Array<Role>;
@@ -235,34 +231,30 @@ export type InheritanceModeType =
     | 'object_only'
     | 'object_and_descendants';
 
-export type PreparedAclSubject = TypedAclSubject & {
-    inheritance_mode?: InheritanceModeType;
-    inherited?: boolean;
-    inheritedFrom?: InheritedFrom;
-    key?: string;
-    permissions?: Array<YTPermissionTypeUI>;
-    subjects: Array<string | number>;
-    action?: string;
-    group?: string;
-    columns?: Role['columns'];
-    row_access_predicate?: string;
-    state?: string;
-    idmLink?: string;
-    depriveDate?: string;
-    isDepriving?: boolean;
-    isRequested?: boolean;
-    isApproved?: boolean;
-    isUnrecognized?: boolean;
-    isMissing?: boolean;
-    revision?: number;
-    aclIndex?: number;
-    isSplitted?: boolean;
-    subjectIndex?: number;
-    vital?: boolean;
-    group_type?: SubjectGroupType;
+export type PreparedAclSubject = TypedAclSubject &
+    AclFlags & {
+        inheritance_mode?: InheritanceModeType;
+        inherited?: boolean;
+        inheritedFrom?: InheritedFrom;
+        key?: string;
+        permissions?: Array<YTPermissionTypeUI>;
+        subjects: Array<string | number>;
+        action?: string;
+        group?: string;
+        columns?: Role['columns'];
+        row_access_predicate?: string;
+        state?: string;
+        idmLink?: string;
+        depriveDate?: string;
+        revision?: number;
+        aclIndex?: number;
+        isSplitted?: boolean;
+        subjectIndex?: number;
+        vital?: boolean;
+        group_type?: SubjectGroupType;
 
-    type?: 'columns';
-};
+        type?: 'columns';
+    };
 
 export type ResponsibleType =
     | {type: 'users'; value: string}
@@ -282,3 +274,11 @@ export interface UpdateAclParams {
     comment?: string;
     name: string;
 }
+
+export type AclFlags = {
+    isUnrecognized?: boolean;
+    isDepriving?: boolean;
+    isRequested?: boolean;
+    isApproved?: boolean;
+    isMissing?: boolean;
+};

--- a/packages/ui/src/ui/utils/acl/index.ts
+++ b/packages/ui/src/ui/utils/acl/index.ts
@@ -201,3 +201,17 @@ export function splitSubjects<T extends {subjects: Array<unknown>}>(items: Array
     });
     return res;
 }
+
+export const permissionsFilterPredicate = (
+    item: {permissions?: Array<YTPermissionTypeUI>},
+    filter: Set<YTPermissionTypeUI>,
+) => {
+    const {permissions} = item;
+    let foundCount = 0;
+    return permissions?.some((p) => {
+        if (filter.has(p)) {
+            foundCount++;
+        }
+        return foundCount >= filter.size;
+    });
+};

--- a/packages/ui/src/ui/utils/acl/index.ts
+++ b/packages/ui/src/ui/utils/acl/index.ts
@@ -1,4 +1,5 @@
 import forEach_ from 'lodash/forEach';
+import some_ from 'lodash/some';
 import {type YTPermissionType} from '../../../shared/yt-types';
 import {
     IdmObjectType,
@@ -187,19 +188,20 @@ export type HasSplitted = {
     subjectIndex?: number;
 };
 
-export function splitSubjects<T extends {subjects: Array<unknown>}>(
+export function splitSubjects<T extends {subjects: Array<unknown>; types?: Array<unknown>}>(
     items: Array<T>,
     {addAclIndex}: {addAclIndex?: boolean} = {},
 ) {
     const res: Array<T & HasSplitted> = [];
     forEach_(items, (item, aclIndex) => {
         const commonPart = addAclIndex ? {aclIndex} : {};
-        const {subjects} = item;
+        const {subjects, types = []} = item;
         if (subjects && subjects.length > 1) {
             forEach_(subjects, (subject, index) => {
                 res.push({
                     ...item,
                     subjects: [subject],
+                    types: [types?.[index]],
                     isSplitted: true,
                     subjectIndex: index,
                     ...commonPart,
@@ -210,6 +212,24 @@ export function splitSubjects<T extends {subjects: Array<unknown>}>(
         }
     });
     return res;
+}
+
+export function subjectFilterPredicate<
+    T extends {subjectType?: unknown; groupInfo?: unknown; subjects: Array<unknown>},
+>(item: T, filter: string) {
+    const {subjectType, groupInfo} = item;
+    if (subjectType === 'group') {
+        return some_(Object.entries(groupInfo ?? {}), ([key, value]) => {
+            let str: string | undefined = String(value);
+            if (key === 'url') {
+                if (str[str.length - 1] === '/') str = str.slice(0, -1);
+                str = str.split('/').pop();
+            }
+            return -1 !== str?.toLowerCase().indexOf(filter);
+        });
+    }
+    const value = String(item.subjects[0] ?? '');
+    return -1 !== value.toLowerCase().indexOf(filter);
 }
 
 export const permissionsFilterPredicate = (

--- a/packages/ui/src/ui/utils/acl/index.ts
+++ b/packages/ui/src/ui/utils/acl/index.ts
@@ -1,3 +1,4 @@
+import forEach_ from 'lodash/forEach';
 import {type YTPermissionType} from '../../../shared/yt-types';
 import {
     IdmObjectType,
@@ -179,4 +180,24 @@ export function convertFromUIPermission(permission: YTPermissionTypeUI): {
 
 export function isGranted(role: boolean | PreparedRole | undefined) {
     return 'boolean' === typeof role ? role : role?.state === 'granted';
+}
+
+export type HasSplitted = {
+    isSplitted?: boolean;
+    subjectIndex?: number;
+};
+
+export function splitSubjects<T extends {subjects: Array<unknown>}>(items: Array<T>) {
+    const res: Array<T & HasSplitted> = [];
+    forEach_(items, (item) => {
+        const {subjects} = item;
+        if (subjects && subjects.length > 1) {
+            forEach_(subjects, (subject, index) => {
+                res.push({...item, subjects: [subject], isSplitted: true, subjectIndex: index});
+            });
+        } else {
+            res.push(item);
+        }
+    });
+    return res;
 }

--- a/packages/ui/src/ui/utils/acl/index.ts
+++ b/packages/ui/src/ui/utils/acl/index.ts
@@ -187,16 +187,26 @@ export type HasSplitted = {
     subjectIndex?: number;
 };
 
-export function splitSubjects<T extends {subjects: Array<unknown>}>(items: Array<T>) {
+export function splitSubjects<T extends {subjects: Array<unknown>}>(
+    items: Array<T>,
+    {addAclIndex}: {addAclIndex?: boolean} = {},
+) {
     const res: Array<T & HasSplitted> = [];
-    forEach_(items, (item) => {
+    forEach_(items, (item, aclIndex) => {
+        const commonPart = addAclIndex ? {aclIndex} : {};
         const {subjects} = item;
         if (subjects && subjects.length > 1) {
             forEach_(subjects, (subject, index) => {
-                res.push({...item, subjects: [subject], isSplitted: true, subjectIndex: index});
+                res.push({
+                    ...item,
+                    subjects: [subject],
+                    isSplitted: true,
+                    subjectIndex: index,
+                    ...commonPart,
+                });
             });
         } else {
-            res.push(item);
+            res.push({...item, ...commonPart});
         }
     });
     return res;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/lEzuJWdS7gW3F8
<!-- nda-end -->  ## Summary by Sourcery

Refactor ACL object permissions and approvers tables to use shared column configuration and a dedicated object permissions component.

Enhancements:
- Extract ACL table column templates into a reusable hook and helper for both approvers and permissions views.
- Introduce a dedicated AclObjectPermissions component to encapsulate the object permissions table layout and toolbar.
- Centralize ACL-related table styling into a new stylesheet tied to the shared columns implementation.
- Move shared ACL row type definitions into a separate ACL-types module for reuse across components.