### PR TITLE
feat(Queries): unified path action menu [YTFRONT-4886]

### DIFF
--- a/packages/ui/src/shared/constants/settings-types.ts
+++ b/packages/ui/src/shared/constants/settings-types.ts
@@ -173,6 +173,10 @@ type DashboardSettings = {
     [key in `local::${Cluster}::dashboard::config`]: DashKitProps['config'];
 };
 
+type FavouritesSettings = {
+    [key in `local::${Cluster}::favourites`]: Array<string | {path: string}>;
+};
+
 type QueryTrackerLastSelectedACOsSettings = {
     [key in `qt-stage::${Stage}::queryTracker::lastSelectedACOs`]: string[];
 };
@@ -239,6 +243,7 @@ export type DescribedSettings = GlobalSettings &
     QueryTrackerLastYqlVersion &
     ComponentsSettings &
     SchedulingSettings &
-    DashboardSettings;
+    DashboardSettings &
+    FavouritesSettings;
 
 export type SettingKey = keyof DescribedSettings;

--- a/packages/ui/src/ui/containers/NavigationFavorites/NavigationFavorites.tsx
+++ b/packages/ui/src/ui/containers/NavigationFavorites/NavigationFavorites.tsx
@@ -1,0 +1,41 @@
+import React, {type FC, useCallback, useMemo} from 'react';
+import {useDispatch, useSelector} from '../../store/redux-hooks';
+import {selectSettingsData} from '../../store/selectors/settings/settings-base';
+import {navigationToggleFavourite} from '../../store/actions/favourites';
+import Favourites, {type FavouritesItem} from '../../components/Favourites/Favourites';
+import {normalizeFavourites} from './helpers/normalizeFavourites';
+import {isFavourite} from './helpers/isFavourite';
+
+export type NavigationFavoritesProps = {
+    path: string;
+    cluster: string;
+    onItemClick: (item: FavouritesItem) => void;
+};
+
+export const NavigationFavorites: FC<NavigationFavoritesProps> = ({path, cluster, onItemClick}) => {
+    const dispatch = useDispatch();
+    const settingsData = useSelector(selectSettingsData);
+
+    const favouriteItems = useMemo(() => {
+        if (!cluster) return [];
+        const items = settingsData[`local::${cluster}::favourites`] || [];
+
+        return normalizeFavourites(items).sort((a, b) => a.path.localeCompare(b.path));
+    }, [settingsData, cluster]);
+
+    const isActive = isFavourite(path, favouriteItems);
+
+    const handleToggle = useCallback(() => {
+        dispatch(navigationToggleFavourite(path, cluster));
+    }, [dispatch, path, cluster]);
+
+    return (
+        <Favourites
+            theme="clear"
+            isActive={isActive}
+            items={favouriteItems}
+            onItemClick={onItemClick}
+            onToggle={handleToggle}
+        />
+    );
+};

--- a/packages/ui/src/ui/containers/NavigationFavorites/helpers/isFavourite.ts
+++ b/packages/ui/src/ui/containers/NavigationFavorites/helpers/isFavourite.ts
@@ -1,0 +1,10 @@
+import type {FavouritePath} from './normalizeFavourites';
+
+export const isFavourite = (
+    path: string,
+    favourites: FavouritePath[] | undefined | null,
+): boolean => {
+    return (favourites ?? []).some(
+        (item) => (typeof item === 'string' ? item : item.path) === path,
+    );
+};

--- a/packages/ui/src/ui/containers/NavigationFavorites/helpers/normalizeFavourites.ts
+++ b/packages/ui/src/ui/containers/NavigationFavorites/helpers/normalizeFavourites.ts
@@ -1,0 +1,9 @@
+import type {FavouritesItem} from '../../../components/Favourites/Favourites';
+
+export type FavouritePath = string | FavouritesItem;
+
+export const normalizeFavourites = (
+    favourites: FavouritePath[] | undefined | null,
+): FavouritesItem[] => {
+    return (favourites ?? []).map((item) => (typeof item === 'string' ? {path: item} : item));
+};

--- a/packages/ui/src/ui/containers/NavigationFavorites/index.ts
+++ b/packages/ui/src/ui/containers/NavigationFavorites/index.ts
@@ -1,0 +1,1 @@
+export {NavigationFavorites, type NavigationFavoritesProps} from './NavigationFavorites';

--- a/packages/ui/src/ui/pages/navigation/Navigation/NavigationTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/navigation/Navigation/NavigationTopRowContent.tsx
@@ -18,16 +18,11 @@ import {makeRoutedURL} from '../../../store/location';
 import {restoreObject} from '../../../store/actions/navigation/modals/restore-object';
 import {selectNavigationDefaultPath} from '../../../store/selectors/settings';
 import {
-    selectFavouritePaths,
-    selectIsCurrentPathInFavourites,
-} from '../../../store/selectors/favourites';
-import {
     selectActualPath,
     selectIsNavigationFinalLoadState,
     selectPath,
     selectTransaction,
 } from '../../../store/selectors/navigation';
-import {navigationToggleFavourite} from '../../../store/actions/favourites';
 import {
     clearTransaction,
     setTransaction,
@@ -35,7 +30,8 @@ import {
     updateView,
 } from '../../../store/actions/navigation';
 
-import Favourites from '../../../components/Favourites/Favourites';
+import {NavigationFavorites} from '../../../containers/NavigationFavorites';
+import {type FavouritesItem} from '../../../components/Favourites/Favourites';
 import {ClipboardButton, Escaped, MetaTable, Tooltip} from '@ytsaurus/components';
 import Link from '../../../containers/Link/Link';
 import Editor from '../../../components/Editor/Editor';
@@ -85,32 +81,17 @@ function NavigationTopRowContent() {
 
 function NavigationFavourites() {
     const dispatch = useDispatch();
-
-    const favourites = useSelector(selectFavouritePaths);
-
-    const isInFavourites = useSelector(selectIsCurrentPathInFavourites);
     const path = useSelector(selectPath);
-
-    const handleToggle = React.useCallback(() => {
-        dispatch(navigationToggleFavourite(path));
-    }, [dispatch, path]);
+    const cluster = useSelector(selectCluster);
 
     const handleItemClick = React.useCallback(
-        ({path}: {path: string}) => {
-            dispatch(updatePath(path));
+        (item: FavouritesItem) => {
+            dispatch(updatePath(item.path));
         },
         [dispatch],
     );
 
-    return (
-        <Favourites
-            theme={'clear'}
-            isActive={isInFavourites}
-            items={favourites || []}
-            onItemClick={handleItemClick}
-            onToggle={handleToggle}
-        />
-    );
+    return <NavigationFavorites path={path} cluster={cluster} onItemClick={handleItemClick} />;
 }
 
 function NavigationPathToClipboard() {

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationHeader/HeaderActions.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationHeader/HeaderActions.tsx
@@ -2,7 +2,6 @@ import React, {type FC, useCallback} from 'react';
 import {Button, Icon} from '@gravity-ui/uikit';
 import StarIcon from '@gravity-ui/icons/svgs/star.svg';
 import StarFillIcon from '@gravity-ui/icons/svgs/star-fill.svg';
-import TextIndentIcon from '@gravity-ui/icons/svgs/text-indent.svg';
 import CopyIcon from '@gravity-ui/icons/svgs/copy.svg';
 import './HeaderActions.scss';
 import cn from 'bem-cn-lite';
@@ -14,25 +13,25 @@ import {
 import {
     selectFavouritePaths,
     selectNavigationCluster,
-    selectNavigationPath,
+    selectPathActionsNode,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
 import {selectQueryEngine} from '../../../../store/selectors/query-tracker/query';
-import {makePathByQueryEngine} from '../helpers/makePathByQueryEngine';
-import {insertTextWhereCursor} from '../helpers/insertTextWhereCursor';
-import {useMonaco} from '../../hooks/useMonaco';
 import {makeNavigationLink} from '../../../../utils/app-url';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
+import {PathActionsMenu} from '../PathActionsMenu';
+import {useToggle} from 'react-use';
 
 const b = cn('navigation-header-actions');
 
 export const HeaderActions: FC<{className?: string}> = ({className}) => {
     const dispatch = useDispatch();
-    const path = useSelector(selectNavigationPath);
+    const pathActionsNode = useSelector(selectPathActionsNode);
     const cluster = useSelector(selectNavigationCluster);
     const favorites = useSelector(selectFavouritePaths);
     const engine = useSelector(selectQueryEngine);
-    const {getEditor} = useMonaco();
+    const [pathMenuOpen, togglePathMenuOpen] = useToggle(false);
 
+    const {path} = pathActionsNode;
     const isFavorite = favorites.includes(path);
     const navigationUrl = makeNavigationLink({path, cluster});
 
@@ -44,17 +43,6 @@ export const HeaderActions: FC<{className?: string}> = ({className}) => {
         dispatch(copyPathToClipboard(path));
     }, [dispatch, path]);
 
-    const handlePastePath = useCallback(() => {
-        if (!cluster) return;
-        const editor = getEditor('queryEditor');
-        const pathString = makePathByQueryEngine({
-            cluster,
-            path,
-            engine,
-        });
-        insertTextWhereCursor(pathString, editor);
-    }, [cluster, engine, getEditor, path]);
-
     if (!cluster) return null;
 
     return (
@@ -65,9 +53,12 @@ export const HeaderActions: FC<{className?: string}> = ({className}) => {
             <Button view="flat" onClick={handleFavoriteToggle}>
                 <Icon data={isFavorite ? StarFillIcon : StarIcon} size={16} />
             </Button>
-            <Button view="flat" onClick={handlePastePath}>
-                <Icon data={TextIndentIcon} size={16} />
-            </Button>
+            <PathActionsMenu
+                node={pathActionsNode}
+                open={pathMenuOpen}
+                onOpenToggle={togglePathMenuOpen}
+                engine={engine}
+            />
             <Button view="flat" onClick={handlePathCopy}>
                 <Icon data={CopyIcon} size={16} />
             </Button>

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationHeader/HeaderActions.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationHeader/HeaderActions.tsx
@@ -1,18 +1,16 @@
 import React, {type FC, useCallback} from 'react';
 import {Button, Icon} from '@gravity-ui/uikit';
-import StarIcon from '@gravity-ui/icons/svgs/star.svg';
-import StarFillIcon from '@gravity-ui/icons/svgs/star-fill.svg';
 import CopyIcon from '@gravity-ui/icons/svgs/copy.svg';
 import './HeaderActions.scss';
 import cn from 'bem-cn-lite';
 import ArrowUpRightFromSquareIcon from '@gravity-ui/icons/svgs/arrow-up-right-from-square.svg';
 import {
     copyPathToClipboard,
-    toggleFavoritePath,
+    loadPath,
 } from '../../../../store/actions/query-tracker/queryNavigation';
 import {
-    selectFavouritePaths,
     selectNavigationCluster,
+    selectNavigationClusterConfig,
     selectPathActionsNode,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
 import {selectQueryEngine} from '../../../../store/selectors/query-tracker/query';
@@ -20,6 +18,8 @@ import {makeNavigationLink} from '../../../../utils/app-url';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {PathActionsMenu} from '../PathActionsMenu';
 import {useToggle} from 'react-use';
+import {NavigationFavorites} from '../../../../containers/NavigationFavorites';
+import {type FavouritesItem} from '../../../../components/Favourites/Favourites';
 
 const b = cn('navigation-header-actions');
 
@@ -27,31 +27,37 @@ export const HeaderActions: FC<{className?: string}> = ({className}) => {
     const dispatch = useDispatch();
     const pathActionsNode = useSelector(selectPathActionsNode);
     const cluster = useSelector(selectNavigationCluster);
-    const favorites = useSelector(selectFavouritePaths);
+    const clusterConfig = useSelector(selectNavigationClusterConfig);
     const engine = useSelector(selectQueryEngine);
     const [pathMenuOpen, togglePathMenuOpen] = useToggle(false);
 
     const {path} = pathActionsNode;
-    const isFavorite = favorites.includes(path);
     const navigationUrl = makeNavigationLink({path, cluster});
-
-    const handleFavoriteToggle = useCallback(() => {
-        dispatch(toggleFavoritePath(path));
-    }, [dispatch, path]);
 
     const handlePathCopy = useCallback(() => {
         dispatch(copyPathToClipboard(path));
     }, [dispatch, path]);
 
+    const handleFavoriteItemClick = useCallback(
+        ({path: favoritePath}: FavouritesItem) => {
+            if (!clusterConfig) return;
+
+            dispatch(loadPath(favoritePath, clusterConfig));
+        },
+        [clusterConfig, dispatch],
+    );
+
     if (!cluster) return null;
 
     return (
         <div className={b(null, className)}>
+            <NavigationFavorites
+                path={path}
+                cluster={cluster}
+                onItemClick={handleFavoriteItemClick}
+            />
             <Button view="flat" href={navigationUrl} target="_blank">
                 <Icon data={ArrowUpRightFromSquareIcon} size={16} />
-            </Button>
-            <Button view="flat" onClick={handleFavoriteToggle}>
-                <Icon data={isFavorite ? StarFillIcon : StarIcon} size={16} />
             </Button>
             <PathActionsMenu
                 node={pathActionsNode}

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
@@ -1,4 +1,4 @@
-import React, {type FC, useCallback, useRef, useState} from 'react';
+import React, {type FC, useCallback} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
     selectIsQueryNavigationLoading,
@@ -10,40 +10,24 @@ import {
     copyPathToClipboard,
     loadNodeByPath,
     loadTableAttributesByPath,
-    makeNewQueryWithTableSelect,
     toggleFavoritePath,
 } from '../../../../store/actions/query-tracker/queryNavigation';
 import './NodeList.scss';
 import cn from 'bem-cn-lite';
 import {isFolderNode} from '../../../../utils/navigation/isFolderNode';
 import {isTableNode} from '../../../../utils/navigation/isTableNode';
-import {useMonaco} from '../../hooks/useMonaco';
-import {insertTextWhereCursor} from '../helpers/insertTextWhereCursor';
-import {
-    selectIsQueryDraftEditted,
-    selectQueryEngine,
-} from '../../../../store/selectors/query-tracker/query';
-import {makePathByQueryEngine} from '../helpers/makePathByQueryEngine';
-import {type QueryEngine} from '../../../../../shared/constants/engines';
+import {selectQueryEngine} from '../../../../store/selectors/query-tracker/query';
 import {getNavigationUrl} from '../helpers/getNavigationUrl';
-import {createTableSelect} from '../helpers/createTableSelect';
-import {selectQueryResultGlobalSettings} from '../../../../store/selectors/query-tracker/queryResult';
-import {NewQueryPromt} from '../../NewQueryButton/NewQueryButton';
 import {ItemsList} from '../ItemsList';
 
 const b = cn('navigation-node-list');
 
 export const NodeList: FC = () => {
     const dispatch = useDispatch();
-    const [showPrompt, setShowPrompt] = useState(false);
-    const newQueryParams = useRef<{path: string; engine: QueryEngine} | null>(null);
     const clusterConfig = useSelector(selectNavigationClusterConfig);
     const nodes = useSelector(selectNodeListByFilter);
     const engine = useSelector(selectQueryEngine);
-    const {pageSize} = selectQueryResultGlobalSettings();
-    const dirtyQuery = useSelector(selectIsQueryDraftEditted);
     const loading = useSelector(selectIsQueryNavigationLoading);
-    const {getEditor} = useMonaco();
 
     const handleNodeClick = (path: string, type: string | undefined) => {
         if (isFolderNode(type)) {
@@ -63,39 +47,13 @@ export const NodeList: FC = () => {
         [dispatch],
     );
 
-    const handleEditorInsert = useCallback(
-        async (path: string, type: 'path' | 'select') => {
-            if (!clusterConfig || !clusterConfig.id) return;
-            const editor = getEditor('queryEditor');
-            let text = '';
-            if (type === 'path') {
-                text = makePathByQueryEngine({
-                    cluster: clusterConfig.id,
-                    path,
-                    engine,
-                });
-            } else {
-                text = await createTableSelect({clusterConfig, path, engine, limit: pageSize});
-            }
-            insertTextWhereCursor(text, editor);
-        },
-        [clusterConfig, engine, getEditor, pageSize],
-    );
-
     const onClipboardCopy = useCallback(
-        (path: string, type: 'path' | 'url') => {
+        (path: string) => {
             if (!clusterConfig || !clusterConfig.id) return;
-            const pathString =
-                type === 'path'
-                    ? makePathByQueryEngine({
-                          cluster: clusterConfig.id,
-                          path,
-                          engine,
-                      })
-                    : getNavigationUrl(clusterConfig.id, path);
+            const pathString = getNavigationUrl(clusterConfig.id, path);
             dispatch(copyPathToClipboard(pathString));
         },
-        [clusterConfig, dispatch, engine],
+        [clusterConfig, dispatch],
     );
 
     const handleNewWindowOpen = useCallback(
@@ -108,33 +66,6 @@ export const NodeList: FC = () => {
         [clusterConfig],
     );
 
-    const handlePromptConfirm = useCallback(() => {
-        const parameters = newQueryParams.current;
-        if (!parameters) return;
-
-        dispatch(makeNewQueryWithTableSelect(parameters.path, parameters.engine));
-        setShowPrompt(false);
-    }, [dispatch, setShowPrompt]);
-
-    const handlePromptCancel = useCallback(() => {
-        newQueryParams.current = null;
-        setShowPrompt(false);
-    }, [setShowPrompt]);
-
-    const handleNewQuery = useCallback(
-        async (path: string, newEngine: QueryEngine) => {
-            if (dirtyQuery) {
-                setShowPrompt(true);
-                newQueryParams.current = {path, engine: newEngine};
-                return;
-            }
-
-            newQueryParams.current = {path, engine: newEngine};
-            handlePromptConfirm();
-        },
-        [dirtyQuery, handlePromptConfirm, setShowPrompt],
-    );
-
     return (
         <div className={b()}>
             <ItemsList
@@ -145,21 +76,14 @@ export const NodeList: FC = () => {
                         <NodeListRow
                             key={node.path}
                             node={node}
-                            queryEngine={engine}
+                            engine={engine}
                             onClick={handleNodeClick}
                             onFavoriteToggle={handleFavoriteToggle}
-                            onEditorInsert={handleEditorInsert}
                             onClipboardCopy={onClipboardCopy}
                             onNewWindowOpen={handleNewWindowOpen}
-                            onNewQuery={handleNewQuery}
                         />
                     );
                 }}
-            />
-            <NewQueryPromt
-                confirm={handlePromptConfirm}
-                cancel={handlePromptCancel}
-                visible={showPrompt}
             />
         </div>
     );

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeList.tsx
@@ -2,6 +2,7 @@ import React, {type FC, useCallback} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {
     selectIsQueryNavigationLoading,
+    selectNavigationCluster,
     selectNavigationClusterConfig,
     selectNodeListByFilter,
 } from '../../../../store/selectors/query-tracker/queryNavigation';
@@ -10,8 +11,8 @@ import {
     copyPathToClipboard,
     loadNodeByPath,
     loadTableAttributesByPath,
-    toggleFavoritePath,
 } from '../../../../store/actions/query-tracker/queryNavigation';
+import {navigationToggleFavourite} from '../../../../store/actions/favourites';
 import './NodeList.scss';
 import cn from 'bem-cn-lite';
 import {isFolderNode} from '../../../../utils/navigation/isFolderNode';
@@ -24,6 +25,7 @@ const b = cn('navigation-node-list');
 
 export const NodeList: FC = () => {
     const dispatch = useDispatch();
+    const cluster = useSelector(selectNavigationCluster);
     const clusterConfig = useSelector(selectNavigationClusterConfig);
     const nodes = useSelector(selectNodeListByFilter);
     const engine = useSelector(selectQueryEngine);
@@ -42,9 +44,9 @@ export const NodeList: FC = () => {
 
     const handleFavoriteToggle = useCallback(
         (favoritePath: string) => {
-            dispatch(toggleFavoritePath(favoritePath));
+            dispatch(navigationToggleFavourite(favoritePath, cluster));
         },
-        [dispatch],
+        [dispatch, cluster],
     );
 
     const onClipboardCopy = useCallback(

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeListRow/NodeListRow.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeListRow/NodeListRow.tsx
@@ -1,5 +1,5 @@
 import React, {type FC, type MouseEvent} from 'react';
-import {type NavigationNode} from '../../../../../store/reducers/query-tracker/queryNavigationSlice';
+import {type NavigationNode} from '@ytsaurus/components';
 import './NodeListRow.scss';
 import cn from 'bem-cn-lite';
 import {Button, DropdownMenu, Icon} from '@gravity-ui/uikit';
@@ -7,39 +7,33 @@ import {isFolderNode} from '../../../../../utils/navigation/isFolderNode';
 import {isTableNode} from '../../../../../utils/navigation/isTableNode';
 import StarFillIcon from '@gravity-ui/icons/svgs/star-fill.svg';
 import StarIcon from '@gravity-ui/icons/svgs/star.svg';
-import TextIndentIcon from '@gravity-ui/icons/svgs/text-indent.svg';
 import ArrowUpRightFromSquareIcon from '@gravity-ui/icons/svgs/arrow-up-right-from-square.svg';
 import {useToggle} from 'react-use';
-import {QueryEngine} from '../../../../../../shared/constants/engines';
 import {MapNodeIcon} from '../../../../../components/MapNodeIcon/MapNodeIcon';
 import {NodeName} from '../NodeName';
 import i18n from './i18n';
+import {PathActionsMenu, type Props as PathActionsMenuProps} from '../../PathActionsMenu';
 
 const b = cn('navigation-node-list-row');
 
 type Props = {
     node: NavigationNode;
-    queryEngine: QueryEngine;
     onClick: (path: string, type: string | undefined) => void;
     onFavoriteToggle: (favoritePath: string) => void;
-    onClipboardCopy: (path: string, type: 'url' | 'path') => void;
-    onEditorInsert: (path: string, type: 'path' | 'select') => void;
-    onNewQuery: (path: string, engine: QueryEngine) => void;
     onNewWindowOpen: (path: string) => void;
-};
+    onClipboardCopy: (path: string) => void;
+} & Omit<PathActionsMenuProps, 'open' | 'onOpenToggle'>;
 
 export const NodeListRow: FC<Props> = ({
     node,
-    queryEngine,
+    engine,
     onClick,
     onFavoriteToggle,
     onClipboardCopy,
-    onEditorInsert,
-    onNewQuery,
     onNewWindowOpen,
 }) => {
-    const {type, dynamic, name, path, targetPath, isFavorite} = node;
-    const [tableMenuOpen, toggleTapleMenuOpen] = useToggle(false);
+    const {type, name, path, targetPath, isFavorite} = node;
+    const [pathMenuOpen, togglePathMenuOpen] = useToggle(false);
     const [menuOpen, toggleMenuOpen] = useToggle(false);
     const isSupported = isFolderNode(type) || isTableNode(type);
     const showActions = isSupported && name !== '...';
@@ -58,14 +52,9 @@ export const NodeListRow: FC<Props> = ({
         onFavoriteToggle(path);
     };
 
-    const handlePastePathClick = (e: MouseEvent<HTMLButtonElement>) => {
-        handleStop(e);
-        onEditorInsert(path, 'path');
-    };
-
     return (
         <div
-            className={b({unsupported: !isSupported, active: menuOpen || tableMenuOpen})}
+            className={b({unsupported: !isSupported, active: menuOpen || pathMenuOpen})}
             onClick={handleClick}
         >
             <div className={b('icon-wrap')}>
@@ -80,104 +69,12 @@ export const NodeListRow: FC<Props> = ({
                     <Button view="flat" onClick={handleFavoriteClick}>
                         <Icon data={isFavorite ? StarFillIcon : StarIcon} size={16} />
                     </Button>
-                    {isTableNode(type) ? (
-                        <DropdownMenu
-                            open={tableMenuOpen}
-                            onOpenToggle={toggleTapleMenuOpen}
-                            renderSwitcher={(props) => (
-                                <Button view="flat" {...props}>
-                                    <Icon data={TextIndentIcon} size={16} />
-                                </Button>
-                            )}
-                            items={[
-                                {
-                                    text: i18n('action_copy-to-clipboard'),
-                                    items: [
-                                        {
-                                            text: i18n('value_path'),
-                                            action: (e) => {
-                                                e.stopPropagation();
-                                                onClipboardCopy(path, 'path');
-                                            },
-                                        },
-                                    ],
-                                },
-                                {
-                                    text: i18n('action_insert-into-editor'),
-                                    items: [
-                                        {
-                                            text: i18n('value_path'),
-                                            action: (e) => {
-                                                e.stopPropagation();
-                                                onEditorInsert(path, 'path');
-                                            },
-                                        },
-                                        ...(dynamic || queryEngine !== QueryEngine.YT_QL
-                                            ? [
-                                                  {
-                                                      text: i18n('value_select'),
-                                                      action: (
-                                                          e:
-                                                              | React.MouseEvent<HTMLElement>
-                                                              | KeyboardEvent,
-                                                      ) => {
-                                                          e.stopPropagation();
-                                                          onEditorInsert(path, 'select');
-                                                      },
-                                                  },
-                                              ]
-                                            : []),
-                                    ],
-                                },
-                                {
-                                    text: i18n('action_create-new-query'),
-                                    items: [
-                                        ...(dynamic
-                                            ? [
-                                                  {
-                                                      text: i18n('value_select-yt-ql'),
-                                                      action: (
-                                                          e:
-                                                              | React.MouseEvent<HTMLElement>
-                                                              | KeyboardEvent,
-                                                      ) => {
-                                                          e.stopPropagation();
-                                                          onNewQuery(path, QueryEngine.YT_QL);
-                                                      },
-                                                  },
-                                              ]
-                                            : []),
-                                        {
-                                            text: i18n('value_select-yql'),
-                                            action: (e) => {
-                                                e.stopPropagation();
-                                                onNewQuery(path, QueryEngine.YQL);
-                                            },
-                                        },
-                                        {
-                                            text: i18n('value_select-chyt'),
-                                            action: (e) => {
-                                                e.stopPropagation();
-                                                onNewQuery(path, QueryEngine.CHYT);
-                                            },
-                                        },
-                                        {
-                                            text: i18n('value_select-spyt'),
-                                            action: (e) => {
-                                                e.stopPropagation();
-                                                onNewQuery(path, QueryEngine.SPYT);
-                                            },
-                                        },
-                                    ],
-                                },
-                            ]}
-                            onSwitcherClick={handleStop}
-                        />
-                    ) : (
-                        <Button view="flat" onClick={handlePastePathClick}>
-                            <Icon data={TextIndentIcon} size={16} />
-                        </Button>
-                    )}
+                    <PathActionsMenu
+                        node={node}
+                        engine={engine}
+                        open={pathMenuOpen}
+                        onOpenToggle={togglePathMenuOpen}
+                    />
                     <DropdownMenu
                         open={menuOpen}
                         onOpenToggle={toggleMenuOpen}
@@ -185,7 +82,7 @@ export const NodeListRow: FC<Props> = ({
                             {
                                 action: (e) => {
                                     e.stopPropagation();
-                                    onClipboardCopy(path, 'url');
+                                    onClipboardCopy(path);
                                 },
                                 text: i18n('action_copy-link'),
                             },

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeListRow/i18n/en.json
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NodeList/NodeListRow/i18n/en.json
@@ -1,13 +1,4 @@
 {
-  "action_copy-to-clipboard": "Copy to clipboard",
-  "action_insert-into-editor": "Insert into editor",
-  "action_create-new-query": "Create new query",
   "action_copy-link": "Copy link",
-  "action_open-in-cluster": "Open in cluster",
-  "value_path": "Path",
-  "value_select": "SELECT",
-  "value_select-yt-ql": "SELECT (YT QL)",
-  "value_select-yql": "SELECT (YQL)",
-  "value_select-chyt": "SELECT (CHYT)",
-  "value_select-spyt": "SELECT (SPYT)"
+  "action_open-in-cluster": "Open in cluster"
 }

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/PathActionsMenu.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/PathActionsMenu.tsx
@@ -1,0 +1,209 @@
+import React, {type FC, type MouseEvent, useRef, useState} from 'react';
+import {Button, DropdownMenu, Icon} from '@gravity-ui/uikit';
+import TextIndentIcon from '@gravity-ui/icons/svgs/text-indent.svg';
+import i18n from './i18n';
+import {QueryEngine} from '../../../../../shared/constants/engines';
+import type {NavigationNode} from '@ytsaurus/components';
+import {isTableNode} from '../../../../utils/navigation/isTableNode';
+import {useDispatch, useSelector} from '../../../../store/redux-hooks';
+import {selectIsQueryDraftEditted} from '../../../../store/selectors/query-tracker/query';
+import {NewQueryPromt} from '../../NewQueryButton/NewQueryButton';
+import {useMonaco} from '../../hooks/useMonaco';
+import {
+    copyPathToClipboard,
+    makeNewQueryWithTableSelect,
+} from '../../../../store/actions/query-tracker/queryNavigation';
+import {makePathByQueryEngine} from '../helpers/makePathByQueryEngine';
+import {selectNavigationClusterConfig} from '../../../../store/selectors/query-tracker/queryNavigation';
+import {createTableSelect} from '../helpers/createTableSelect';
+import {insertTextWhereCursor} from '../helpers/insertTextWhereCursor';
+import {selectQueryResultGlobalSettings} from '../../../../store/selectors/query-tracker/queryResult';
+
+export type Props = {
+    node: Pick<NavigationNode, 'path' | 'type' | 'dynamic'>;
+    engine: QueryEngine;
+    open: boolean;
+    onOpenToggle: () => void;
+};
+
+export const PathActionsMenu: FC<Props> = ({node, engine, open, onOpenToggle}) => {
+    const dispatch = useDispatch();
+    const dirtyQuery = useSelector(selectIsQueryDraftEditted);
+    const clusterConfig = useSelector(selectNavigationClusterConfig);
+    const {getEditor} = useMonaco();
+    const {pageSize} = selectQueryResultGlobalSettings();
+
+    const [showPrompt, setShowPrompt] = useState(false);
+    const newQueryParams = useRef<{path: string; engine: QueryEngine} | null>(null);
+    const {dynamic, path, type} = node;
+    const tableNode = isTableNode(type);
+
+    const handleStop = (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+    };
+
+    const handlePromptConfirm = () => {
+        const parameters = newQueryParams.current;
+        if (!parameters) return;
+
+        dispatch(makeNewQueryWithTableSelect(parameters.path, parameters.engine));
+        setShowPrompt(false);
+    };
+
+    const handlePromptCancel = () => {
+        newQueryParams.current = null;
+        setShowPrompt(false);
+    };
+
+    const handleNewQuery = (queryPath: string, newEngine: QueryEngine) => {
+        if (dirtyQuery) {
+            setShowPrompt(true);
+            newQueryParams.current = {path: queryPath, engine: newEngine};
+            return;
+        }
+
+        newQueryParams.current = {path: queryPath, engine: newEngine};
+        handlePromptConfirm();
+    };
+
+    const handleClipboardCopy = (nodePath: string) => {
+        if (!clusterConfig || !clusterConfig.id) return;
+        const pathString = makePathByQueryEngine({
+            cluster: clusterConfig.id,
+            path: nodePath,
+            engine,
+        });
+        dispatch(copyPathToClipboard(pathString));
+    };
+
+    const handleEditorInsert = async (nodePath: string, insertMode: 'path' | 'select') => {
+        if (!clusterConfig || !clusterConfig.id) return;
+        const editor = getEditor('queryEditor');
+        let text = '';
+        if (insertMode === 'path') {
+            text = makePathByQueryEngine({
+                cluster: clusterConfig.id,
+                path: nodePath,
+                engine,
+            });
+        } else {
+            text = await createTableSelect({
+                clusterConfig,
+                path: nodePath,
+                engine,
+                limit: pageSize,
+            });
+        }
+        insertTextWhereCursor(text, editor);
+    };
+
+    return (
+        <>
+            <DropdownMenu
+                open={open}
+                onOpenToggle={onOpenToggle}
+                renderSwitcher={(props) => (
+                    <Button view="flat" {...props}>
+                        <Icon data={TextIndentIcon} size={16} />
+                    </Button>
+                )}
+                items={[
+                    {
+                        text: i18n('action_copy-to-clipboard'),
+                        items: [
+                            {
+                                text: i18n('value_path'),
+                                action: (e) => {
+                                    e.stopPropagation();
+                                    handleClipboardCopy(path);
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        text: i18n('action_insert-into-editor'),
+                        items: [
+                            {
+                                text: i18n('value_path'),
+                                action: (e) => {
+                                    e.stopPropagation();
+                                    handleEditorInsert(path, 'path');
+                                },
+                            },
+                            ...(tableNode && (dynamic || engine !== QueryEngine.YT_QL)
+                                ? [
+                                      {
+                                          text: i18n('value_select'),
+                                          action: (
+                                              e: React.MouseEvent<HTMLElement> | KeyboardEvent,
+                                          ) => {
+                                              e.stopPropagation();
+                                              handleEditorInsert(path, 'select');
+                                          },
+                                      },
+                                  ]
+                                : []),
+                        ],
+                    },
+                    ...(tableNode
+                        ? [
+                              {
+                                  text: i18n('action_create-new-query'),
+                                  items: [
+                                      ...(dynamic
+                                          ? [
+                                                {
+                                                    text: i18n('value_select-yt-ql'),
+                                                    action: (
+                                                        e:
+                                                            | React.MouseEvent<HTMLElement>
+                                                            | KeyboardEvent,
+                                                    ) => {
+                                                        e.stopPropagation();
+                                                        handleNewQuery(path, QueryEngine.YT_QL);
+                                                    },
+                                                },
+                                            ]
+                                          : []),
+                                      {
+                                          text: i18n('value_select-yql'),
+                                          action: (
+                                              e: React.MouseEvent<HTMLElement> | KeyboardEvent,
+                                          ) => {
+                                              e.stopPropagation();
+                                              handleNewQuery(path, QueryEngine.YQL);
+                                          },
+                                      },
+                                      {
+                                          text: i18n('value_select-chyt'),
+                                          action: (
+                                              e: React.MouseEvent<HTMLElement> | KeyboardEvent,
+                                          ) => {
+                                              e.stopPropagation();
+                                              handleNewQuery(path, QueryEngine.CHYT);
+                                          },
+                                      },
+                                      {
+                                          text: i18n('value_select-spyt'),
+                                          action: (
+                                              e: React.MouseEvent<HTMLElement> | KeyboardEvent,
+                                          ) => {
+                                              e.stopPropagation();
+                                              handleNewQuery(path, QueryEngine.SPYT);
+                                          },
+                                      },
+                                  ],
+                              },
+                          ]
+                        : []),
+                ]}
+                onSwitcherClick={handleStop}
+            />
+            <NewQueryPromt
+                confirm={handlePromptConfirm}
+                cancel={handlePromptCancel}
+                visible={showPrompt}
+            />
+        </>
+    );
+};

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/i18n/en.json
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/i18n/en.json
@@ -1,0 +1,11 @@
+{
+  "action_copy-to-clipboard": "Copy to clipboard",
+  "action_insert-into-editor": "Insert into editor",
+  "action_create-new-query": "Create new query",
+  "value_path": "Path",
+  "value_select": "SELECT",
+  "value_select-yt-ql": "SELECT (YT QL)",
+  "value_select-yql": "SELECT (YQL)",
+  "value_select-chyt": "SELECT (CHYT)",
+  "value_select-spyt": "SELECT (SPYT)"
+}

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/i18n/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:query-tracker.navigation-path-actions-menu', dicts);

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/index.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/PathActionsMenu/index.ts
@@ -1,0 +1,1 @@
+export {PathActionsMenu, type Props} from './PathActionsMenu';

--- a/packages/ui/src/ui/store/actions/favourites.js
+++ b/packages/ui/src/ui/store/actions/favourites.js
@@ -9,7 +9,8 @@ import {
     selectClusterNS,
     selectGetSetting,
 } from '../../store/selectors/settings';
-import {SettingName} from '../../../shared/constants/settings';
+import {NAMESPACES, SettingName} from '../../../shared/constants/settings';
+import {createNestedNS} from '../../../shared/utils/settings';
 import {reloadSetting, setSetting} from '../../store/actions/settings';
 
 import {selectActiveAccount} from '../../store/selectors/accounts/accounts';
@@ -97,11 +98,13 @@ export function chytToggleFavourite(clique) {
     };
 }
 
-export function navigationToggleFavourite(path) {
+export function navigationToggleFavourite(path, cluster) {
     getMetrics().countEvent('navigation_toggle-favourites');
 
-    return (dispatch, getState) => {
-        const parentNS = selectClusterNS(getState());
+    return (dispatch) => {
+        if (!cluster) return;
+
+        const parentNS = createNestedNS(cluster, NAMESPACES.LOCAL);
         return dispatch(toggleFavourite(path, parentNS));
     };
 }

--- a/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
@@ -16,6 +16,7 @@ import {
     setNodeType,
     setNodes,
     setPath,
+    setPathTargetNode,
     setTable,
 } from '../../reducers/query-tracker/queryNavigationSlice';
 import {
@@ -51,6 +52,63 @@ import {toaster} from '../../../utils/toaster';
 import {ytComponentsNavigationMetaConfig} from '../../../components/MetaTable/ytComponentsNavigationMetaConfig';
 
 type AsyncAction = ThunkAction<void, RootState, undefined, Action>;
+
+const loadPathTargetNode =
+    (path: string): AsyncAction =>
+    async (dispatch, getState) => {
+        const state = getState();
+        const clusterConfig = selectNavigationClusterConfig(state);
+        const nodeList = selectNavigationNodes(state);
+
+        const nodeFromList = nodeList.find((node) => node.path === path);
+        if (nodeFromList?.type) {
+            dispatch(
+                setPathTargetNode({
+                    type: nodeFromList.type,
+                    dynamic: nodeFromList.dynamic,
+                }),
+            );
+            return;
+        }
+
+        if (!clusterConfig) return;
+
+        try {
+            const setup = {
+                proxy: getClusterProxy(clusterConfig),
+                JSONSerializer,
+            };
+
+            const results = await ytApiV3Id.executeBatch(YTApiId.navigationGetPath, {
+                parameters: {
+                    requests: [
+                        {
+                            command: 'get',
+                            parameters: {
+                                path: `${path}/@type`,
+                            },
+                        },
+                        {
+                            command: 'get',
+                            parameters: {
+                                path: `${path}/@dynamic`,
+                            },
+                        },
+                    ],
+                },
+                setup,
+            });
+
+            dispatch(
+                setPathTargetNode({
+                    type: results[0].output as string,
+                    dynamic: Boolean(results[1].output),
+                }),
+            );
+        } catch {
+            dispatch(setPathTargetNode(undefined));
+        }
+    };
 
 export const toggleFavoritePath =
     (favoritePath: string): AsyncAction =>
@@ -104,6 +162,7 @@ export const loadNodeByPath =
         dispatch(setFilter(''));
         dispatch(setPath(path));
         dispatch(setNodeType(BodyType.Tree));
+        dispatch(setPathTargetNode(undefined));
         dispatch(setNodes(nodes as NavigationNode[]));
     };
 
@@ -127,6 +186,7 @@ export const loadTableAttributesByPath =
         };
 
         try {
+            await dispatch(loadPathTargetNode(path));
             const tableData = await loadTableAttributesByPathFromComponents(path, setup, {
                 clusterId: clusterConfig.id,
                 login,

--- a/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/queryNavigation.ts
@@ -30,9 +30,6 @@ import {
 import {wrapApiPromiseByToaster} from '../../../utils/utils';
 import {YTApiId, ytApiV3Id} from '../../../rum/rum-wrap-api';
 import {JSONSerializer} from '../../../common/yt-api';
-import {toggleFavourite} from '../favourites';
-import {createNestedNS} from '../../../../shared/utils/settings';
-import {NAMESPACES} from '../../../../shared/constants/settings';
 import {isTableNode} from '../../../utils/navigation/isTableNode';
 import {isFolderNode} from '../../../utils/navigation/isFolderNode';
 import {QueryEngine} from '../../../../shared/constants/engines';
@@ -108,29 +105,6 @@ const loadPathTargetNode =
         } catch {
             dispatch(setPathTargetNode(undefined));
         }
-    };
-
-export const toggleFavoritePath =
-    (favoritePath: string): AsyncAction =>
-    (dispatch, getState) => {
-        const state = getState();
-        const cluster = selectNavigationCluster(state);
-        const nodes = selectNavigationNodes(state);
-
-        if (!cluster) return;
-        const parentNS = createNestedNS(cluster, NAMESPACES.LOCAL);
-        dispatch(toggleFavourite(favoritePath, parentNS));
-
-        const newNodes = nodes.map((node) => {
-            if (node.path === favoritePath) {
-                return {
-                    ...node,
-                    isFavorite: !node.isFavorite,
-                };
-            }
-            return node;
-        });
-        dispatch(setNodes(newNodes));
     };
 
 // nodes list by path

--- a/packages/ui/src/ui/store/reducers/query-tracker/queryNavigationSlice.ts
+++ b/packages/ui/src/ui/store/reducers/query-tracker/queryNavigationSlice.ts
@@ -24,6 +24,7 @@ export type RepoNavigationState = {
     cluster: string | undefined;
     filter: string;
     nodes: NavigationNode[];
+    pathTargetNode?: Pick<NavigationNode, 'type' | 'dynamic'>;
     table?: NavigationTable;
     error?: YTError;
 };
@@ -61,6 +62,9 @@ const queryNavigationSlice = createSlice({
         setNodes(state, {payload}: PayloadAction<any>) {
             state.nodes = payload;
         },
+        setPathTargetNode(state, {payload}: PayloadAction<RepoNavigationState['pathTargetNode']>) {
+            state.pathTargetNode = payload;
+        },
         setTable(state, {payload}: PayloadAction<NavigationTable>) {
             state.table = payload;
         },
@@ -77,6 +81,7 @@ export const {
     setPath,
     setNodeType,
     setNodes,
+    setPathTargetNode,
     setTable,
     setError,
 } = queryNavigationSlice.actions;

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -14,7 +14,6 @@ import {
 } from '../../store/selectors/settings';
 import {SettingName} from '../../../shared/constants/settings';
 import {selectActiveAccount} from '../../store/selectors/accounts/accounts';
-import {selectPath} from '../../store/selectors/navigation';
 import {selectPool, selectTree} from '../../store/selectors/scheduling/scheduling';
 import {selectTabletsActiveBundle} from './tablet_cell_bundles';
 import {selectChaosActiveBundle} from './chaos_cell_bundles';
@@ -69,11 +68,6 @@ export const selectLastVisitedPaths = createSelector(
 );
 
 export const selectPopularPaths = createSelector([selectLastVisitedPaths], preparePopulars);
-
-export const selectIsCurrentPathInFavourites = createSelector(
-    [selectPath, selectFavouritePaths],
-    prepareIsInFavourites,
-);
 
 //************* Selectors for Scheduling *****************
 

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
@@ -75,10 +75,17 @@ export const selectClustersByFilter: (state: RootState) => ReturnType<typeof sel
     });
 
 export const selectNodeListByFilter = createSelector(
-    [selectNavigationNodes, selectNavigationFilter, selectNavigationPath],
-    (nodes, filter, path) => {
+    [selectNavigationNodes, selectNavigationFilter, selectNavigationPath, selectFavouritePaths],
+    (nodes, filter, path, favouritePaths) => {
         const isRoot = !path || path === '/';
         const parentPath = isRoot ? path : path.split('/').slice(0, -1).join('/');
+
+        const favouritePathSet = new Set(favouritePaths);
+        const nodesWithFavoriteState = nodes.map((node) => {
+            const isFavorite = favouritePathSet.has(node.path);
+            return node.isFavorite === isFavorite ? node : {...node, isFavorite};
+        });
+
         const upItem: NavigationNode = {
             name: '...',
             type: 'map_node',
@@ -86,9 +93,9 @@ export const selectNodeListByFilter = createSelector(
             isFavorite: false,
         };
 
-        if (!filter) return isRoot ? nodes : [upItem, ...nodes];
+        if (!filter) return isRoot ? nodesWithFavoriteState : [upItem, ...nodesWithFavoriteState];
 
-        const result = nodes.filter(({name}) => filterValueInText(name, filter));
+        const result = nodesWithFavoriteState.filter(({name}) => filterValueInText(name, filter));
 
         if (!isRoot) {
             result.unshift(upItem);

--- a/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queryNavigation.ts
@@ -1,7 +1,7 @@
 import {type RootState} from '../../reducers';
 import {createSelector} from 'reselect';
 import {selectClusterList} from '../slideoutMenu';
-import {type NavigationNode} from '../../reducers/query-tracker/queryNavigationSlice';
+import {BodyType, type NavigationNode} from '../../reducers/query-tracker/queryNavigationSlice';
 import {selectGetSetting} from '../settings';
 import {createNestedNS} from '../../../../shared/utils/settings';
 import {NAMESPACES, SettingName} from '../../../../shared/constants/settings';
@@ -42,6 +42,25 @@ export const selectNavigationFilter = (state: RootState) =>
     state.queryTracker.queryNavigation.filter;
 
 export const selectNavigationNodes = (state: RootState) => state.queryTracker.queryNavigation.nodes;
+
+export const selectPathTargetNode = (state: RootState) =>
+    state.queryTracker.queryNavigation.pathTargetNode;
+
+export const selectPathActionsNode = createSelector(
+    [selectNavigationPath, selectNavigationNodes, selectPathTargetNode, selectNavigationNodeType],
+    (path, nodes, pathTargetNode, bodyType): Pick<NavigationNode, 'path' | 'type' | 'dynamic'> => {
+        const nodeFromList = nodes.find((node) => node.path === path);
+
+        return {
+            path,
+            type:
+                nodeFromList?.type ??
+                pathTargetNode?.type ??
+                (bodyType === BodyType.Table ? 'table' : undefined),
+            dynamic: nodeFromList?.dynamic ?? pathTargetNode?.dynamic,
+        };
+    },
+);
 
 export const selectNavigationTable = (state: RootState) => state.queryTracker.queryNavigation.table;
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/awpYfK3H7hFbhf
<!-- nda-end -->    ## Summary by Sourcery

Introduce a unified, reusable path actions menu for query navigation and header, and adjust path-related state to support it.

New Features:
- Add a shared PathActionsMenu component that provides path copying, editor insertion, and new-query creation actions for navigation nodes.
- Add a NavigationFavorites component in the navigation header to expose and manage favorite paths via a dropdown.

Bug Fixes:
- Ensure path action availability in the header for table views by inferring node type when it is not present in the node list.

Enhancements:
- Refactor NodeListRow and Navigation header actions to use the unified PathActionsMenu instead of duplicating path action logic.
- Extend query navigation state and selectors to derive a generic path actions node, including type and dynamic flags, for both list rows and header.
- Reuse the shared NavigationNode type from @ytsaurus/components for node list rows.