### PR TITLE
fix(Queries): wrong default aco [YTFRONT-5668]

### DIFF
--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -18,6 +18,7 @@ import {
 import {requestQueriesList} from './queriesList';
 import {
     SHARED_QUERY_ACO,
+    selectCurrentDraftQueryACO,
     selectCurrentQuery,
     selectQuery,
     selectQueryDraft,
@@ -474,7 +475,6 @@ export function createEmptyQuery(
     return (dispatch, getState) => {
         const state = getState();
         const lastEngine = selectLastUserChoiceQueryEngine(state);
-        const defaultQueryACO = selectDefaultQueryACO(state);
         const defaultSpytSettings = selectSpytDefaultSettings(state);
 
         const initialEngine = engine || lastEngine || QueryEngine.YQL;
@@ -486,8 +486,6 @@ export function createEmptyQuery(
             type: SET_QUERY,
             data: {
                 initialQuery: {
-                    access_control_object: defaultQueryACO,
-                    access_control_objects: [defaultQueryACO],
                     query: query || '',
                     engine: initialEngine,
                     settings: querySettings,
@@ -507,12 +505,16 @@ export function runQuery(
     return async (dispatch, getState) => {
         const state = getState();
         const query = selectQueryDraft(state);
+        const isMultipleAco = selectIsMultipleAco(state);
+        const effectiveACO = selectCurrentDraftQueryACO(state).filter(
+            (i) => i !== SHARED_QUERY_ACO,
+        );
 
         const newQuery = {...query};
-        if ('access_control_objects' in newQuery) {
-            newQuery.access_control_objects = newQuery.access_control_objects?.filter(
-                (i) => i !== SHARED_QUERY_ACO,
-            );
+        if (isMultipleAco) {
+            newQuery.access_control_objects = effectiveACO;
+        } else {
+            newQuery.access_control_object = effectiveACO[0];
         }
 
         dispatch({

--- a/packages/ui/src/ui/store/reducers/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/reducers/query-tracker/query.ts
@@ -22,7 +22,6 @@ import {
     UPDATE_QUERY_ITEM,
 } from './query-tracker-contants';
 import {cleanupQueryForDraft} from '../../../types/query-tracker/query';
-import {DEFAULT_QUERY_ACO} from '../../selectors/query-tracker/query';
 import {type ChytInfo} from '../chyt/list';
 
 export interface QueryState {
@@ -53,8 +52,6 @@ const initialQueryDraftState: QueryState['draft'] = {
     files: [],
     secrets: [],
     settings: {},
-    access_control_object: DEFAULT_QUERY_ACO, // deprecated parameter
-    access_control_objects: [DEFAULT_QUERY_ACO],
 };
 
 const initState: QueryState = {

--- a/packages/ui/src/ui/store/selectors/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/query.ts
@@ -207,11 +207,10 @@ export const selectCurrentQueryACO = (state: RootState) => {
     return getAco(defaultACO, selectIsMultipleAco(state), state.queryTracker.query?.queryItem);
 };
 
-export const selectCurrentDraftQueryACO = (state: RootState) => {
-    const defaultACO = selectDefaultQueryACO(state);
-
-    return getAco(defaultACO, selectIsMultipleAco(state), state.queryTracker.query?.draft);
-};
+export const selectCurrentDraftQueryACO = createSelector(
+    [selectDefaultQueryACO, selectIsMultipleAco, selectQueryDraft],
+    (defaultACO, isMultipleAco, draft) => getAco(defaultACO, isMultipleAco, draft),
+);
 
 export const selectQuerySingleProgress = createSelector([selectQueryProgress], (progress) => {
     if (!isSingleProgress(progress)) return {};

--- a/packages/ui/src/ui/types/query-tracker/api.ts
+++ b/packages/ui/src/ui/types/query-tracker/api.ts
@@ -50,7 +50,7 @@ export interface DraftQuery {
         execution_mode?: 'validate' | 'optimize';
     } & Record<string, unknown>;
     error?: unknown;
-    access_control_object: string;
+    access_control_object?: string;
     access_control_objects?: string[];
 }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Iv2MGuQ27h2JwV
<!-- nda-end -->## Summary by Sourcery

Adjust query ACO handling to rely on selectors and current draft state instead of hardcoded defaults, and normalize single vs multiple ACO fields when running a query.

Bug Fixes:
- Ensure the default ACO is correctly derived for draft queries instead of being set as a deprecated hardcoded default in the initial draft state.
- Prevent SHARED_QUERY_ACO from being sent by normalizing draft access control objects to either a single or multiple field based on configuration.

Enhancements:
- Refactor current draft ACO selector to a memoized selector that composes existing selectors.
- Relax DraftQuery typing to allow absence of a single access_control_object field.