### PR TITLE
fix(UI): format min/max bounds in NumberInput validation errors [YTFR…

### DIFF
--- a/packages/ui/src/ui/components/NumberInput/NumberInput.tsx
+++ b/packages/ui/src/ui/components/NumberInput/NumberInput.tsx
@@ -37,6 +37,20 @@ export function formatValue(
     return res === hammer.format.NO_VALUE ? '' : res;
 }
 
+function formatBoundForError(bound: number, props: NumberInputWithErrorProps) {
+    const {format, decimalPlaces, formatFn} = props;
+    const formatted = formatFn
+        ? formatFn(bound)
+        : formatValue(bound, format, {digits: decimalPlaces});
+    const raw = String(bound);
+
+    if (!formatted || formatted === raw) {
+        return raw;
+    }
+
+    return `${raw} (${formatted})`;
+}
+
 function toRawValue(value: NumberInputProps['value']) {
     return value === undefined ? '' : value;
 }
@@ -146,11 +160,15 @@ export class NumberInputWithError extends React.Component<NumberInputWithErrorPr
         }
 
         if (min !== undefined && value < min) {
-            return i18n('error_must-be-gte', {min});
+            return i18n('error_must-be-gte', {
+                min: formatBoundForError(min, props),
+            });
         }
 
         if (max !== undefined && value > max) {
-            return i18n('error_must-be-lte', {max});
+            return i18n('error_must-be-lte', {
+                max: formatBoundForError(max, props),
+            });
         }
 
         return undefined;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/RTkDzKc67h9KMw
<!-- nda-end --> …ONT-5452]

## Summary by Sourcery

Bug Fixes:
- Ensure min/max bounds in NumberInput validation errors respect custom format functions and decimal formatting settings.