### PR TITLE
fix(Operations): wrong data in timeline modal [YTFRONT-5894]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsTimeline/EventsSidePanel/EventsTable.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/JobsTimeline/EventsSidePanel/EventsTable.tsx
@@ -20,7 +20,7 @@ const PhaseNameCell: FC<{state: string; phase: string}> = ({state, phase}) => {
 };
 
 const getDateTime = (timestamp: number) =>
-    hammer.format['DateTime'](new Date(timestamp).toString());
+    hammer.format['DateTime'](new Date(timestamp).toISOString());
 
 type Props = {
     events: JobEvent[];


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/aZnNtjEk7guXvP
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Correct display of event timestamps in the jobs timeline modal by using ISO-formatted datetime strings.