### PR TITLE
fix(Queries): correct color for warnings within errors [YTFRONT-5264]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/ErrorList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/ErrorList.tsx
@@ -1,7 +1,7 @@
 import React, {type FC} from 'react';
 import {type ErrorPosition, type QueryError} from '../../../../types/query-tracker/api';
 import {ErrorCloud} from './ErrorCloud';
-import {isInfoNode} from './helpers/isInfoNode';
+import {getNodeSeverityType} from './helpers/getNodeSeverityType';
 
 type Props = {
     errors: QueryError[];
@@ -30,7 +30,7 @@ export const ErrorList: FC<Props> = ({
                     level={level}
                     disableCloud={disableCloud && !(errors.length > 1)}
                     error={error}
-                    initialExpanded={isInfoNode(error) ? false : expanded}
+                    initialExpanded={getNodeSeverityType(error).isInfo ? false : expanded}
                     onErrorClick={onErrorClick}
                     onShowParent={onShowParent}
                     fromCloud={fromCloud}

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/ErrorTreeNode.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/ErrorTreeNode.scss
@@ -11,6 +11,12 @@
         }
     }
 
+    &_warning {
+        #{$self}__icon {
+            color: var(--g-color-text-warning);
+        }
+    }
+
     &__errors {
         padding-left: 28px;
     }

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/ErrorTreeNode.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/ErrorTreeNode.tsx
@@ -16,7 +16,7 @@ import ChevronDownIcon from '@gravity-ui/icons/svgs/chevron-down.svg';
 import unipika from '../../../../common/thor/unipika';
 import {Yson} from '../../../../components/Yson/Yson';
 import {ClickableText} from '../../../../components/ClickableText/ClickableText';
-import {isInfoNode} from './helpers/isInfoNode';
+import {getNodeSeverityType} from './helpers/getNodeSeverityType';
 
 const block = cn('yt-error-tree-node');
 
@@ -43,7 +43,7 @@ export const ErrorTreeNode: FC<Props> = ({
     const [expandedAttributes, toggleExpandedAttributes] = useToggle(false);
     const hasIssues = error.inner_errors && error.inner_errors.length > 0;
     const position = getIssuePosition(error);
-    const isInfo = isInfoNode(error);
+    const nodeType = getNodeSeverityType(error);
 
     const handleIssueClick = useCallback(() => {
         if (error.attributes?.start_position) {
@@ -52,7 +52,13 @@ export const ErrorTreeNode: FC<Props> = ({
     }, [error.attributes.start_position, onErrorClick]);
 
     return (
-        <div className={block({leaf: !hasIssues, info: isInfo})}>
+        <div
+            className={block({
+                leaf: !hasIssues,
+                info: nodeType.isInfo,
+                warning: nodeType.isWarning,
+            })}
+        >
             <div className={block('error-body')}>
                 <div className={block('line')}>
                     {hasIssues && (
@@ -69,10 +75,12 @@ export const ErrorTreeNode: FC<Props> = ({
                     <span className={block('header')}>
                         <Icon
                             className={block('icon')}
-                            data={isInfo ? CircleInfoFillIcon : errorIcon}
+                            data={nodeType.isInfo ? CircleInfoFillIcon : errorIcon}
                             size={16}
                         />
-                        <span className={block('title')}>{isInfo ? 'Info' : 'Error'}</span>
+                        <span className={block('title')}>
+                            {error.attributes?.severity || 'Error'}
+                        </span>
                         <Button view="flat-secondary" onClick={toggleExpandedAttributes}>
                             Attributes{' '}
                             <Icon

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/helpers/getNodeSeverityType.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/helpers/getNodeSeverityType.ts
@@ -1,0 +1,16 @@
+import type {QueryError} from '../../../../../types/query-tracker/api';
+
+const INFO_NODE_SEVERITY = 'Info';
+const WARNING_NODE_SEVERITY = 'Warning';
+
+export const getNodeSeverityType = (node: QueryError) => {
+    const severity = node.attributes?.severity;
+    const isInfo = severity === INFO_NODE_SEVERITY;
+    const isWarning = severity === WARNING_NODE_SEVERITY;
+
+    return {
+        isInfo,
+        isWarning,
+        isError: !isInfo && !isWarning,
+    };
+};

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/helpers/isInfoNode.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/ErrorTree/helpers/isInfoNode.ts
@@ -1,7 +1,0 @@
-import {type QueryError} from '../../../../../types/query-tracker/api';
-
-const INFO_NODE_SEVERITY = 'Info';
-
-export const isInfoNode = (node: QueryError) => {
-    return node.attributes.severity === INFO_NODE_SEVERITY;
-};


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/dpVjZBkc7h8Sz3
<!-- nda-end --> ## Summary by Sourcery

Adjust error tree rendering to distinguish info, warning, and error nodes based on severity, including updated icon/title and styling.

Bug Fixes:
- Correct warning node coloring and labeling in the query tracker error tree to match their severity.

Enhancements:
- Introduce a helper to derive node type from error severity and use it across error tree components to control initial expansion and rendering.