### PR TITLE
fix(Queries): cyrillic name in history [YTFRONT-5881]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/Columns/ColumnCells.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/Columns/ColumnCells.tsx
@@ -2,6 +2,7 @@ import React, {type FC} from 'react';
 import {Text} from '@gravity-ui/uikit';
 import block from 'bem-cn-lite';
 import hammer from '../../../../../common/hammer';
+import unipika from '../../../../../common/thor/unipika';
 import {QueryStatusIcon} from '../../../../../components/QueryStatus';
 import {formatTime} from '../../../../../components/common/Timeline/util';
 import {type QueryItem} from '../../../../../types/query-tracker/api';
@@ -18,7 +19,9 @@ type CellProps = {
 };
 
 export const QueryHistoryNameCell: FC<CellProps> = ({row}) => {
-    const name = row.annotations?.title;
+    const title = row.annotations?.title;
+    const name = title ? unipika.decode(title) : title;
+
     return (
         <div className={b('name')} title={name}>
             <QueryStatusIcon className={b('status-icon')} status={row.state} />

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/HistoryList/QueryHistoryItemRow.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/HistoryList/QueryHistoryItemRow.scss
@@ -7,5 +7,6 @@
 
     &__cell {
         padding: var(--data-table-cell-vertical-padding) var(--data-table-cell-horizontal-padding);
+        overflow: hidden;
     }
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/JPZsLaNE7gzenG
<!-- nda-end -->## Summary by Sourcery

Decode query history names and adjust cell styling to correctly display titles in the query tracker history list.

Bug Fixes:
- Ensure query history titles, including Cyrillic characters, are properly decoded before display.

Enhancements:
- Prevent query history table cells from overflowing their container by hiding excess content.