### PR TITLE
chore(scheduling): rename selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/hooks/global-pool-trees.ts
+++ b/packages/ui/src/ui/hooks/global-pool-trees.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import {useDispatch, useSelector} from '../store/redux-hooks';
 
 import {loadPoolTreesIfNotLoaded} from '../store/actions/global';
-import {getTree} from '../store/selectors/scheduling/scheduling';
+import {selectTree} from '../store/selectors/scheduling/scheduling';
 import {loadDefaultPoolTree} from '../utils/poolTrees';
 
 export function usePoolTreesLoaded() {
@@ -31,7 +31,7 @@ export function useDefaultPoolTree() {
 }
 
 export function usePoolTreeOrDefaultPoolTree() {
-    const tree = useSelector(getTree);
+    const tree = useSelector(selectTree);
     const defaultTree = useDefaultPoolTree();
     return tree || defaultTree;
 }

--- a/packages/ui/src/ui/pages/scheduling/Content/Content.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/Content.tsx
@@ -19,11 +19,11 @@ import PoolAcl from '../../../pages/scheduling/Content/tabs/PoolAcl/PoolAcl';
 import {useSelector} from '../../../store/redux-hooks';
 import {selectCluster} from '../../../store/selectors/global';
 import {
-    getIsRoot,
-    getPool,
-    getPoolIsEphemeral,
-    getTree,
-    isPoolAclAllowed,
+    selectIsPoolAclAllowed,
+    selectPool,
+    selectPoolIsEphemeral,
+    selectSchedulingIsRoot,
+    selectTree,
 } from '../../../store/selectors/scheduling/scheduling';
 import {type TabSettings, makeTabProps} from '../../../utils';
 import {makeSchedulingUrl} from '../../../utils/app-url';
@@ -43,11 +43,11 @@ type ContentProps = {
 
 function Content({match, location}: ContentProps) {
     const cluster = useSelector(selectCluster);
-    const pool = useSelector(getPool);
-    const tree = useSelector(getTree);
-    const isEphemeral = useSelector(getPoolIsEphemeral);
-    const isRoot = useSelector(getIsRoot);
-    const allowAcl = useSelector(isPoolAclAllowed);
+    const pool = useSelector(selectPool);
+    const tree = useSelector(selectTree);
+    const isEphemeral = useSelector(selectPoolIsEphemeral);
+    const isRoot = useSelector(selectSchedulingIsRoot);
+    const allowAcl = useSelector(selectIsPoolAclAllowed);
 
     const localTab: Record<string, string> = {...SchedulingTab};
 

--- a/packages/ui/src/ui/pages/scheduling/Content/SchedulingExpandedPoolsUpdater.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/SchedulingExpandedPoolsUpdater.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import {getPool, getTree} from '../../../store/selectors/scheduling/scheduling';
+import {selectPool, selectTree} from '../../../store/selectors/scheduling/scheduling';
 import {useDispatch, useSelector} from '../../../store/redux-hooks';
 import {loadExpandedPools} from '../../../store/actions/scheduling/expanded-pools';
 
 function SchedulingExpandedPoolsUpdater() {
-    const tree = useSelector(getTree);
-    const name = useSelector(getPool);
+    const tree = useSelector(selectTree);
+    const name = useSelector(selectPool);
 
     const dispatch = useDispatch();
 

--- a/packages/ui/src/ui/pages/scheduling/Content/SchedulingResources.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/SchedulingResources.tsx
@@ -5,7 +5,10 @@ import map_ from 'lodash/map';
 import isEmpty_ from 'lodash/isEmpty';
 
 import hammer from '../../../common/hammer';
-import {getIsRoot, getResources} from '../../../store/selectors/scheduling/scheduling';
+import {
+    selectResources,
+    selectSchedulingIsRoot,
+} from '../../../store/selectors/scheduling/scheduling';
 import {Progress} from '@gravity-ui/uikit';
 
 import './SchedulingResources.scss';
@@ -14,8 +17,8 @@ const block = cn('scheduling-resources');
 const headingBlock = cn('elements-heading');
 
 function SchedulingResources() {
-    const isRoot = useSelector(getIsRoot);
-    const resources = useSelector(getResources) as any;
+    const isRoot = useSelector(selectSchedulingIsRoot);
+    const resources = useSelector(selectResources) as any;
 
     return !isRoot || isEmpty_(resources) ? null : (
         <div className={block()}>

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Monitoring/SchedulingMonitoring.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Monitoring/SchedulingMonitoring.tsx
@@ -4,12 +4,12 @@ import {useSelector} from 'react-redux';
 import {PrometheusDashboardLazy} from '../../../../../containers/PrometheusDashboard/lazy';
 
 import {selectCluster} from '../../../../../store/selectors/global';
-import {getPool, getTree} from '../../../../../store/selectors/scheduling/scheduling';
+import {selectPool, selectTree} from '../../../../../store/selectors/scheduling/scheduling';
 
 export function SchedulingMonitoring() {
     const cluster = useSelector(selectCluster);
-    const pool = useSelector(getPool);
-    const tree = useSelector(getTree);
+    const pool = useSelector(selectPool);
+    const tree = useSelector(selectTree);
 
     const params = React.useMemo(() => {
         return !cluster || !pool || !tree ? undefined : {cluster, tree, pool};

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingMeta.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingMeta.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../../../store/selectors/scheduling/scheduling';
 import {
     type PoolStaticConfigurationItem,
-    getCurrentPoolGuarantees,
+    selectCurrentPoolGuarantees,
 } from '../../../../../store/selectors/scheduling/scheduling-ts';
 import {addProgressStackSpacers} from '../../../../../utils/progress';
 import {type PoolData} from '../../../../../utils/scheduling/pool-child';
@@ -32,7 +32,7 @@ const block = cn('yt-scheduling-meta');
 export function SchedulingMeta() {
     const pool = useSelector(getCurrentPool);
 
-    const guarantees = useSelector(getCurrentPoolGuarantees);
+    const guarantees = useSelector(selectCurrentPoolGuarantees);
     const mainResource = useSelector(getSchedulingTreeMainResource);
 
     // eslint-disable-next-line complexity

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingMeta.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingMeta.tsx
@@ -13,8 +13,8 @@ import {ColorCircle} from '../../../../../components/ColorCircle/ColorCircle';
 import {MetaTable, type MetaTableItem, Tooltip, YTText} from '@ytsaurus/components';
 import {ROOT_POOL_NAME} from '../../../../../constants/scheduling';
 import {
-    getCurrentPool,
-    getSchedulingTreeMainResource,
+    selectCurrentPool,
+    selectSchedulingTreeMainResource,
 } from '../../../../../store/selectors/scheduling/scheduling';
 import {
     type PoolStaticConfigurationItem,
@@ -30,10 +30,10 @@ import './SchedulingMeta.scss';
 const block = cn('yt-scheduling-meta');
 
 export function SchedulingMeta() {
-    const pool = useSelector(getCurrentPool);
+    const pool = useSelector(selectCurrentPool);
 
     const guarantees = useSelector(selectCurrentPoolGuarantees);
-    const mainResource = useSelector(getSchedulingTreeMainResource);
+    const mainResource = useSelector(selectSchedulingTreeMainResource);
 
     // eslint-disable-next-line complexity
     const {items, subTitles} = React.useMemo(() => {

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/NameCell.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/NameCell.tsx
@@ -12,7 +12,7 @@ import {
     getCurrentPool,
     getCurrentTreeExpandedPools,
 } from '../../../../../../store/selectors/scheduling/scheduling';
-import {getTree} from '../../../../../../store/selectors/scheduling/scheduling-pools';
+import {selectTree} from '../../../../../../store/selectors/scheduling/scheduling-pools';
 import {type PoolLeafNode} from '../../../../../../utils/scheduling/pool-child';
 import {unquote} from '../../../../../../utils/string';
 import {YSON_AS_TEXT, prettyPrintSafe} from '../../../../../../utils/unipika';
@@ -25,7 +25,7 @@ const block = cn('yt-scheduling-name-cell');
 
 export function NameCell({row}: {row: RowData}) {
     const cluster = useSelector(selectCluster);
-    const tree = useSelector(getTree);
+    const tree = useSelector(selectTree);
     const currentPool = useSelector(getCurrentPool);
 
     const dispatch = useDispatch();

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/NameCell.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/NameCell.tsx
@@ -9,8 +9,8 @@ import {setExpandedPools} from '../../../../../../store/actions/scheduling/expan
 import {useDispatch, useSelector} from '../../../../../../store/redux-hooks';
 import {selectCluster} from '../../../../../../store/selectors/global/cluster';
 import {
-    getCurrentPool,
-    getCurrentTreeExpandedPools,
+    selectCurrentPool,
+    selectCurrentTreeExpandedPools,
 } from '../../../../../../store/selectors/scheduling/scheduling';
 import {selectTree} from '../../../../../../store/selectors/scheduling/scheduling-pools';
 import {type PoolLeafNode} from '../../../../../../utils/scheduling/pool-child';
@@ -26,10 +26,10 @@ const block = cn('yt-scheduling-name-cell');
 export function NameCell({row}: {row: RowData}) {
     const cluster = useSelector(selectCluster);
     const tree = useSelector(selectTree);
-    const currentPool = useSelector(getCurrentPool);
+    const currentPool = useSelector(selectCurrentPool);
 
     const dispatch = useDispatch();
-    const expandedPools = useSelector(getCurrentTreeExpandedPools);
+    const expandedPools = useSelector(selectCurrentTreeExpandedPools);
 
     const handlePoolExpand = React.useCallback(
         (poolName: string, value: boolean) => {

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
@@ -24,7 +24,7 @@ import Label from '../../../../../../components/Label';
 import {MetaTable, Tooltip} from '@ytsaurus/components';
 import {OperationType} from '../../../../../../components/OperationType/OperationType';
 import {SubjectCard} from '../../../../../../components/SubjectLink/SubjectLink';
-import {getSchedulingOperationsLoading} from '../../../../../../store/selectors/scheduling/expanded-pools';
+import {selectSchedulingOperationsLoading} from '../../../../../../store/selectors/scheduling/expanded-pools';
 import {
     getSchedulingContentMode,
     getSchedulingLoading,
@@ -711,7 +711,7 @@ function useSchedulingTableColumns() {
 }
 
 function NameHeader() {
-    const expandedeLoading = useSelector(getSchedulingOperationsLoading);
+    const expandedeLoading = useSelector(selectSchedulingOperationsLoading);
     const loading = useSelector(getSchedulingLoading);
     return (
         <SchedulingColumnHeader

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
@@ -26,12 +26,12 @@ import {OperationType} from '../../../../../../components/OperationType/Operatio
 import {SubjectCard} from '../../../../../../components/SubjectLink/SubjectLink';
 import {selectSchedulingOperationsLoading} from '../../../../../../store/selectors/scheduling/expanded-pools';
 import {
-    getSchedulingContentMode,
-    getSchedulingLoading,
-    getSchedulingOverviewTableItems,
-    getSchedulingShowAbsResources,
-    getSchedulingSortState,
-    getSchedulingTreeMainResource,
+    selectSchedulingContentMode,
+    selectSchedulingLoading,
+    selectSchedulingOverviewTableItems,
+    selectSchedulingShowAbsResources,
+    selectSchedulingSortState,
+    selectSchedulingTreeMainResource,
 } from '../../../../../../store/selectors/scheduling/scheduling';
 
 import {type KeysByType} from '../../../../../../../@types/types';
@@ -61,7 +61,7 @@ import './SchedulingTable.scss';
 
 const block = cn('yt-scheduling-table');
 
-export type RowData = ReturnType<typeof getSchedulingOverviewTableItems>[number];
+export type RowData = ReturnType<typeof selectSchedulingOverviewTableItems>[number];
 
 export function SchedulingTable() {
     const {columnSizes, setColumnSizes} = useSettingsColumnSizes(
@@ -74,7 +74,7 @@ export function SchedulingTable() {
     );
 
     const {columns, columnVisibility, columnOrder} = useSchedulingTableColumns();
-    const items = useSelector(getSchedulingOverviewTableItems);
+    const items = useSelector(selectSchedulingOverviewTableItems);
 
     const operationRefId = useSelector(selectSchedulingOperationRefId);
 
@@ -122,7 +122,7 @@ export function SchedulingTable() {
     );
 }
 
-type SchedulintTableMode = ReturnType<typeof getSchedulingContentMode>;
+type SchedulintTableMode = ReturnType<typeof selectSchedulingContentMode>;
 
 const COLUMNS_BY_MODE: Record<SchedulintTableMode, Array<SchedulingColumn>> = {
     summary: [
@@ -198,7 +198,7 @@ const COLUMNS_BY_MODE: Record<SchedulintTableMode, Array<SchedulingColumn>> = {
 };
 
 function useSchedulingVisibleColumns() {
-    const mode = useSelector(getSchedulingContentMode);
+    const mode = useSelector(selectSchedulingContentMode);
     const customColumns = useSelector(selectSchedulingOverivewColumns);
 
     return mode === 'custom' ? customColumns : (COLUMNS_BY_MODE[mode] ?? []);
@@ -712,7 +712,7 @@ function useSchedulingTableColumns() {
 
 function NameHeader() {
     const expandedeLoading = useSelector(selectSchedulingOperationsLoading);
-    const loading = useSelector(getSchedulingLoading);
+    const loading = useSelector(selectSchedulingLoading);
     return (
         <SchedulingColumnHeader
             title={i18n('title_pool-operation')}
@@ -729,8 +729,8 @@ type ResourceSummaryProps = {
 };
 
 function ResourceSummary({item, type}: ResourceSummaryProps) {
-    const showAbsResources = useSelector(getSchedulingShowAbsResources);
-    const dominantResource = useSelector(getSchedulingTreeMainResource) ?? 'CPU';
+    const showAbsResources = useSelector(selectSchedulingShowAbsResources);
+    const dominantResource = useSelector(selectSchedulingTreeMainResource) ?? 'CPU';
 
     const {fairShareRatio} = item;
 
@@ -903,7 +903,7 @@ function FairShareUsage({item}: {item: RowData}) {
 function SchedulingColumnHeader(props: ColumnHeaderProps<SchedulingColumn>) {
     const dispatch = useDispatch();
 
-    const [sortState] = useSelector(getSchedulingSortState);
+    const [sortState] = useSelector(selectSchedulingSortState);
 
     const order = props.column === sortState?.column ? sortState.order : undefined;
 
@@ -959,7 +959,7 @@ function SchedulingColumnHeader(props: ColumnHeaderProps<SchedulingColumn>) {
 }
 
 function SchedulingTableSettings<T extends tanstack.Table<any>>({table}: {table: T}) {
-    const mode = useSelector(getSchedulingContentMode);
+    const mode = useSelector(selectSchedulingContentMode);
 
     return mode === 'custom' ? <TableSettings table={table} /> : null;
 }

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
@@ -47,7 +47,7 @@ import {
 } from '../../../../../../store/actions/scheduling/scheduling';
 import {openPoolDeleteModal} from '../../../../../../store/actions/scheduling/scheduling-ts';
 import {useDispatch, useSelector} from '../../../../../../store/redux-hooks';
-import {getSchedulingOperationRefId} from '../../../../../../store/selectors/scheduling/attributes-to-filter';
+import {selectSchedulingOperationRefId} from '../../../../../../store/selectors/scheduling/attributes-to-filter';
 import {selectSchedulingOverivewColumns} from '../../../../../../store/selectors/scheduling/overview-columns';
 import {getProgressTheme} from '../../../../../../utils/progress';
 import {
@@ -76,7 +76,7 @@ export function SchedulingTable() {
     const {columns, columnVisibility, columnOrder} = useSchedulingTableColumns();
     const items = useSelector(getSchedulingOverviewTableItems);
 
-    const operationRefId = useSelector(getSchedulingOperationRefId);
+    const operationRefId = useSelector(selectSchedulingOperationRefId);
 
     const table = useTable({
         columns,

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
@@ -48,7 +48,7 @@ import {
 import {openPoolDeleteModal} from '../../../../../../store/actions/scheduling/scheduling-ts';
 import {useDispatch, useSelector} from '../../../../../../store/redux-hooks';
 import {getSchedulingOperationRefId} from '../../../../../../store/selectors/scheduling/attributes-to-filter';
-import {getSchedulingOverivewColumns} from '../../../../../../store/selectors/scheduling/overview-columns';
+import {selectSchedulingOverivewColumns} from '../../../../../../store/selectors/scheduling/overview-columns';
 import {getProgressTheme} from '../../../../../../utils/progress';
 import {
     type SchedulingColumn,
@@ -199,7 +199,7 @@ const COLUMNS_BY_MODE: Record<SchedulintTableMode, Array<SchedulingColumn>> = {
 
 function useSchedulingVisibleColumns() {
     const mode = useSelector(getSchedulingContentMode);
-    const customColumns = useSelector(getSchedulingOverivewColumns);
+    const customColumns = useSelector(selectSchedulingOverivewColumns);
 
     return mode === 'custom' ? customColumns : (COLUMNS_BY_MODE[mode] ?? []);
 }

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingToolbar.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingToolbar.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../../../store/actions/scheduling/scheduling';
 import {schedulingSetAbcFilter} from '../../../../../store/actions/scheduling/scheduling-ts';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
-import {getSchedulingAbcFilter} from '../../../../../store/selectors/scheduling/attributes-to-filter';
+import {selectSchedulingAbcFilter} from '../../../../../store/selectors/scheduling/attributes-to-filter';
 import {getExpandedPoolsLoadAll} from '../../../../../store/selectors/scheduling/expanded-pools';
 import {
     SCHEDULING_CONTENT_MODES,
@@ -70,7 +70,7 @@ function SchedulingContentMode() {
 
 function SchedulingAbc() {
     const dispatch = useDispatch();
-    const {slug} = useSelector(getSchedulingAbcFilter) ?? {};
+    const {slug} = useSelector(selectSchedulingAbcFilter) ?? {};
 
     return UIFactory.renderControlAbcService({
         className: block('abc-filter'),

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingToolbar.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingToolbar.tsx
@@ -14,7 +14,7 @@ import {
 import {schedulingSetAbcFilter} from '../../../../../store/actions/scheduling/scheduling-ts';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {selectSchedulingAbcFilter} from '../../../../../store/selectors/scheduling/attributes-to-filter';
-import {getExpandedPoolsLoadAll} from '../../../../../store/selectors/scheduling/expanded-pools';
+import {selectExpandedPoolsLoadAll} from '../../../../../store/selectors/scheduling/expanded-pools';
 import {
     SCHEDULING_CONTENT_MODES,
     getSchedulingContentMode,
@@ -85,7 +85,7 @@ export function SchedulingExpandAll() {
     const [showConfirmation, setShowConfirmation] = React.useState(false);
 
     const dispatch = useDispatch();
-    const loadAll = useSelector(getExpandedPoolsLoadAll);
+    const loadAll = useSelector(selectExpandedPoolsLoadAll);
 
     const confirmation = showConfirmation ? (
         <DialogWrapper open={true} onClose={() => {}}>

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingToolbar.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingToolbar.tsx
@@ -17,8 +17,8 @@ import {selectSchedulingAbcFilter} from '../../../../../store/selectors/scheduli
 import {selectExpandedPoolsLoadAll} from '../../../../../store/selectors/scheduling/expanded-pools';
 import {
     SCHEDULING_CONTENT_MODES,
-    getSchedulingContentMode,
-    getSchedulingShowAbsResources,
+    selectSchedulingContentMode,
+    selectSchedulingShowAbsResources,
 } from '../../../../../store/selectors/scheduling/scheduling';
 
 import {PoolsSuggest} from '../../../../../pages/scheduling/PoolsSuggest/PoolsSuggest';
@@ -30,7 +30,7 @@ import './SchedulingToolbar.scss';
 const block = cn('yt-scheduling-toolbar');
 
 export function SchedulingToolbar() {
-    const mode = useSelector(getSchedulingContentMode);
+    const mode = useSelector(selectSchedulingContentMode);
 
     return (
         <Toolbar
@@ -52,7 +52,7 @@ export function SchedulingToolbar() {
 
 function SchedulingContentMode() {
     const dispatch = useDispatch();
-    const mode = useSelector(getSchedulingContentMode);
+    const mode = useSelector(selectSchedulingContentMode);
 
     return (
         <SegmentedRadioGroup
@@ -127,7 +127,7 @@ export function SchedulingExpandAll() {
 
 function SchedulingShowAbsResources() {
     const dispatch = useDispatch();
-    const value = useSelector(getSchedulingShowAbsResources);
+    const value = useSelector(selectSchedulingShowAbsResources);
 
     return (
         <Switch

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAcl/PoolAcl.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAcl/PoolAcl.tsx
@@ -9,10 +9,10 @@ import {NoContent} from '../../../../../components/NoContent';
 import i18n from './i18n';
 import {type RootState} from '../../../../../store/reducers';
 import {
-    getIsRoot,
-    getPool,
-    getPools,
-    getTree,
+    selectPool,
+    selectPools,
+    selectSchedulingIsRoot,
+    selectTree,
 } from '../../../../../store/selectors/scheduling/scheduling';
 import {PoolAclPanel} from '../../../../../containers/ACL';
 import {RumMeasureTypes} from '../../../../../rum/rum-measure-types';
@@ -24,11 +24,11 @@ import {IdmObjectType} from '../../../../../constants/acl';
 import {useAppRumMeasureStart} from '../../../../../rum/rum-app-measures';
 
 function PoolAcl() {
-    const isRoot = useSelector(getIsRoot);
+    const isRoot = useSelector(selectSchedulingIsRoot);
 
-    const pool = useSelector(getPool);
-    const tree = useSelector(getTree);
-    const pools = useSelector(getPools);
+    const pool = useSelector(selectPool);
+    const tree = useSelector(selectTree);
+    const pools = useSelector(selectPools);
 
     if (isRoot) {
         return (

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAttributes/PoolAttributes.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/PoolAttributes/PoolAttributes.tsx
@@ -6,13 +6,13 @@ import {YsonWithScroll} from '../../../../../components/Yson/YsonWithScroll';
 import {YTApiId} from '../../../../../rum/rum-wrap-api';
 import {getPoolPathsByName} from '../../../../../store/actions/scheduling/expanded-pools';
 import {useFetchBatchQuery} from '../../../../../store/api/yt';
-import {getCurrentPool} from '../../../../../store/selectors/scheduling/scheduling';
+import {selectCurrentPool} from '../../../../../store/selectors/scheduling/scheduling';
 import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {type PoolTreeNode} from '../../../../../utils/scheduling/pool-child';
 import i18n from './i18n';
 
 export function PoolAttributes({className}: {className: string}) {
-    const pool = useSelector(getCurrentPool);
+    const pool = useSelector(selectCurrentPool);
 
     if (!pool) {
         return null;

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/SchedulingOperationsError/SchedulingOperationsError.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/SchedulingOperationsError/SchedulingOperationsError.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {useSelector} from '../../../../../store/redux-hooks';
 
 import {YTErrorBlock} from '../../../../../containers/Block/Block';
-import {getSchedulingOperationsError} from '../../../../../store/selectors/scheduling/expanded-pools';
+import {selectSchedulingOperationsError} from '../../../../../store/selectors/scheduling/expanded-pools';
 
 function SchedulingOperationsError() {
-    const error = useSelector(getSchedulingOperationsError);
+    const error = useSelector(selectSchedulingOperationsError);
     return !error ? null : <YTErrorBlock error={error} topMargin={'none'} />;
 }
 

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/ScherdulingOperataionsLoader/SchedulingOperationsLoader.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/ScherdulingOperataionsLoader/SchedulingOperationsLoader.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {getSchedulingOperationsLoadingStatus} from '../../../../../store/selectors/scheduling/expanded-pools';
+import {selectSchedulingOperationsLoadingStatus} from '../../../../../store/selectors/scheduling/expanded-pools';
 import {useSelector} from '../../../../../store/redux-hooks';
 import Loader from '../../../../../components/Loader/Loader';
 
 function SchedulingOperationsLoader() {
-    const loading = useSelector(getSchedulingOperationsLoadingStatus);
+    const loading = useSelector(selectSchedulingOperationsLoadingStatus);
     return <Loader visible={loading} />;
 }
 

--- a/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
@@ -19,10 +19,10 @@ import {
     selectCreatePoolDialogFlatTreeItems,
 } from '../../../../store/selectors/scheduling/create-pool-dialog';
 import {
-    getIsRoot,
-    getPool,
-    getTree,
-    getTreesSelectItems,
+    selectPool,
+    selectSchedulingIsRoot,
+    selectTree,
+    selectTreesSelectItems,
 } from '../../../../store/selectors/scheduling/scheduling';
 import {type FIX_MY_TYPE} from '../../../../types';
 import UIFactory from '../../../../UIFactory';
@@ -34,7 +34,7 @@ const allowRoot = !uiSettings.schedulingDenyRootAsParent;
 export default function CreatePoolButton() {
     const dispatch = useDispatch();
 
-    const isRoot = useSelector(getIsRoot);
+    const isRoot = useSelector(selectSchedulingIsRoot);
 
     const [visible, changeVisibility] = useState(false);
     const handleShow = useCallback(() => changeVisibility(true), [changeVisibility]);
@@ -63,7 +63,7 @@ interface FormValues {
 
 function CreatePoolDialog(props: {onClose: () => void}) {
     const dispatch = useDispatch();
-    const treeStored: string = useSelector(getTree);
+    const treeStored: string = useSelector(selectTree);
     const [tree, setTree] = React.useState(treeStored);
     const handleTreeChange = React.useCallback(
         (newTree: string | undefined) => {
@@ -79,8 +79,8 @@ function CreatePoolDialog(props: {onClose: () => void}) {
     const error = useSelector(selectCreatePoolDialogError);
 
     const login = useSelector(selectCurrentUserName);
-    const treeItems = useSelector(getTreesSelectItems);
-    const pool = useSelector(getPool);
+    const treeItems = useSelector(selectTreesSelectItems);
+    const pool = useSelector(selectPool);
 
     const handleCreateConfirm = useCallback(
         (form: FormApi<FormValues>) => {

--- a/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolDialog.tsx
@@ -15,8 +15,8 @@ import {
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {selectCurrentUserName} from '../../../../store/selectors/global';
 import {
-    getCreatePoolDialogError,
-    getCreatePoolDialogFlatTreeItems,
+    selectCreatePoolDialogError,
+    selectCreatePoolDialogFlatTreeItems,
 } from '../../../../store/selectors/scheduling/create-pool-dialog';
 import {
     getIsRoot,
@@ -76,7 +76,7 @@ function CreatePoolDialog(props: {onClose: () => void}) {
         dispatch(fetchCreatePoolDialogTreeItems(tree));
     }, [dispatch]);
 
-    const error = useSelector(getCreatePoolDialogError);
+    const error = useSelector(selectCreatePoolDialogError);
 
     const login = useSelector(selectCurrentUserName);
     const treeItems = useSelector(getTreesSelectItems);
@@ -117,7 +117,7 @@ function CreatePoolDialog(props: {onClose: () => void}) {
         [setName],
     );
 
-    const {sortedFlatTree} = useSelector(getCreatePoolDialogFlatTreeItems);
+    const {sortedFlatTree} = useSelector(selectCreatePoolDialogFlatTreeItems);
 
     const validateForm = React.useCallback(
         (values: FormValues): null | {name?: string} => {

--- a/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolParentSuggest.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Instruments/CreatePoolDialog/CreatePoolParentSuggest.tsx
@@ -5,7 +5,7 @@ import map_ from 'lodash/map';
 
 import cn from 'bem-cn-lite';
 
-import {getCreatePoolDialogFlatTreeItems} from '../../../../store/selectors/scheduling/create-pool-dialog';
+import {selectCreatePoolDialogFlatTreeItems} from '../../../../store/selectors/scheduling/create-pool-dialog';
 import Select from '../../../../components/Select/Select';
 
 const block = cn('accounts-suggest');
@@ -21,7 +21,7 @@ interface Props {
 export default function CreatePoolParentSuggest(props: Props) {
     const {onChange, placeholder, value, error, ...rest} = props;
 
-    const {sortedFlatTree} = useSelector(getCreatePoolDialogFlatTreeItems);
+    const {sortedFlatTree} = useSelector(selectCreatePoolDialogFlatTreeItems);
 
     const ycItems = map_(sortedFlatTree, (item) => ({
         value: item,

--- a/packages/ui/src/ui/pages/scheduling/PoolQoutaEditor/PoolQuotaEditor.tsx
+++ b/packages/ui/src/ui/pages/scheduling/PoolQoutaEditor/PoolQuotaEditor.tsx
@@ -12,8 +12,8 @@ import {type ConnectedProps, connect} from 'react-redux';
 import {useSelector} from '../../../store/redux-hooks';
 import {selectSchedulingPoolsMapByName} from '../../../store/selectors/scheduling/scheduling-pools';
 import {
-    getSchedulingSourcesOfEditItem,
-    getSchedulingSourcesOfEditItemSkipParent,
+    selectSchedulingSourcesOfEditItem,
+    selectSchedulingSourcesOfEditItemSkipParent,
 } from '../../../store/selectors/scheduling/scheduling';
 import Select from '../../../components/Select/Select';
 import {type PoolResourceType, getPoolResourceInfo} from '../../../utils/scheduling/scheduling';
@@ -134,8 +134,8 @@ function PoolSourceSuggest(props: {
     skipParent?: boolean;
 }) {
     const {value, onChange, disabled, skipParent} = props;
-    const sources = useSelector(getSchedulingSourcesOfEditItem);
-    const sourcesNoParent = useSelector(getSchedulingSourcesOfEditItemSkipParent);
+    const sources = useSelector(selectSchedulingSourcesOfEditItem);
+    const sourcesNoParent = useSelector(selectSchedulingSourcesOfEditItemSkipParent);
 
     const items = React.useMemo(() => {
         const res = skipParent ? sourcesNoParent : sources;

--- a/packages/ui/src/ui/pages/scheduling/PoolQoutaEditor/PoolQuotaEditor.tsx
+++ b/packages/ui/src/ui/pages/scheduling/PoolQoutaEditor/PoolQuotaEditor.tsx
@@ -10,7 +10,7 @@ import i18n from './i18n';
 import {type RootState} from '../../../store/reducers';
 import {type ConnectedProps, connect} from 'react-redux';
 import {useSelector} from '../../../store/redux-hooks';
-import {getSchedulingPoolsMapByName} from '../../../store/selectors/scheduling/scheduling-pools';
+import {selectSchedulingPoolsMapByName} from '../../../store/selectors/scheduling/scheduling-pools';
 import {
     getSchedulingSourcesOfEditItem,
     getSchedulingSourcesOfEditItemSkipParent,
@@ -120,7 +120,7 @@ class PoolQuotaEditorControl extends React.Component<Props & ReduxProps> {
 
 const mapStateToProps = (state: RootState) => {
     return {
-        poolsByName: getSchedulingPoolsMapByName(state),
+        poolsByName: selectSchedulingPoolsMapByName(state),
     };
 };
 

--- a/packages/ui/src/ui/pages/scheduling/PoolStaticConfiguration/SchedulingStaticConfiguration.tsx
+++ b/packages/ui/src/ui/pages/scheduling/PoolStaticConfiguration/SchedulingStaticConfiguration.tsx
@@ -8,7 +8,7 @@ import {type Column} from '@gravity-ui/react-data-table';
 
 import CollapsibleSection from '../../../components/CollapsibleSection/CollapsibleSection';
 import {getIsRoot, getTree} from '../../../store/selectors/scheduling/scheduling';
-import {getCurrentPoolTreeStaticConfiguration} from '../../../store/selectors/scheduling/scheduling-ts';
+import {selectCurrentPoolTreeStaticConfiguration} from '../../../store/selectors/scheduling/scheduling-ts';
 
 import {DataTableYT} from '../../../components/DataTableYT';
 import format from '../../../common/hammer/format';
@@ -51,7 +51,7 @@ function SchedulingStaticConfiguration() {
 export default React.memo(SchedulingStaticConfiguration);
 
 function PoolTreeStaticConfiguration() {
-    const items = useSelector(getCurrentPoolTreeStaticConfiguration);
+    const items = useSelector(selectCurrentPoolTreeStaticConfiguration);
     const poolTree = useSelector(getTree);
     const cluster = useSelector(selectCluster);
 

--- a/packages/ui/src/ui/pages/scheduling/PoolStaticConfiguration/SchedulingStaticConfiguration.tsx
+++ b/packages/ui/src/ui/pages/scheduling/PoolStaticConfiguration/SchedulingStaticConfiguration.tsx
@@ -7,7 +7,7 @@ import i18n from './i18n';
 import {type Column} from '@gravity-ui/react-data-table';
 
 import CollapsibleSection from '../../../components/CollapsibleSection/CollapsibleSection';
-import {getIsRoot, getTree} from '../../../store/selectors/scheduling/scheduling';
+import {selectSchedulingIsRoot, selectTree} from '../../../store/selectors/scheduling/scheduling';
 import {selectCurrentPoolTreeStaticConfiguration} from '../../../store/selectors/scheduling/scheduling-ts';
 
 import {DataTableYT} from '../../../components/DataTableYT';
@@ -24,7 +24,7 @@ const block = cn('scheduling-static-configuration');
 
 function SchedulingStaticConfiguration() {
     const dispatch = useDispatch();
-    const isRoot = useSelector(getIsRoot);
+    const isRoot = useSelector(selectSchedulingIsRoot);
 
     const collapsed = useSelector(selectSettingsSchedulingExpandStaticConfiguration);
     const onToggle = React.useCallback(
@@ -52,7 +52,7 @@ export default React.memo(SchedulingStaticConfiguration);
 
 function PoolTreeStaticConfiguration() {
     const items = useSelector(selectCurrentPoolTreeStaticConfiguration);
-    const poolTree = useSelector(getTree);
+    const poolTree = useSelector(selectTree);
     const cluster = useSelector(selectCluster);
 
     const columns: Array<Column<ArrayElement<typeof items>>> = [

--- a/packages/ui/src/ui/pages/scheduling/PoolsSuggest/PoolsSuggest.tsx
+++ b/packages/ui/src/ui/pages/scheduling/PoolsSuggest/PoolsSuggest.tsx
@@ -4,7 +4,7 @@ import cn from 'bem-cn-lite';
 
 import forEach_ from 'lodash/forEach';
 
-import {getPoolsNames, getTree} from '../../../store/selectors/scheduling/scheduling';
+import {selectPoolsNames, selectTree} from '../../../store/selectors/scheduling/scheduling';
 import {changePool} from '../../../store/actions/scheduling/scheduling';
 import {schedulingLoadFilterAttributes} from '../../../store/actions/scheduling/scheduling-ts';
 
@@ -26,8 +26,8 @@ export function PoolsSuggest({
     className?: string;
     autoFocus?: boolean;
 }) {
-    const poolNames = useSelector(getPoolsNames);
-    const tree = useSelector(getTree);
+    const poolNames = useSelector(selectPoolsNames);
+    const tree = useSelector(selectTree);
     const dispatch = useDispatch();
 
     const getSuggestItems = React.useCallback(

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/PoolEditorDialog/PoolEditorDialog.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/PoolEditorDialog/PoolEditorDialog.tsx
@@ -31,7 +31,7 @@ import {
 
 import {checkUserPermissionsUI} from '../../../../utils/acl/acl-api';
 import {selectCluster, selectCurrentUserName} from '../../../../store/selectors/global';
-import {getCurrentTreeGpuLimit} from '../../../../store/selectors/scheduling/scheduling-ts';
+import {selectCurrentTreeGpuLimit} from '../../../../store/selectors/scheduling/scheduling-ts';
 
 import Link from '../../../../containers/Link/Link';
 import {type RootState} from '../../../../store/reducers';
@@ -77,7 +77,7 @@ export function PoolEditorDialog() {
         (state: RootState) => state.scheduling.scheduling,
     );
 
-    const treGpuLimit = useSelector(getCurrentTreeGpuLimit);
+    const treGpuLimit = useSelector(selectCurrentTreeGpuLimit);
 
     const allowedSources = useSelector(getSchedulingSourcesOfEditItem);
 

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/PoolEditorDialog/PoolEditorDialog.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/PoolEditorDialog/PoolEditorDialog.tsx
@@ -14,11 +14,11 @@ import {YTErrorBlock} from '../../../../containers/Block/Block';
 import {closeEditModal, editPool} from '../../../../store/actions/scheduling/scheduling';
 import {
     calculatePoolPath,
-    getPools,
-    getPoolsSelectItems,
-    getSchedulingEditItem,
-    getSchedulingSourcesOfEditItem,
-    getTree,
+    selectPools,
+    selectPoolsSelectItems,
+    selectSchedulingEditItem,
+    selectSchedulingSourcesOfEditItem,
+    selectTree,
 } from '../../../../store/selectors/scheduling/scheduling';
 import {isAbcPoolName, isTopLevelPool} from '../../../../utils/scheduling/pool';
 import {
@@ -72,18 +72,18 @@ function makeError(error: any) {
 export function PoolEditorDialog() {
     const dispatch = useDispatch();
 
-    const editItem = useSelector(getSchedulingEditItem);
+    const editItem = useSelector(selectSchedulingEditItem);
     const {poolErrorData, editVisibility} = useSelector(
         (state: RootState) => state.scheduling.scheduling,
     );
 
     const treGpuLimit = useSelector(selectCurrentTreeGpuLimit);
 
-    const allowedSources = useSelector(getSchedulingSourcesOfEditItem);
+    const allowedSources = useSelector(selectSchedulingSourcesOfEditItem);
 
-    const poolsItems = useSelector(getPoolsSelectItems);
-    const pools = useSelector(getPools);
-    const tree = useSelector(getTree);
+    const poolsItems = useSelector(selectPoolsSelectItems);
+    const pools = useSelector(selectPools);
+    const tree = useSelector(selectTree);
     const modeItems = [
         {key: 'fair_share', value: 'fair_share', title: 'fair_share'},
         {key: 'fifo', value: 'fifo', title: 'fifo'},

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/PoolEditorDialog/PoolEditorDialog.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/PoolEditorDialog/PoolEditorDialog.tsx
@@ -35,7 +35,7 @@ import {getCurrentTreeGpuLimit} from '../../../../store/selectors/scheduling/sch
 
 import Link from '../../../../containers/Link/Link';
 import {type RootState} from '../../../../store/reducers';
-import {getSchedulingPoolsMapByName} from '../../../../store/selectors/scheduling/scheduling-pools';
+import {selectSchedulingPoolsMapByName} from '../../../../store/selectors/scheduling/scheduling-pools';
 
 import UIFactory from '../../../../UIFactory';
 import ypath from '../../../../common/thor/ypath';
@@ -523,7 +523,7 @@ export function PoolEditorDialog() {
 function useTransferNotice(editItem?: PoolTreeNode): [DialogField<PoolEditorFormValues>] | [] {
     const {parent} = editItem || {};
     //    const abcInfo = abcInfoFromAttributes(cypressAttributes);
-    const poolsByName = useSelector(getSchedulingPoolsMapByName);
+    const poolsByName = useSelector(selectSchedulingPoolsMapByName);
     const parentPool = poolsByName[parent!];
 
     const children = UIFactory.renderTransferQuotaNoticeForPool({

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/Scheduling.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/Scheduling.tsx
@@ -28,7 +28,7 @@ import {getSchedulingIsFinalLoadingState} from '../../../store/selectors/schedul
 import SchedulingResources from '../Content/SchedulingResources';
 import {PoolEditorDialog} from './PoolEditorDialog/PoolEditorDialog';
 import {type RootState} from '../../../store/reducers';
-import {getPool, selectSchedulingError} from '../../../store/selectors/scheduling/scheduling';
+import {selectPool, selectSchedulingError} from '../../../store/selectors/scheduling/scheduling';
 import {changePool} from '../../../store/actions/scheduling/scheduling';
 import {SchedulingError} from './SchedulingError';
 
@@ -38,7 +38,7 @@ const SchedulingDialogsMemo = React.memo(SchedulingDialogs);
 
 function Scheduling() {
     const error = useSelector(selectSchedulingError);
-    const pool = useSelector(getPool);
+    const pool = useSelector(selectPool);
     const dispatch = useDispatch();
 
     const updateFn = React.useCallback(() => {

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
@@ -10,12 +10,12 @@ import {RowWithName} from '../../../containers/AppNavigation/TopRowContent/Secti
 import Favourites from '../../../components/Favourites/Favourites';
 import {PoolsSuggest} from '../PoolsSuggest/PoolsSuggest';
 import {
-    getCurrentPool,
-    getCurrentPoolPath,
-    getPool,
-    getTree,
-    getTreesSelectItems,
+    selectCurrentPool,
+    selectCurrentPoolPath,
+    selectPool,
     selectSchedulingError,
+    selectTree,
+    selectTreesSelectItems,
 } from '../../../store/selectors/scheduling/scheduling';
 import {
     selectFavouritePools,
@@ -48,7 +48,7 @@ import i18n from './i18n';
 const block = cn('scheduling-top-row-content');
 
 function SchedulingTopRowContent() {
-    const pool = useSelector(getCurrentPool);
+    const pool = useSelector(selectCurrentPool);
     const clusterUiConfig = useSelector(selectClusterUiConfig);
 
     return (
@@ -77,9 +77,9 @@ function SchedulingTopRowContent() {
 }
 
 function SchedulingFavourites() {
-    const tree = useSelector(getTree);
+    const tree = useSelector(selectTree);
     const dispatch = useDispatch();
-    const pool = useSelector(getPool);
+    const pool = useSelector(selectPool);
     const favouritesPools = useSelector(selectFavouritePools);
     const isActivePool = useSelector(selectIsActivePoolInFavourites);
 
@@ -110,8 +110,8 @@ function SchedulingFavourites() {
 }
 
 function CurrentPoolToClipboardButton() {
-    const currentPool = useSelector(getPool);
-    const currentPoolPath = useSelector(getCurrentPoolPath);
+    const currentPool = useSelector(selectPool);
+    const currentPoolPath = useSelector(selectCurrentPoolPath);
 
     return (
         <ClipboardButton
@@ -127,9 +127,9 @@ function SchedulingBreadcrumbs() {
     const bcItems = useSelector(selectSchedulingBreadcrumbItems);
     const dispatch = useDispatch();
     const history = useHistory();
-    const tree = useSelector(getTree);
+    const tree = useSelector(selectTree);
     const cluster = useSelector(selectCluster);
-    const pool = useSelector(getPool);
+    const pool = useSelector(selectPool);
 
     const error = useSelector(selectSchedulingError);
 
@@ -194,8 +194,8 @@ function calcPathname(pathname: string, cluster: string, pool?: string) {
 }
 
 function SchedulingPhysicalTree() {
-    const tree = useSelector(getTree);
-    const treeItems = useSelector(getTreesSelectItems);
+    const tree = useSelector(selectTree);
+    const treeItems = useSelector(selectTreesSelectItems);
     const dispatch = useDispatch();
 
     const onChange = React.useCallback((tree: string) => dispatch(changeTree(tree)), [dispatch]);

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/SchedulingTopRowContent.tsx
@@ -33,7 +33,7 @@ import {
     SchedulingTab,
 } from '../../../constants/scheduling';
 import {ClipboardButton} from '@ytsaurus/components';
-import {getSchedulingBreadcrumbItems} from '../../../store/selectors/scheduling/scheduling-ts';
+import {selectSchedulingBreadcrumbItems} from '../../../store/selectors/scheduling/scheduling-ts';
 import {Page} from '../../../constants';
 import {EditableBreadcrumbs} from '../../../components/EditableBreadcrumbs/EditableBreadcrumbs';
 import CreatePoolButton from '../Instruments/CreatePoolDialog/CreatePoolDialog';
@@ -124,7 +124,7 @@ function CurrentPoolToClipboardButton() {
 }
 
 function SchedulingBreadcrumbs() {
-    const bcItems = useSelector(getSchedulingBreadcrumbItems);
+    const bcItems = useSelector(selectSchedulingBreadcrumbItems);
     const dispatch = useDispatch();
     const history = useHistory();
     const tree = useSelector(getTree);

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleAclTab.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleAclTab.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import {useSelector} from '../../../store/redux-hooks';
 import ErrorBoundary from '../../../containers/ErrorBoundary/ErrorBoundary';
 import {selectTabletsActiveBundle} from '../../../store/selectors/tablet_cell_bundles';
-import {isPoolAclAllowed} from '../../../store/selectors/scheduling/scheduling';
+import {selectIsPoolAclAllowed} from '../../../store/selectors/scheduling/scheduling';
 import {NoContent} from '../../../components/NoContent';
 import {BundleAcl} from '../../../containers/ACL';
 import i18n from './i18n';
 
 export default function BundleAclTab({className}: {className: string}) {
     const activeBundle = useSelector(selectTabletsActiveBundle);
-    const allowAcl = useSelector(isPoolAclAllowed);
+    const allowAcl = useSelector(selectIsPoolAclAllowed);
     return (
         <ErrorBoundary>
             {allowAcl ? (

--- a/packages/ui/src/ui/store/actions/acl.ts
+++ b/packages/ui/src/ui/store/actions/acl.ts
@@ -11,7 +11,7 @@ import {
     REQUEST_PERMISSION,
     UPDATE_ACL,
 } from '../../constants/acl';
-import {getTree} from '../../store/selectors/scheduling/scheduling';
+import {selectTree} from '../../store/selectors/scheduling/scheduling';
 import {
     type YTPermissionTypeUI,
     checkUserPermissionsUI,
@@ -87,7 +87,7 @@ export function loadAclData(
         dispatch({type: ACL_LOAD_DATA.REQUEST, idmKind, data: {path}});
 
         const poolTree =
-            idmKind === IdmObjectType.POOL ? normalizedPoolTree || getTree(state) : undefined;
+            idmKind === IdmObjectType.POOL ? normalizedPoolTree || selectTree(state) : undefined;
         const {permissionTypes} = UIFactory.getAclPermissionsSettings()[idmKind];
 
         const {userPermissionsPath} = options;
@@ -168,7 +168,7 @@ export function deletePermissions(
         });
 
         const poolTree =
-            idmKind === IdmObjectType.POOL ? normalizedPoolTree || getTree(state) : undefined;
+            idmKind === IdmObjectType.POOL ? normalizedPoolTree || selectTree(state) : undefined;
 
         try {
             const deletePermissionsPath = await getPathToCheckPermissions(idmKind, path, poolTree);
@@ -312,7 +312,7 @@ export function requestPermissions(
         }
 
         const poolTree =
-            idmKind === IdmObjectType.POOL ? normalizedPoolTree || getTree(state) : undefined;
+            idmKind === IdmObjectType.POOL ? normalizedPoolTree || selectTree(state) : undefined;
 
         const requestPermissionsPath = await getPathToCheckPermissions(
             idmKind,
@@ -393,7 +393,7 @@ export function updateAcl(
         });
 
         const poolTree =
-            idmKind === IdmObjectType.POOL ? normalizedPoolTree || getTree(state) : undefined;
+            idmKind === IdmObjectType.POOL ? normalizedPoolTree || selectTree(state) : undefined;
 
         return getPathToCheckPermissions(idmKind, path, poolTree)
             .then((sysPath) => {

--- a/packages/ui/src/ui/store/actions/scheduling/expanded-pools.tsx
+++ b/packages/ui/src/ui/store/actions/scheduling/expanded-pools.tsx
@@ -31,7 +31,7 @@ import {
 import {EMPTY_OBJECT} from '../../../constants/empty';
 import {
     type PoolInfo,
-    getSchedulingPoolsMapByName,
+    selectSchedulingPoolsMapByName,
 } from '../../selectors/scheduling/scheduling-pools';
 import {type BatchSubRequest} from '../../../../shared/yt-types';
 import {type SchedulingAction} from '../../../store/reducers/scheduling/scheduling';
@@ -396,7 +396,7 @@ export function setExpandedPools(changes: Record<string, boolean>): ExpandedPool
         const tree = getTree(getState());
         const expandedPools = selectSchedulingOperationsExpandedPools(state);
 
-        const poolsByName = getSchedulingPoolsMapByName(state);
+        const poolsByName = selectSchedulingPoolsMapByName(state);
 
         const treeExpandedPools = new Map(expandedPools[tree]);
         forEach_(changes, (expanded, poolName) => {
@@ -488,7 +488,7 @@ export function getSchedulingOperationsCount(): ThunkAction<number, RootState, a
     return (_dispatch, getState) => {
         const state = getState();
 
-        const tree = getSchedulingPoolsMapByName(state);
+        const tree = selectSchedulingPoolsMapByName(state);
         const root = tree[ROOT_POOL_NAME];
         return root?.operationCount || 0;
     };

--- a/packages/ui/src/ui/store/actions/scheduling/expanded-pools.tsx
+++ b/packages/ui/src/ui/store/actions/scheduling/expanded-pools.tsx
@@ -25,8 +25,8 @@ import {
 import {schedulingDataFailure} from './scheduling';
 import {calculatePoolPath, getPool, getPools, getTree} from '../../selectors/scheduling/scheduling';
 import {
-    getExpandedPoolsLoadAll,
-    getSchedulingOperationsExpandedPools,
+    selectExpandedPoolsLoadAll,
+    selectSchedulingOperationsExpandedPools,
 } from '../../selectors/scheduling/expanded-pools';
 import {EMPTY_OBJECT} from '../../../constants/empty';
 import {
@@ -162,10 +162,10 @@ function loadExpandedOperationsAndPools(tree: string): ExpandedPoolsThunkAction 
     return (dispatch, getState) => {
         const state = getState();
 
-        const loadAll = getExpandedPoolsLoadAll(state);
+        const loadAll = selectExpandedPoolsLoadAll(state);
         const expandedPools: Map<string, ExpandedPoolInfo> = loadAll
             ? new Map()
-            : (getSchedulingOperationsExpandedPools(state)[tree] ?? new Map());
+            : (selectSchedulingOperationsExpandedPools(state)[tree] ?? new Map());
         const expandedPoolNames: Array<string> = [...expandedPools.keys()];
 
         const operationsExpandedPools: Array<string> = [...expandedPoolNames];
@@ -394,7 +394,7 @@ export function setExpandedPools(changes: Record<string, boolean>): ExpandedPool
     return (dispatch, getState) => {
         const state = getState();
         const tree = getTree(getState());
-        const expandedPools = getSchedulingOperationsExpandedPools(state);
+        const expandedPools = selectSchedulingOperationsExpandedPools(state);
 
         const poolsByName = getSchedulingPoolsMapByName(state);
 
@@ -423,7 +423,7 @@ function addFullPathToExpandedPoolsNoLoad(
 ): ExpandedPoolsThunkAction {
     return (dispatch, getState) => {
         const state = getState();
-        const oldExpandedPools = getSchedulingOperationsExpandedPools(state);
+        const oldExpandedPools = selectSchedulingOperationsExpandedPools(state);
         const treeExpandedPools = new Map(oldExpandedPools[tree]);
 
         /**
@@ -447,7 +447,7 @@ function updateExpandedPoolNoLoad(
     treeExpandedPools: Map<string, ExpandedPoolInfo>,
 ): ExpandedPoolsThunkAction {
     return (dispatch, getState) => {
-        const oldExpandedPools = getSchedulingOperationsExpandedPools(getState());
+        const oldExpandedPools = selectSchedulingOperationsExpandedPools(getState());
 
         const expandedPools = {
             ...oldExpandedPools,
@@ -468,7 +468,7 @@ export function resetExpandedPools(tree: string): ExpandedPoolsThunkAction {
         }
 
         const state = getState();
-        const {[tree]: old, ...rest} = getSchedulingOperationsExpandedPools(state);
+        const {[tree]: old, ...rest} = selectSchedulingOperationsExpandedPools(state);
 
         if (old?.size) {
             dispatch({

--- a/packages/ui/src/ui/store/actions/scheduling/expanded-pools.tsx
+++ b/packages/ui/src/ui/store/actions/scheduling/expanded-pools.tsx
@@ -23,7 +23,12 @@ import {
     SCHEDULING_EXPANDED_POOLS_SUCCESS,
 } from '../../../constants/scheduling';
 import {schedulingDataFailure} from './scheduling';
-import {calculatePoolPath, getPool, getPools, getTree} from '../../selectors/scheduling/scheduling';
+import {
+    calculatePoolPath,
+    selectPool,
+    selectPools,
+    selectTree,
+} from '../../selectors/scheduling/scheduling';
 import {
     selectExpandedPoolsLoadAll,
     selectSchedulingOperationsExpandedPools,
@@ -109,7 +114,7 @@ class EmptyFullPath extends Error {}
 
 export function loadExpandedPools(tree: string): ExpandedPoolsThunkAction {
     return (dispatch, getState) => {
-        const pool = getPool(getState());
+        const pool = selectPool(getState());
 
         if (!tree) {
             return undefined;
@@ -393,7 +398,7 @@ function loadExpandedOperationsAndPools(tree: string): ExpandedPoolsThunkAction 
 export function setExpandedPools(changes: Record<string, boolean>): ExpandedPoolsThunkAction {
     return (dispatch, getState) => {
         const state = getState();
-        const tree = getTree(getState());
+        const tree = selectTree(getState());
         const expandedPools = selectSchedulingOperationsExpandedPools(state);
 
         const poolsByName = selectSchedulingPoolsMapByName(state);
@@ -499,8 +504,8 @@ export function getPoolPathsByName(
 ): ThunkAction<{fullPath: string; orchidPath: string}, RootState, unknown, any> {
     return (_dispatch, getState) => {
         const state = getState();
-        const pools = getPools(state);
-        const tree = getTree(state);
+        const pools = selectPools(state);
+        const tree = selectTree(state);
 
         return {
             fullPath: calculatePoolPath(poolName, pools, tree),
@@ -517,7 +522,7 @@ export function setLoadAllOperations(loadAll: boolean): ExpandedPoolsThunkAction
             data: {loadAll},
         });
 
-        const tree = getTree(state);
+        const tree = selectTree(state);
         dispatch(loadExpandedPools(tree));
     };
 }

--- a/packages/ui/src/ui/store/actions/scheduling/monitor.ts
+++ b/packages/ui/src/ui/store/actions/scheduling/monitor.ts
@@ -1,4 +1,4 @@
-import {getSchedulingMonitorChartStates} from '../../selectors/scheduling/monitor';
+import {selectSchedulingMonitorChartStates} from '../../selectors/scheduling/monitor';
 import {type ThunkAction} from 'redux-thunk';
 import {type RootState} from '../../reducers';
 import {SCHEDULING_DATA_PARTITION} from '../../../constants/scheduling';
@@ -12,7 +12,7 @@ export function setSchedulingMonitorChartState(v: {
     return (dispatch, getState) => {
         const {chartType, finalState} = v;
         const monitorChartStatus = {
-            ...getSchedulingMonitorChartStates(getState()),
+            ...selectSchedulingMonitorChartStates(getState()),
         };
         monitorChartStatus[chartType] = finalState;
 

--- a/packages/ui/src/ui/store/actions/scheduling/scheduling-ts.ts
+++ b/packages/ui/src/ui/store/actions/scheduling/scheduling-ts.ts
@@ -46,8 +46,8 @@ import {RumMeasureTypes} from '../../../rum/rum-measure-types';
 import {type RootState} from '../../../store/reducers';
 import {type SchedulingAction} from '../../../store/reducers/scheduling/scheduling';
 import {
-    getSchedulingAttributesToFilterParams,
-    schedulingOverviewHasFilter,
+    selectSchedulingAttributesToFilterParams,
+    selectSchedulingOverviewHasFilter,
 } from '../../../store/selectors/scheduling/attributes-to-filter';
 import {USE_CACHE} from '../../../../shared/constants/yt-api';
 import {toaster} from '../../../utils/toaster';
@@ -336,11 +336,11 @@ export function schedulingLoadFilterAttributes(
     return (dispatch, getState) => {
         const state = getState();
 
-        if (checkFilters && !schedulingOverviewHasFilter(state)) {
+        if (checkFilters && !selectSchedulingOverviewHasFilter(state)) {
             return undefined;
         }
 
-        const {lastTime, lastTree} = getSchedulingAttributesToFilterParams(state);
+        const {lastTime, lastTree} = selectSchedulingAttributesToFilterParams(state);
         if (tree === lastTree && Date.now() - lastTime < 120000) {
             return undefined;
         }

--- a/packages/ui/src/ui/store/actions/scheduling/scheduling-ts.ts
+++ b/packages/ui/src/ui/store/actions/scheduling/scheduling-ts.ts
@@ -24,9 +24,9 @@ import {type ThunkAction} from 'redux-thunk';
 import yt from '@ytsaurus/javascript-wrapper/lib/yt';
 
 import {
-    getPools,
-    getSchedulingIsInitialLoading,
-    getTree,
+    selectPools,
+    selectSchedulingIsInitialLoading,
+    selectTree,
 } from '../../../store/selectors/scheduling/scheduling';
 
 import {
@@ -62,7 +62,7 @@ export function loadSchedulingData(): SchedulingThunkAction {
         dispatch({type: SCHEDULING_DATA_REQUEST});
 
         const state = getState();
-        const isInitialLoading = getSchedulingIsInitialLoading(state);
+        const isInitialLoading = selectSchedulingIsInitialLoading(state);
 
         const cluster = selectCluster(state);
         const rumId = new RumWrapper(cluster, RumMeasureTypes.SCHEDULING);
@@ -179,8 +179,8 @@ export function deletePool(item?: {name: string; parent?: string}): SchedulingTh
 
         const state = getState();
 
-        const tree = getTree(state);
-        const pools = getPools(state);
+        const tree = selectTree(state);
+        const pools = selectPools(state);
         const path = computePoolPath(item, pools);
 
         dispatch({type: SCHEDULING_DELETE_POOL_REQUEST});
@@ -374,7 +374,7 @@ export function schedulingSetAbcFilter(abcService?: {
 }): SchedulingThunkAction {
     return (dispatch, getState) => {
         const {id, slug} = abcService ?? {};
-        dispatch(schedulingLoadFilterAttributes(getTree(getState())));
+        dispatch(schedulingLoadFilterAttributes(selectTree(getState())));
         dispatch({
             type: SCHEDULING_DATA_PARTITION,
             data: {abcServiceFilter: {id, slug}},

--- a/packages/ui/src/ui/store/actions/scheduling/scheduling.ts
+++ b/packages/ui/src/ui/store/actions/scheduling/scheduling.ts
@@ -18,8 +18,8 @@ import {selectSchedulingNS} from '../../../store/selectors/settings';
 import {toggleFavourite} from '../../../store/actions/favourites';
 import {
     type SchedulingContentMode,
-    getPools,
-    getTree,
+    selectPools,
+    selectTree,
 } from '../../../store/selectors/scheduling/scheduling';
 import {
     type SchedulingAction,
@@ -207,8 +207,8 @@ export function editPool(
     return (dispatch, getState) => {
         const state = getState();
 
-        const tree = getTree(state);
-        const pools = getPools(state);
+        const tree = selectTree(state);
+        const pools = selectPools(state);
         const poolPath = computePoolPath(pool, pools);
         const path = `//sys/pool_trees/${tree}/${poolPath}`;
 

--- a/packages/ui/src/ui/store/selectors/favourites.js
+++ b/packages/ui/src/ui/store/selectors/favourites.js
@@ -15,7 +15,7 @@ import {
 import {SettingName} from '../../../shared/constants/settings';
 import {selectActiveAccount} from '../../store/selectors/accounts/accounts';
 import {selectPath} from '../../store/selectors/navigation';
-import {getPool, getTree} from '../../store/selectors/scheduling/scheduling';
+import {selectPool, selectTree} from '../../store/selectors/scheduling/scheduling';
 import {selectTabletsActiveBundle} from './tablet_cell_bundles';
 import {selectChaosActiveBundle} from './chaos_cell_bundles';
 import {selectChytCurrentAlias} from './chyt';
@@ -83,7 +83,7 @@ export const selectFavouritePools = createSelector(
 );
 
 export const selectIsActivePoolInFavourites = createSelector(
-    [getPool, getTree, selectFavouritePools],
+    [selectPool, selectTree, selectFavouritePools],
     prepareIsPoolInFavourites,
 );
 

--- a/packages/ui/src/ui/store/selectors/scheduling/attributes-to-filter.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/attributes-to-filter.ts
@@ -3,7 +3,7 @@ import reduce_ from 'lodash/reduce';
 import forEach_ from 'lodash/forEach';
 
 import {type RootState} from '../../reducers';
-import {getSchedulingPoolsMapByName} from './scheduling-pools';
+import {selectSchedulingPoolsMapByName} from './scheduling-pools';
 
 export const selectSchedulingAbcFilter = (state: RootState) =>
     state.scheduling.scheduling.abcServiceFilter;
@@ -23,7 +23,7 @@ export const selectSchedulingOverviewHasFilter = (state: RootState) => {
 };
 
 export const selectSchedulingFilteredPoolNames = createSelector(
-    [selectSchedulingAttributesToFilter, getSchedulingPoolsMapByName, selectSchedulingAbcFilter],
+    [selectSchedulingAttributesToFilter, selectSchedulingPoolsMapByName, selectSchedulingAbcFilter],
     (attrsToFilter, loadedPools, abcFilter) => {
         if (!attrsToFilter) {
             return undefined;

--- a/packages/ui/src/ui/store/selectors/scheduling/attributes-to-filter.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/attributes-to-filter.ts
@@ -5,25 +5,25 @@ import forEach_ from 'lodash/forEach';
 import {type RootState} from '../../reducers';
 import {getSchedulingPoolsMapByName} from './scheduling-pools';
 
-export const getSchedulingAbcFilter = (state: RootState) =>
+export const selectSchedulingAbcFilter = (state: RootState) =>
     state.scheduling.scheduling.abcServiceFilter;
 
-export const getSchedulingOperationRefId = (state: RootState) =>
+export const selectSchedulingOperationRefId = (state: RootState) =>
     state.scheduling.scheduling.operationRefId;
 
-export const getSchedulingAttributesToFilter = (state: RootState) =>
+export const selectSchedulingAttributesToFilter = (state: RootState) =>
     state.scheduling.scheduling.attributesToFilter;
-export const getSchedulingAttributesToFilterParams = (state: RootState) =>
+export const selectSchedulingAttributesToFilterParams = (state: RootState) =>
     state.scheduling.scheduling.attributesToFilterParams;
 
-export const schedulingOverviewHasFilter = (state: RootState) => {
-    const abcFilter = getSchedulingAbcFilter(state);
+export const selectSchedulingOverviewHasFilter = (state: RootState) => {
+    const abcFilter = selectSchedulingAbcFilter(state);
 
     return abcFilter?.id !== undefined;
 };
 
-export const getSchedulingFilteredPoolNames = createSelector(
-    [getSchedulingAttributesToFilter, getSchedulingPoolsMapByName, getSchedulingAbcFilter],
+export const selectSchedulingFilteredPoolNames = createSelector(
+    [selectSchedulingAttributesToFilter, getSchedulingPoolsMapByName, selectSchedulingAbcFilter],
     (attrsToFilter, loadedPools, abcFilter) => {
         if (!attrsToFilter) {
             return undefined;

--- a/packages/ui/src/ui/store/selectors/scheduling/create-pool-dialog.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/create-pool-dialog.ts
@@ -3,15 +3,15 @@ import forEach_ from 'lodash/forEach';
 import {type RootState} from '../../reducers';
 import {createSelector} from 'reselect';
 
-export const getCreatePoolDialogCurrentTree = (state: RootState) =>
+export const selectCreatePoolDialogCurrentTree = (state: RootState) =>
     state.scheduling.createPoolDialog.currentTree;
-export const getCreatePoolDialogTreeItems = (state: RootState) =>
+export const selectCreatePoolDialogTreeItems = (state: RootState) =>
     state.scheduling.createPoolDialog.treeItems;
-export const getCreatePoolDialogError = (state: RootState) =>
+export const selectCreatePoolDialogError = (state: RootState) =>
     state.scheduling.createPoolDialog.error;
 
-export const getCreatePoolDialogFlatTreeItems = createSelector(
-    [getCreatePoolDialogTreeItems, getCreatePoolDialogCurrentTree],
+export const selectCreatePoolDialogFlatTreeItems = createSelector(
+    [selectCreatePoolDialogTreeItems, selectCreatePoolDialogCurrentTree],
     (tree, treeName) => {
         return {
             sortedFlatTree: collectTreeKeys([], tree).sort(),
@@ -22,7 +22,7 @@ export const getCreatePoolDialogFlatTreeItems = createSelector(
 
 function collectTreeKeys(
     dst: Array<string>,
-    tree: ReturnType<typeof getCreatePoolDialogTreeItems>,
+    tree: ReturnType<typeof selectCreatePoolDialogTreeItems>,
 ): Array<string> {
     forEach_(tree, (value: typeof tree, key: string) => {
         dst.push(key);

--- a/packages/ui/src/ui/store/selectors/scheduling/expanded-pools.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/expanded-pools.ts
@@ -2,25 +2,26 @@ import {createSelector} from 'reselect';
 
 import {type RootState} from '../../reducers';
 
-export const getExpandedPoolCypressData = (state: RootState) =>
+export const selectExpandedPoolCypressData = (state: RootState) =>
     state.scheduling.expandedPools.flattenCypressData;
 
-export const getSchedulingOperations = (state: RootState) =>
+export const selectSchedulingOperations = (state: RootState) =>
     state.scheduling.expandedPools.rawOperations;
-export const getExpandedPoolsTree = (state: RootState) =>
+export const selectExpandedPoolsTree = (state: RootState) =>
     state.scheduling.expandedPools.expandedPoolsTree;
-export const getSchedulingOperationsError = (state: RootState) =>
+export const selectSchedulingOperationsError = (state: RootState) =>
     state.scheduling.expandedPools.error;
-export const getSchedulingOperationsLoading = (state: RootState) =>
+export const selectSchedulingOperationsLoading = (state: RootState) =>
     state.scheduling.expandedPools.loading;
-export const getSchedulingOperationsLoaded = (state: RootState) =>
+export const selectSchedulingOperationsLoaded = (state: RootState) =>
     state.scheduling.expandedPools.loading;
-export const getSchedulingOperationsExpandedPools = (state: RootState) =>
+export const selectSchedulingOperationsExpandedPools = (state: RootState) =>
     state.scheduling.expandedPools.expandedPools;
-export const getExpandedPoolsLoadAll = (state: RootState) => state.scheduling.expandedPools.loadAll;
+export const selectExpandedPoolsLoadAll = (state: RootState) =>
+    state.scheduling.expandedPools.loadAll;
 
-export const getSchedulingOperationsLoadingStatus = createSelector(
-    [getSchedulingOperationsLoading, getSchedulingOperationsLoaded],
+export const selectSchedulingOperationsLoadingStatus = createSelector(
+    [selectSchedulingOperationsLoading, selectSchedulingOperationsLoaded],
     (loading, loaded) => {
         return loading && !loaded;
     },

--- a/packages/ui/src/ui/store/selectors/scheduling/monitor.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/monitor.ts
@@ -2,5 +2,5 @@ import {type RootState} from '../../reducers';
 
 type MonitorChartStuts = {[chartType: string]: boolean};
 
-export const getSchedulingMonitorChartStates = (state: RootState): MonitorChartStuts =>
+export const selectSchedulingMonitorChartStates = (state: RootState): MonitorChartStuts =>
     state.scheduling.scheduling.monitorChartStatus;

--- a/packages/ui/src/ui/store/selectors/scheduling/overview-columns.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/overview-columns.ts
@@ -22,7 +22,7 @@ const DEFAULT_COLUMNS: Array<SchedulingColumn> = [
     'actions',
 ];
 
-export const getSchedulingOverivewColumns = createSelector([selectSettingsData], (data) => {
+export const selectSchedulingOverivewColumns = createSelector([selectSettingsData], (data) => {
     const columns = data['global::scheduling::overviewColumns'];
     if (!columns) {
         return [...DEFAULT_COLUMNS];

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
@@ -10,9 +10,9 @@ import {preparePools} from '../../../utils/scheduling/scheduling';
 import ypath from '../../../common/thor/ypath';
 import {updatePoolChild} from '../../../utils/scheduling/pool-child';
 import {
-    getExpandedPoolCypressData,
-    getExpandedPoolsTree,
-    getSchedulingOperations,
+    selectExpandedPoolCypressData,
+    selectExpandedPoolsTree,
+    selectSchedulingOperations,
 } from './expanded-pools';
 import {selectCluster} from '../../../store/selectors/global';
 import {RumWrapper} from '../../../rum/rum-wrap-api';
@@ -24,7 +24,7 @@ const getPoolsRaw = (state: RootState) => state.scheduling.expandedPools.rawPool
 const getTreeResources = (state: RootState) => state.scheduling.scheduling.treeResources;
 
 const getSchedulingTreeOperations = createSelector(
-    [getSchedulingOperations, getExpandedPoolsTree, getTree],
+    [selectSchedulingOperations, selectExpandedPoolsTree, getTree],
     (rawOperations, expandedPoolsTree, tree) => {
         if (tree !== expandedPoolsTree) {
             return EMPTY_OBJECT as typeof rawOperations;
@@ -54,7 +54,7 @@ const getPoolsPrepared = createSelector(
     [
         getPoolsRaw,
         getOperationsFiltered,
-        getExpandedPoolCypressData,
+        selectExpandedPoolCypressData,
         getTreeResources,
         selectCluster,
     ],

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
@@ -19,12 +19,12 @@ import {RumWrapper} from '../../../rum/rum-wrap-api';
 import {RumMeasureTypes} from '../../../rum/rum-measure-types';
 import {EMPTY_OBJECT} from '../../../constants/empty';
 
-export const getTree = (state: RootState) => state.scheduling.scheduling.tree;
-const getPoolsRaw = (state: RootState) => state.scheduling.expandedPools.rawPools;
-const getTreeResources = (state: RootState) => state.scheduling.scheduling.treeResources;
+export const selectTree = (state: RootState) => state.scheduling.scheduling.tree;
+const selectPoolsRaw = (state: RootState) => state.scheduling.expandedPools.rawPools;
+const selectTreeResources = (state: RootState) => state.scheduling.scheduling.treeResources;
 
 const getSchedulingTreeOperations = createSelector(
-    [selectSchedulingOperations, selectExpandedPoolsTree, getTree],
+    [selectSchedulingOperations, selectExpandedPoolsTree, selectTree],
     (rawOperations, expandedPoolsTree, tree) => {
         if (tree !== expandedPoolsTree) {
             return EMPTY_OBJECT as typeof rawOperations;
@@ -34,8 +34,8 @@ const getSchedulingTreeOperations = createSelector(
     },
 );
 
-const getOperationsFiltered = createSelector(
-    [getPoolsRaw, getSchedulingTreeOperations],
+const selectOperationsFiltered = createSelector(
+    [selectPoolsRaw, getSchedulingTreeOperations],
     (rawPools, rawOperations) => {
         return reduce_(
             rawOperations,
@@ -50,12 +50,12 @@ const getOperationsFiltered = createSelector(
     },
 );
 
-const getPoolsPrepared = createSelector(
+const selectPoolsPrepared = createSelector(
     [
-        getPoolsRaw,
-        getOperationsFiltered,
+        selectPoolsRaw,
+        selectOperationsFiltered,
         selectExpandedPoolCypressData,
-        getTreeResources,
+        selectTreeResources,
         selectCluster,
     ],
     (rawPools, rawOperations, attributes, treeResources, cluster) => {
@@ -80,7 +80,7 @@ const getPoolsPrepared = createSelector(
     },
 );
 
-export const getSchedulingPoolsMapByName = createSelector([getPoolsPrepared], (pools) => {
+export const selectSchedulingPoolsMapByName = createSelector([selectPoolsPrepared], (pools) => {
     return reduce_(
         pools,
         (acc, item) => {
@@ -91,8 +91,8 @@ export const getSchedulingPoolsMapByName = createSelector([getPoolsPrepared], (p
     );
 });
 
-export const getSchedulingPoolsExtraInfo = createSelector(
-    [getSchedulingPoolsMapByName],
+export const selectSchedulingPoolsExtraInfo = createSelector(
+    [selectSchedulingPoolsMapByName],
     (poolsMap) => {
         const root = poolsMap[ROOT_POOL_NAME];
         if (!root) {
@@ -223,8 +223,8 @@ export type PoolResourceDetails = {
     guaranteed?: number;
 };
 
-export const getPools = createSelector(
-    [getPoolsPrepared, getSchedulingPoolsExtraInfo],
+export const selectPools = createSelector(
+    [selectPoolsPrepared, selectSchedulingPoolsExtraInfo],
     (pools, extras) => {
         const res = map_(pools, (item) => {
             const itemExtra = extras[item.name] || {};

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-ts.tsx
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-ts.tsx
@@ -10,7 +10,7 @@ import {ROOT_POOL_NAME} from '../../../constants/scheduling';
 import {selectCluster} from '../global';
 import {selectPools} from './scheduling-pools';
 
-export const getSchedulingBreadcrumbItems = createSelector(
+export const selectSchedulingBreadcrumbItems = createSelector(
     [getPool, selectPools],
     (pool: string, pools) => {
         let current: string | undefined = pool;
@@ -46,7 +46,7 @@ function makeStaticConfigurationItem(name: string, attrs: object): PoolStaticCon
     };
 }
 
-export const getCurrentPoolGuarantees = createSelector(
+export const selectCurrentPoolGuarantees = createSelector(
     [getIsRoot, getCurrentPool],
     (isRoot, data) => {
         if (isRoot || !data?.attributes) {
@@ -111,11 +111,11 @@ function calcTreeStaticConfigurationByDistributed(
     };
 }
 
-export const getPoolsTopLevel = createSelector([selectPools], (pools) => {
+export const selectPoolsTopLevel = createSelector([selectPools], (pools) => {
     return filter_(pools, ({parent}) => parent === ROOT_POOL_NAME);
 });
 
-const getPoolsAllocatedOperationsCount = createSelector([getPoolsTopLevel], (topPools) => {
+const selectPoolsAllocatedOperationsCount = createSelector([selectPoolsTopLevel], (topPools) => {
     return reduce_(
         topPools,
         (acc, item) => {
@@ -127,12 +127,12 @@ const getPoolsAllocatedOperationsCount = createSelector([getPoolsTopLevel], (top
     );
 });
 
-export const getCurrentTreeGpuLimit = createSelector([getTreeResources], (resources): number => {
+export const selectCurrentTreeGpuLimit = createSelector([getTreeResources], (resources): number => {
     return ypath.getNumber(resources, '/resource_limits/gpu', 0);
 });
 
-export const getOperationsStaticConfiguration = createSelector(
-    [getTreeResources, getPoolsAllocatedOperationsCount, selectCluster, getTree],
+export const selectOperationsStaticConfiguration = createSelector(
+    [getTreeResources, selectPoolsAllocatedOperationsCount, selectCluster, getTree],
     ({config}, allocated): Array<PoolTreeStaticConfigurationItem> => {
         const operationCount = ypath.getNumber(config, '/max_operation_count', 0);
         const runningOperationCount = ypath.getNumber(config, '/max_running_operation_count', 0);
@@ -171,8 +171,8 @@ export const getOperationsStaticConfiguration = createSelector(
     },
 );
 
-export const getCurrentPoolTreeStaticConfiguration = createSelector(
-    [getTreeResources, getOperationsStaticConfiguration],
+export const selectCurrentPoolTreeStaticConfiguration = createSelector(
+    [getTreeResources, selectOperationsStaticConfiguration],
     (treeResources = {}, operationRows): Array<PoolTreeStaticConfigurationItem> => {
         const {resource_distribution_info, resource_limits} = treeResources;
 

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-ts.tsx
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-ts.tsx
@@ -3,7 +3,13 @@ import find_ from 'lodash/find';
 import reduce_ from 'lodash/reduce';
 
 import {createSelector} from 'reselect';
-import {getCurrentPool, getIsRoot, getPool, getTree, getTreeResources} from './scheduling';
+import {
+    selectCurrentPool,
+    selectPool,
+    selectSchedulingIsRoot,
+    selectTree,
+    selectTreeResources,
+} from './scheduling';
 
 import ypath from '../../../common/thor/ypath';
 import {ROOT_POOL_NAME} from '../../../constants/scheduling';
@@ -11,7 +17,7 @@ import {selectCluster} from '../global';
 import {selectPools} from './scheduling-pools';
 
 export const selectSchedulingBreadcrumbItems = createSelector(
-    [getPool, selectPools],
+    [selectPool, selectPools],
     (pool: string, pools) => {
         let current: string | undefined = pool;
         const path = [];
@@ -47,7 +53,7 @@ function makeStaticConfigurationItem(name: string, attrs: object): PoolStaticCon
 }
 
 export const selectCurrentPoolGuarantees = createSelector(
-    [getIsRoot, getCurrentPool],
+    [selectSchedulingIsRoot, selectCurrentPool],
     (isRoot, data) => {
         if (isRoot || !data?.attributes) {
             return {};
@@ -127,12 +133,15 @@ const selectPoolsAllocatedOperationsCount = createSelector([selectPoolsTopLevel]
     );
 });
 
-export const selectCurrentTreeGpuLimit = createSelector([getTreeResources], (resources): number => {
-    return ypath.getNumber(resources, '/resource_limits/gpu', 0);
-});
+export const selectCurrentTreeGpuLimit = createSelector(
+    [selectTreeResources],
+    (resources): number => {
+        return ypath.getNumber(resources, '/resource_limits/gpu', 0);
+    },
+);
 
 export const selectOperationsStaticConfiguration = createSelector(
-    [getTreeResources, selectPoolsAllocatedOperationsCount, selectCluster, getTree],
+    [selectTreeResources, selectPoolsAllocatedOperationsCount, selectCluster, selectTree],
     ({config}, allocated): Array<PoolTreeStaticConfigurationItem> => {
         const operationCount = ypath.getNumber(config, '/max_operation_count', 0);
         const runningOperationCount = ypath.getNumber(config, '/max_running_operation_count', 0);
@@ -172,7 +181,7 @@ export const selectOperationsStaticConfiguration = createSelector(
 );
 
 export const selectCurrentPoolTreeStaticConfiguration = createSelector(
-    [getTreeResources, selectOperationsStaticConfiguration],
+    [selectTreeResources, selectOperationsStaticConfiguration],
     (treeResources = {}, operationRows): Array<PoolTreeStaticConfigurationItem> => {
         const {resource_distribution_info, resource_limits} = treeResources;
 

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-ts.tsx
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-ts.tsx
@@ -8,10 +8,10 @@ import {getCurrentPool, getIsRoot, getPool, getTree, getTreeResources} from './s
 import ypath from '../../../common/thor/ypath';
 import {ROOT_POOL_NAME} from '../../../constants/scheduling';
 import {selectCluster} from '../global';
-import {getPools} from './scheduling-pools';
+import {selectPools} from './scheduling-pools';
 
 export const getSchedulingBreadcrumbItems = createSelector(
-    [getPool, getPools],
+    [getPool, selectPools],
     (pool: string, pools) => {
         let current: string | undefined = pool;
         const path = [];
@@ -111,7 +111,7 @@ function calcTreeStaticConfigurationByDistributed(
     };
 }
 
-export const getPoolsTopLevel = createSelector([getPools], (pools) => {
+export const getPoolsTopLevel = createSelector([selectPools], (pools) => {
     return filter_(pools, ({parent}) => parent === ROOT_POOL_NAME);
 });
 

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
@@ -21,7 +21,7 @@ import {isAbcPoolName, isTopLevelPool} from '../../../utils/scheduling/pool';
 import {type PoolTreeNode} from '../../../utils/scheduling/pool-child';
 import {orderTypeToOldSortState} from '../../../utils/sort-helpers';
 import {visitTreeItems} from '../../../utils/utils';
-import {getSchedulingOperationsExpandedPools} from './expanded-pools';
+import {selectSchedulingOperationsExpandedPools} from './expanded-pools';
 import {
     selectSchedulingAttributesToFilter,
     selectSchedulingFilteredPoolNames,
@@ -164,7 +164,7 @@ export const getResources = createSelector(
 );
 
 export const getCurrentTreeExpandedPools = createSelector(
-    [getTree, getSchedulingOperationsExpandedPools],
+    [getTree, selectSchedulingOperationsExpandedPools],
     (tree, expandedPools) => {
         return expandedPools[tree];
     },

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
@@ -15,7 +15,7 @@ import {ROOT_POOL_NAME} from '../../../constants/scheduling';
 
 import {type OldSortState} from '../../../types';
 
-import {getPools as getPoolsImpl, getSchedulingPoolsMapByName} from './scheduling-pools';
+import {selectPools as getPoolsImpl, selectSchedulingPoolsMapByName} from './scheduling-pools';
 import {type RootState} from '../../../store/reducers';
 import {isAbcPoolName, isTopLevelPool} from '../../../utils/scheduling/pool';
 import {type PoolTreeNode} from '../../../utils/scheduling/pool-child';
@@ -252,7 +252,7 @@ export function calculatePoolPath(
 }
 
 export const getSchedulingTopPoolOfEditItem = createSelector(
-    [getSchedulingEditItem, getSchedulingPoolsMapByName],
+    [getSchedulingEditItem, selectSchedulingPoolsMapByName],
     (pool, mapOfPools) => {
         if (isAbcPoolName(pool?.name)) {
             return undefined;
@@ -280,7 +280,7 @@ export const getSchedulingTopPoolOfEditItem = createSelector(
 );
 
 export const getSchedulingSourcesOfEditItem = createSelector(
-    [getSchedulingEditItem, getSchedulingTopPoolOfEditItem, getSchedulingPoolsMapByName],
+    [getSchedulingEditItem, getSchedulingTopPoolOfEditItem, selectSchedulingPoolsMapByName],
     (pool, topPool, mapOfPools): Array<string> => {
         if (!pool?.name || !mapOfPools || !topPool) {
             return [];

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
@@ -15,7 +15,7 @@ import {ROOT_POOL_NAME} from '../../../constants/scheduling';
 
 import {type OldSortState} from '../../../types';
 
-import {selectPools as getPoolsImpl, selectSchedulingPoolsMapByName} from './scheduling-pools';
+import {selectPools as selectPoolsImpl, selectSchedulingPoolsMapByName} from './scheduling-pools';
 import {type RootState} from '../../../store/reducers';
 import {isAbcPoolName, isTopLevelPool} from '../../../utils/scheduling/pool';
 import {type PoolTreeNode} from '../../../utils/scheduling/pool-child';
@@ -27,56 +27,57 @@ import {
     selectSchedulingFilteredPoolNames,
 } from './attributes-to-filter';
 
-export const getPools = getPoolsImpl;
+export const selectPools = selectPoolsImpl;
 
-export const getSchedulingLoading = (state: RootState) => {
+export const selectSchedulingLoading = (state: RootState) => {
     const {loading, poolLoading} = state.scheduling.scheduling;
     return loading || poolLoading;
 };
 
-const getExpandedPoolsIsInitialLoading = (state: RootState) => {
+const selectExpandedPoolsIsInitialLoading = (state: RootState) => {
     const {loaded, loading} = state.scheduling.expandedPools;
     return !loaded && loading;
 };
 
-export const getSchedulingIsInitialLoading = (state: RootState) => {
+export const selectSchedulingIsInitialLoading = (state: RootState) => {
     const {loaded, loading} = state.scheduling.scheduling;
-    return (!loaded && loading) || getExpandedPoolsIsInitialLoading(state);
+    return (!loaded && loading) || selectExpandedPoolsIsInitialLoading(state);
 };
 
-export const getTreeResources = (state: RootState) => state.scheduling.scheduling.treeResources;
-export const getSchedulingTreeMainResource = (state: RootState) =>
+export const selectTreeResources = (state: RootState) => state.scheduling.scheduling.treeResources;
+export const selectSchedulingTreeMainResource = (state: RootState) =>
     state.scheduling.scheduling.treeResources.config?.main_resource;
 
-export const getPoolChildrenFilter = (state: RootState) =>
+export const selectPoolChildrenFilter = (state: RootState) =>
     state.scheduling.scheduling.poolChildrenFilter;
-export const getSchedulingTreeState = (state: RootState) => state.scheduling.scheduling.treeState;
-const getContentModeRaw = (state: RootState) => state.scheduling.scheduling.contentMode;
+const selectSchedulingContentModeRaw = (state: RootState) =>
+    state.scheduling.scheduling.contentMode;
 
-export const getTree = (state: RootState) => state.scheduling.scheduling.tree;
-export const getTrees = (state: RootState) => state.scheduling.scheduling.trees;
+export const selectTree = (state: RootState) => state.scheduling.scheduling.tree;
+export const selectTrees = (state: RootState) => state.scheduling.scheduling.trees;
 
-export const getPool = (state: RootState) => state.scheduling.scheduling.pool;
+export const selectPool = (state: RootState) => state.scheduling.scheduling.pool;
 
 export const selectSchedulingError = (state: RootState) => {
     const {error, errorData} = state.scheduling.scheduling;
     return error ? errorData : undefined;
 };
 
-export const getSchedulingShowAbsResources = (state: RootState) =>
+export const selectSchedulingShowAbsResources = (state: RootState) =>
     state.scheduling.scheduling.showAbsResources;
 
-export const getSchedulingEditItem = (state: RootState) => state.scheduling.scheduling.editItem;
+export const selectSchedulingEditItem = (state: RootState) => state.scheduling.scheduling.editItem;
 
-export const getCurrentPool = createSelector([getPool, getPools], (pool, pools) => {
+export const selectCurrentPool = createSelector([selectPool, selectPools], (pool, pools) => {
     const res = find_(pools, (item) => item.name === pool);
     return res;
 });
 
-export const getSchedulingSortState = (state: RootState) => state.scheduling.scheduling.sortState;
+export const selectSchedulingSortState = (state: RootState) =>
+    state.scheduling.scheduling.sortState;
 
-export const getSchedulingEffectiveSortState = createSelector(
-    [getSchedulingSortState, getCurrentPool],
+export const selectSchedulingEffectiveSortState = createSelector(
+    [selectSchedulingSortState, selectCurrentPool],
     (sortState, pool): OldSortState => {
         if (!sortState?.length) {
             return pool?.mode === 'fifo' ? {field: 'FI', asc: true} : {field: 'name', asc: true};
@@ -88,7 +89,7 @@ export const getSchedulingEffectiveSortState = createSelector(
     },
 );
 
-export const getPoolsNames = createSelector(
+export const selectPoolsNames = createSelector(
     selectSchedulingAttributesToFilter,
     (pools): Array<string> => map_(pools, (_v, name) => name).sort(),
 );
@@ -106,21 +107,24 @@ export const SCHEDULING_CONTENT_MODES = [
 
 export type SchedulingContentMode = (typeof SCHEDULING_CONTENT_MODES)[number];
 
-export const getSchedulingContentMode = createSelector([getContentModeRaw], (mode) => {
-    const index = SCHEDULING_CONTENT_MODES.indexOf(mode as any);
-    return SCHEDULING_CONTENT_MODES[index !== -1 ? index : 0];
-});
+export const selectSchedulingContentMode = createSelector(
+    [selectSchedulingContentModeRaw],
+    (mode) => {
+        const index = SCHEDULING_CONTENT_MODES.indexOf(mode as any);
+        return SCHEDULING_CONTENT_MODES[index !== -1 ? index : 0];
+    },
+);
 
-export const getIsRoot = createSelector(getPool, (pool) => pool === ROOT_POOL_NAME);
+export const selectSchedulingIsRoot = createSelector(selectPool, (pool) => pool === ROOT_POOL_NAME);
 
-export const getTreesSelectItems = createSelector(getTrees, (trees) =>
+export const selectTreesSelectItems = createSelector(selectTrees, (trees) =>
     map_(trees, (tree) => ({
         value: tree,
         content: hammer.format['Readable'](tree) as string,
     })),
 );
 
-export const getPoolsSelectItems = createSelector(getPoolsNames, (pools) => {
+export const selectPoolsSelectItems = createSelector(selectPoolsNames, (pools) => {
     const items = map_(pools, (pool) => ({
         value: pool,
         content: pool,
@@ -129,12 +133,12 @@ export const getPoolsSelectItems = createSelector(getPoolsNames, (pools) => {
     return items;
 });
 
-export const getPoolIsEphemeral = createSelector([getCurrentPool], (currentPool) => {
+export const selectPoolIsEphemeral = createSelector([selectCurrentPool], (currentPool) => {
     if (currentPool && currentPool.isEphemeral !== undefined) return currentPool.isEphemeral;
     return undefined;
 });
 
-export const getCurrentPoolChildren = createSelector(getCurrentPool, (currentPool) => {
+export const selectCurrentPoolChildren = createSelector(selectCurrentPool, (currentPool) => {
     if (currentPool) {
         return currentPool.children;
     }
@@ -142,7 +146,7 @@ export const getCurrentPoolChildren = createSelector(getCurrentPool, (currentPoo
     return undefined;
 });
 
-export const getCurrentPoolOperations = createSelector(getCurrentPool, (currentPool) => {
+export const selectCurrentPoolOperations = createSelector(selectCurrentPool, (currentPool) => {
     if (currentPool) {
         return currentPool.leaves;
     }
@@ -150,8 +154,8 @@ export const getCurrentPoolOperations = createSelector(getCurrentPool, (currentP
     return undefined;
 });
 
-export const getResources = createSelector(
-    [getCurrentPool, getTreeResources],
+export const selectResources = createSelector(
+    [selectCurrentPool, selectTreeResources],
     (currentPool, resources) => {
         if (currentPool && currentPool.name !== '<Root>') {
             return prepareResources(currentPool.attributes);
@@ -163,15 +167,15 @@ export const getResources = createSelector(
     },
 );
 
-export const getCurrentTreeExpandedPools = createSelector(
-    [getTree, selectSchedulingOperationsExpandedPools],
+export const selectCurrentTreeExpandedPools = createSelector(
+    [selectTree, selectSchedulingOperationsExpandedPools],
     (tree, expandedPools) => {
         return expandedPools[tree];
     },
 );
 
-const getSchedulingOverviewFilteredTree = createSelector(
-    [getCurrentPool, selectSchedulingFilteredPoolNames, getCurrentTreeExpandedPools],
+const selectSchedulingOverviewFilteredTree = createSelector(
+    [selectCurrentPool, selectSchedulingFilteredPoolNames, selectCurrentTreeExpandedPools],
     (treeRoot, visiblePools, expandedPools) => {
         if (treeRoot) {
             const res = treeList.filterTreeEachChild(
@@ -191,8 +195,8 @@ const getSchedulingOverviewFilteredTree = createSelector(
     },
 );
 
-export const getSchedulingOverviewTableItems = createSelector(
-    [getSchedulingOverviewFilteredTree, getSchedulingEffectiveSortState],
+export const selectSchedulingOverviewTableItems = createSelector(
+    [selectSchedulingOverviewFilteredTree, selectSchedulingEffectiveSortState],
     (filteredTree, sortState) => {
         if (filteredTree) {
             const isRoot = filteredTree && filteredTree.name === ROOT_POOL_NAME;
@@ -219,12 +223,12 @@ export const getSchedulingOverviewTableItems = createSelector(
 // The same cluster is ready for bundle's ACL
 const CLUSTERS_WITHOUT_POOL_ACL = ['locke'];
 
-export const isPoolAclAllowed = createSelector([selectCluster], (cluster) => {
+export const selectIsPoolAclAllowed = createSelector([selectCluster], (cluster) => {
     return CLUSTERS_WITHOUT_POOL_ACL.indexOf(cluster) === -1;
 });
 
-export const getCurrentPoolPath = createSelector(
-    [getPool, getPools, getTree],
+export const selectCurrentPoolPath = createSelector(
+    [selectPool, selectPools, selectTree],
     (pool, pools, tree) => {
         return calculatePoolPath(pool, pools, tree);
     },
@@ -251,8 +255,8 @@ export function calculatePoolPath(
     return `${prefix}${pathStr}`;
 }
 
-export const getSchedulingTopPoolOfEditItem = createSelector(
-    [getSchedulingEditItem, selectSchedulingPoolsMapByName],
+export const selectSchedulingTopPoolOfEditItem = createSelector(
+    [selectSchedulingEditItem, selectSchedulingPoolsMapByName],
     (pool, mapOfPools) => {
         if (isAbcPoolName(pool?.name)) {
             return undefined;
@@ -279,8 +283,8 @@ export const getSchedulingTopPoolOfEditItem = createSelector(
     },
 );
 
-export const getSchedulingSourcesOfEditItem = createSelector(
-    [getSchedulingEditItem, getSchedulingTopPoolOfEditItem, selectSchedulingPoolsMapByName],
+export const selectSchedulingSourcesOfEditItem = createSelector(
+    [selectSchedulingEditItem, selectSchedulingTopPoolOfEditItem, selectSchedulingPoolsMapByName],
     (pool, topPool, mapOfPools): Array<string> => {
         if (!pool?.name || !mapOfPools || !topPool) {
             return [];
@@ -305,8 +309,8 @@ export const getSchedulingSourcesOfEditItem = createSelector(
     },
 );
 
-export const getSchedulingSourcesOfEditItemSkipParent = createSelector(
-    [getSchedulingEditItem, getSchedulingSourcesOfEditItem],
+export const selectSchedulingSourcesOfEditItemSkipParent = createSelector(
+    [selectSchedulingEditItem, selectSchedulingSourcesOfEditItem],
     (pool, sources) => {
         if (!pool?.parent) {
             return sources;

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
@@ -23,8 +23,8 @@ import {orderTypeToOldSortState} from '../../../utils/sort-helpers';
 import {visitTreeItems} from '../../../utils/utils';
 import {getSchedulingOperationsExpandedPools} from './expanded-pools';
 import {
-    getSchedulingAttributesToFilter,
-    getSchedulingFilteredPoolNames,
+    selectSchedulingAttributesToFilter,
+    selectSchedulingFilteredPoolNames,
 } from './attributes-to-filter';
 
 export const getPools = getPoolsImpl;
@@ -89,7 +89,7 @@ export const getSchedulingEffectiveSortState = createSelector(
 );
 
 export const getPoolsNames = createSelector(
-    getSchedulingAttributesToFilter,
+    selectSchedulingAttributesToFilter,
     (pools): Array<string> => map_(pools, (_v, name) => name).sort(),
 );
 
@@ -171,7 +171,7 @@ export const getCurrentTreeExpandedPools = createSelector(
 );
 
 const getSchedulingOverviewFilteredTree = createSelector(
-    [getCurrentPool, getSchedulingFilteredPoolNames, getCurrentTreeExpandedPools],
+    [getCurrentPool, selectSchedulingFilteredPoolNames, getCurrentTreeExpandedPools],
     (treeRoot, visiblePools, expandedPools) => {
         if (treeRoot) {
             const res = treeList.filterTreeEachChild(


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/GAivI56b7hNb4C
<!-- nda-end -->## Summary by Sourcery

Enhancements:
- Standardize scheduling selector naming across store, actions, hooks, and UI components to use a consistent `select*` prefix.