### PR TITLE
fix(Scheduling): add 'Aggregated by children' row [YTFRONT-5841]

### DIFF
--- a/packages/ui/src/ui/components/DataTableGravity/DataTableGravity.scss
+++ b/packages/ui/src/ui/components/DataTableGravity/DataTableGravity.scss
@@ -24,7 +24,7 @@
     .gt-table__cell_pinned-right,
     .gt-table__header-cell_pinned-left,
     .gt-table__cell_pinned-left {
-        background-color: var(--main-background);
+        background-color: var(--yt-table-background-color, var(--main-background));
         opacity: 0.9;
     }
 

--- a/packages/ui/src/ui/components/DataTableGravity/DataTableGravity.tsx
+++ b/packages/ui/src/ui/components/DataTableGravity/DataTableGravity.tsx
@@ -82,7 +82,11 @@ export function DataTableGravity<TData, TScrollElement extends Element | Window>
         [rowClassName, isHighlightedRow],
     );
 
-    const {cellAttributes: cellAttrs, headerCellAttributes: headerCellAttrs} = props;
+    const {
+        cellAttributes: cellAttrs,
+        headerCellAttributes: headerCellAttrs,
+        footerCellAttributes: footerCellAttrs,
+    } = props;
 
     const cellAttributes = React.useCallback<
         Exclude<typeof props.cellAttributes & Function, undefined>
@@ -131,6 +135,29 @@ export function DataTableGravity<TData, TScrollElement extends Element | Window>
         [headerCellAttrs],
     );
 
+    const footerCellAttributes = React.useCallback<
+        Exclude<typeof props.footerCellAttributes & Function, undefined>
+    >(
+        (footer) => {
+            const res =
+                typeof footerCellAttrs === 'function' ? footerCellAttrs(footer) : footerCellAttrs;
+
+            const style = {...getCellStyles(footer)};
+            if (style.left !== undefined) {
+                Object.assign(style, {left: `calc(${style.left} + var(--gn-aside-header-size))`});
+            }
+
+            return {
+                ...res,
+                style: {
+                    ...res?.style,
+                    ...style,
+                },
+            };
+        },
+        [footerCellAttrs],
+    );
+
     return (
         <div className={block({virtualized}, className)} ref={setElement}>
             <Table
@@ -139,8 +166,9 @@ export function DataTableGravity<TData, TScrollElement extends Element | Window>
                 rowClassName={rowClassNameFn}
                 {...virtualizerProps}
                 {...props}
-                cellAttributes={cellAttributes}
                 headerCellAttributes={headerCellAttributes}
+                cellAttributes={cellAttributes}
+                footerCellAttributes={footerCellAttributes}
                 renderSortIndicator={(sortProps) => {
                     if (renderSortIndicator) {
                         return renderSortIndicator(sortProps);

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.scss
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.scss
@@ -24,4 +24,14 @@
     &__duration {
         white-space: nowrap;
     }
+
+    &__footer {
+        .gt-table__footer-row {
+            height: 48px;
+        }
+        .gt-table__footer-cell {
+            --yt-table-background-color: var(--g-color-base-generic-ultralight);
+            background-color: var(--yt-table-background-color);
+        }
+    }
 }

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
@@ -1,11 +1,10 @@
+import {DropdownMenu, Flex, Progress, Text} from '@gravity-ui/uikit';
+import {MetaTable, Tooltip, YTText} from '@ytsaurus/components';
 import cn from 'bem-cn-lite';
 import moment from 'moment';
 import React from 'react';
-
-import {DropdownMenu, Flex, Progress, Text} from '@gravity-ui/uikit';
-
+import {type KeysByType} from '../../../../../../../@types/types';
 import format from '../../../../../../common/hammer/format';
-
 import ColumnHeader, {
     type ColumnHeaderProps,
 } from '../../../../../../components/ColumnHeader/ColumnHeader';
@@ -21,20 +20,8 @@ import {
     type FormatNumberProps,
 } from '../../../../../../components/FormatNumber/FormatNumber';
 import Label from '../../../../../../components/Label';
-import {MetaTable, Tooltip} from '@ytsaurus/components';
 import {OperationType} from '../../../../../../components/OperationType/OperationType';
 import {SubjectCard} from '../../../../../../components/SubjectLink/SubjectLink';
-import {selectSchedulingOperationsLoading} from '../../../../../../store/selectors/scheduling/expanded-pools';
-import {
-    selectSchedulingContentMode,
-    selectSchedulingLoading,
-    selectSchedulingOverviewTableItems,
-    selectSchedulingShowAbsResources,
-    selectSchedulingSortState,
-    selectSchedulingTreeMainResource,
-} from '../../../../../../store/selectors/scheduling/scheduling';
-
-import {type KeysByType} from '../../../../../../../@types/types';
 import {formatTimeDuration} from '../../../../../../components/TimeDuration/TimeDuration';
 import {useSettingsColumnSizes} from '../../../../../../hooks/settings/use-settings-column-sizes';
 import {useSettingsVisibleColumns} from '../../../../../../hooks/settings/use-settings-column-visibility';
@@ -48,7 +35,17 @@ import {
 import {openPoolDeleteModal} from '../../../../../../store/actions/scheduling/scheduling-ts';
 import {useDispatch, useSelector} from '../../../../../../store/redux-hooks';
 import {selectSchedulingOperationRefId} from '../../../../../../store/selectors/scheduling/attributes-to-filter';
+import {selectSchedulingOperationsLoading} from '../../../../../../store/selectors/scheduling/expanded-pools';
 import {selectSchedulingOverivewColumns} from '../../../../../../store/selectors/scheduling/overview-columns';
+import {
+    selectSchedulingChildrenAggregatedRow,
+    selectSchedulingContentMode,
+    selectSchedulingLoading,
+    selectSchedulingOverviewTableItems,
+    selectSchedulingShowAbsResources,
+    selectSchedulingSortState,
+    selectSchedulingTreeMainResource,
+} from '../../../../../../store/selectors/scheduling/scheduling';
 import {getProgressTheme} from '../../../../../../utils/progress';
 import {
     type SchedulingColumn,
@@ -112,6 +109,9 @@ export function SchedulingTable() {
 
     return (
         <DataTableGravity
+            withFooter
+            stickyFooter
+            footerClassName={block('footer')}
             className={block()}
             table={table}
             virtualized
@@ -210,6 +210,7 @@ type KeyByGetterReturnType<T> =
 
 function makeNumberColumn(
     id: KeyByGetterReturnType<number | undefined>,
+    aggregationRow: RowData | undefined,
     {
         type = 'NumberSmart',
         ...rest
@@ -219,7 +220,7 @@ function makeNumberColumn(
     return {
         id,
         header: () => <SchedulingColumnHeader column={id} />,
-        cell: ({row: {original: item}}: tanstack.CellContext<RowData, unknown>) => {
+        ...cellAndFooter(aggregationRow, (item) => {
             let value: number | undefined;
             if ('sort' in info && 'function' === typeof info.sort) {
                 value = info.sort(item);
@@ -232,7 +233,7 @@ function makeNumberColumn(
                     <FormatNumber value={value} type={type} {...rest} />
                 </TableCell>
             );
-        },
+        }),
     };
 }
 
@@ -266,8 +267,25 @@ type SchedulingColumnDef = Omit<tanstack.ColumnDef<RowData>, 'id'> & {id: Schedu
 
 const DurationMemo = React.memo(Duration);
 
+function cellAndFooter(
+    aggregationRow: RowData | undefined,
+    renderItem: (item: RowData) => React.ReactNode,
+): Pick<SchedulingColumnDef, 'cell' | 'footer'> {
+    if (!aggregationRow) {
+        return {
+            cell: ({row: {original: item}}) => renderItem(item),
+        };
+    }
+    return {
+        cell: ({row: {original: item}}) => renderItem(item),
+        footer: () => renderItem(aggregationRow),
+    };
+}
+
 function useSchedulingTableColumns() {
     const visibleColumns = useSchedulingVisibleColumns();
+
+    const aggregationRow = useSelector(selectSchedulingChildrenAggregatedRow);
 
     const columns = React.useMemo(() => {
         const availableColumns: Array<SchedulingColumnDef> = [
@@ -284,6 +302,13 @@ function useSchedulingTableColumns() {
                 },
                 enableColumnFilter: false,
                 enableHiding: false,
+                ...(aggregationRow
+                    ? {
+                          footer: () => {
+                              return <YTText bold>{i18n('title_aggregation')}</YTText>;
+                          },
+                      }
+                    : {}),
             },
             {
                 id: 'weight',
@@ -294,7 +319,7 @@ function useSchedulingTableColumns() {
                         allowUnordered
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     const {weightEdited = NaN, type, weight} = item;
                     return (
                         <TableCell>
@@ -309,7 +334,7 @@ function useSchedulingTableColumns() {
                             )}
                         </TableCell>
                     );
-                },
+                }),
                 size: 100,
             },
             {
@@ -373,13 +398,13 @@ function useSchedulingTableColumns() {
                         allowUnordered
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     return (
                         <TableCell justifyContent="center">
                             <FairShareUsage item={item} />
                         </TableCell>
                     );
-                },
+                }),
             },
             {
                 id: 'usage',
@@ -400,13 +425,13 @@ function useSchedulingTableColumns() {
                         ]}
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     return (
                         <TableCell>
                             <ResourceSummary item={item} type="usage" />
                         </TableCell>
                     );
-                },
+                }),
                 size: 100,
             },
             {
@@ -428,13 +453,13 @@ function useSchedulingTableColumns() {
                         ]}
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     return (
                         <TableCell>
                             <ResourceSummary item={item} type="demand" />
                         </TableCell>
                     );
-                },
+                }),
                 size: 100,
             },
             {
@@ -468,13 +493,13 @@ function useSchedulingTableColumns() {
                         ]}
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     return (
                         <TableCell>
                             <ResourceSummary item={item} type="effectiveGuaranteed" />
                         </TableCell>
                     );
-                },
+                }),
                 size: 100,
             },
             {
@@ -498,7 +523,7 @@ function useSchedulingTableColumns() {
                         ]}
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     const {
                         maxOperationCount,
                         maxOperationCountEdited,
@@ -523,7 +548,7 @@ function useSchedulingTableColumns() {
                             </Text>
                         </TableCell>
                     );
-                },
+                }),
                 size: 120,
             },
             {
@@ -584,7 +609,7 @@ function useSchedulingTableColumns() {
                         ]}
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     const info = childTableItems.operation_progress;
                     const value = info.get(item);
                     const theme = getProgressTheme(value);
@@ -594,7 +619,7 @@ function useSchedulingTableColumns() {
                     ) : (
                         <Progress value={value * 100} theme={theme} text={text} />
                     );
-                },
+                }),
             },
             {
                 id: 'running_operation_progress',
@@ -621,7 +646,7 @@ function useSchedulingTableColumns() {
                         ]}
                     />
                 ),
-                cell: ({row: {original: item}}) => {
+                ...cellAndFooter(aggregationRow, (item) => {
                     const info = childTableItems.running_operation_progress;
                     const value = info.get(item);
                     const theme = getProgressTheme(value);
@@ -631,46 +656,61 @@ function useSchedulingTableColumns() {
                     ) : (
                         <Progress value={value * 100} theme={theme} text={text} />
                     );
-                },
+                }),
             },
-            makeNumberColumn('abs_demand_cpu', {hideApproximateChar: true}),
-            makeNumberColumn('abs_demand_gpu', {hideApproximateChar: true}),
-            makeNumberColumn('abs_demand_memory', {type: 'Bytes', hideApproximateChar: true}),
-            makeNumberColumn('abs_demand_user_slots'),
-            makeNumberColumn('abs_guaranteed_cpu', {hideApproximateChar: true}),
-            makeNumberColumn('abs_guaranteed_gpu', {hideApproximateChar: true}),
-            makeNumberColumn('abs_guaranteed_memory', {type: 'Bytes', hideApproximateChar: true}),
-            makeNumberColumn('abs_guaranteed_user_slots'),
-            makeNumberColumn('abs_usage_cpu', {hideApproximateChar: true}),
-            makeNumberColumn('abs_usage_gpu', {hideApproximateChar: true}),
-            makeNumberColumn('abs_usage_memory', {type: 'Bytes', hideApproximateChar: true}),
-            makeNumberColumn('abs_usage_user_slots'),
-            makeNumberColumn('accumulated'),
-            makeNumberColumn('burst_cpu'),
-            makeNumberColumn('burst_duration'),
-            makeNumberColumn('children_burst_cpu'),
-            makeNumberColumn('children_flow_cpu'),
-            makeNumberColumn('flow_cpu'),
-            makeReadableFieldColumn('integral_type'),
-            makeNumberColumn('max_operation_count'),
-            makeNumberColumn('max_running_operation_count'),
-            makeNumberColumn('min_resources_cpu', {hideApproximateChar: true}),
-            makeNumberColumn('min_resources_gpu', {hideApproximateChar: true}),
-            makeNumberColumn('min_resources_memory', {type: 'Bytes', hideApproximateChar: true}),
-            makeNumberColumn('min_resources_user_slots'),
-            makeNumberColumn('operation_count'),
-            makeNumberColumn('resource_detailed_cpu', {hideApproximateChar: true}),
-            makeNumberColumn('resource_detailed_gpu', {hideApproximateChar: true}),
-            makeNumberColumn('resource_detailed_memory', {
+            makeNumberColumn('abs_demand_cpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('abs_demand_gpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('abs_demand_memory', aggregationRow, {
                 type: 'Bytes',
                 hideApproximateChar: true,
             }),
-            makeNumberColumn('resource_detailed_user_slots'),
-            makeNumberColumn('resource_limit_cpu'),
-            makeNumberColumn('resource_limit_gpu'),
-            makeNumberColumn('resource_limit_memory', {type: 'Bytes', hideApproximateChar: true}),
-            makeNumberColumn('resource_limit_user_slots'),
-            makeNumberColumn('running_operation_count'),
+            makeNumberColumn('abs_demand_user_slots', aggregationRow),
+            makeNumberColumn('abs_guaranteed_cpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('abs_guaranteed_gpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('abs_guaranteed_memory', aggregationRow, {
+                type: 'Bytes',
+                hideApproximateChar: true,
+            }),
+            makeNumberColumn('abs_guaranteed_user_slots', aggregationRow),
+            makeNumberColumn('abs_usage_cpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('abs_usage_gpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('abs_usage_memory', aggregationRow, {
+                type: 'Bytes',
+                hideApproximateChar: true,
+            }),
+            makeNumberColumn('abs_usage_user_slots', aggregationRow),
+            makeNumberColumn('accumulated', aggregationRow),
+            makeNumberColumn('burst_cpu', aggregationRow),
+            makeNumberColumn('burst_duration', aggregationRow),
+            makeNumberColumn('children_burst_cpu', aggregationRow),
+            makeNumberColumn('children_flow_cpu', aggregationRow),
+            makeNumberColumn('flow_cpu', aggregationRow),
+            makeReadableFieldColumn('integral_type'),
+            makeNumberColumn('max_operation_count', aggregationRow),
+            makeNumberColumn('max_running_operation_count', aggregationRow),
+            makeNumberColumn('min_resources_cpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('min_resources_gpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('min_resources_memory', aggregationRow, {
+                type: 'Bytes',
+                hideApproximateChar: true,
+            }),
+            makeNumberColumn('min_resources_user_slots', aggregationRow),
+            makeNumberColumn('operation_count', aggregationRow),
+            makeNumberColumn('resource_detailed_cpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('resource_detailed_gpu', aggregationRow, {hideApproximateChar: true}),
+            makeNumberColumn('resource_detailed_memory', aggregationRow, {
+                type: 'Bytes',
+                hideApproximateChar: true,
+            }),
+            makeNumberColumn('resource_detailed_user_slots', aggregationRow),
+            makeNumberColumn('resource_limit_cpu', aggregationRow),
+            makeNumberColumn('resource_limit_gpu', aggregationRow),
+            makeNumberColumn('resource_limit_memory', aggregationRow, {
+                type: 'Bytes',
+                hideApproximateChar: true,
+            }),
+            makeNumberColumn('resource_limit_user_slots', aggregationRow),
+            makeNumberColumn('running_operation_count', aggregationRow),
             {
                 id: 'actions',
                 header: (ctx) => {
@@ -687,7 +727,7 @@ function useSchedulingTableColumns() {
         ];
 
         return availableColumns;
-    }, []);
+    }, [aggregationRow]);
 
     const {columnVisibility, columnOrder} = React.useMemo(() => {
         const visible = new Set(visibleColumns);
@@ -839,8 +879,8 @@ function Duration({start}: {start?: string}) {
 function RowActions({item}: {item: RowData}) {
     const dispatch = useDispatch();
 
-    const {type, isEphemeral} = item;
-    const editable = !isEphemeral && type === 'pool';
+    const {type, isEphemeral, isAggregationRow} = item;
+    const editable = !isEphemeral && type === 'pool' && !isAggregationRow;
 
     return (
         editable && (

--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/i18n/en.json
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/i18n/en.json
@@ -1,4 +1,5 @@
 {
+  "title_aggregation": "Aggregation",
   "title_pool-operation": "Pool / Operation",
   "field_weight": "Weight",
   "field_mode": "Mode",

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling.ts
@@ -8,24 +8,24 @@ import * as treeList from '../../../common/hammer/tree-list';
 import {createSelector} from 'reselect';
 import {selectCluster} from '../../../store/selectors/global';
 
-import {prepareResources} from '../../../utils/scheduling/overview';
 import {childTableItems} from '../../../utils/scheduling/detailsTable';
+import {prepareResources} from '../../../utils/scheduling/overview';
 
 import {ROOT_POOL_NAME} from '../../../constants/scheduling';
 
 import {type OldSortState} from '../../../types';
 
-import {selectPools as selectPoolsImpl, selectSchedulingPoolsMapByName} from './scheduling-pools';
 import {type RootState} from '../../../store/reducers';
 import {isAbcPoolName, isTopLevelPool} from '../../../utils/scheduling/pool';
 import {type PoolTreeNode} from '../../../utils/scheduling/pool-child';
 import {orderTypeToOldSortState} from '../../../utils/sort-helpers';
 import {visitTreeItems} from '../../../utils/utils';
-import {selectSchedulingOperationsExpandedPools} from './expanded-pools';
 import {
     selectSchedulingAttributesToFilter,
     selectSchedulingFilteredPoolNames,
 } from './attributes-to-filter';
+import {selectSchedulingOperationsExpandedPools} from './expanded-pools';
+import {selectPools as selectPoolsImpl, selectSchedulingPoolsMapByName} from './scheduling-pools';
 
 export const selectPools = selectPoolsImpl;
 
@@ -195,6 +195,8 @@ const selectSchedulingOverviewFilteredTree = createSelector(
     },
 );
 
+type RowData = ReturnType<typeof selectSchedulingOverviewTableItems>[number];
+
 export const selectSchedulingOverviewTableItems = createSelector(
     [selectSchedulingOverviewFilteredTree, selectSchedulingEffectiveSortState],
     (filteredTree, sortState) => {
@@ -217,6 +219,101 @@ export const selectSchedulingOverviewTableItems = createSelector(
         }
 
         return [];
+    },
+);
+
+type AggResources = NonNullable<PoolTreeNode['resources']>;
+
+function aggregateChildrenResources(children: Array<PoolTreeNode>): AggResources {
+    const resourceTypes = ['cpu', 'gpu', 'user_memory', 'user_slots'] as const;
+    const resourceFields = [
+        'usage',
+        'demand',
+        'guaranteed',
+        'effectiveGuaranteed',
+        'min',
+        'detailed',
+        'limit',
+    ] as const;
+
+    const result: AggResources = {};
+
+    for (const resource of resourceTypes) {
+        const hasAnyValue = children.some((child) => child.resources?.[resource]);
+        if (!hasAnyValue) continue;
+
+        const aggregated: NonNullable<AggResources[typeof resource]> = {};
+        for (const field of resourceFields) {
+            let total = 0;
+            let hasValue = false;
+            for (const child of children) {
+                if (child.incomplete) continue;
+                const val = child.resources?.[resource]?.[field];
+                if (typeof val === 'number' && !isNaN(val)) {
+                    total += val;
+                    hasValue = true;
+                }
+            }
+            if (hasValue) {
+                aggregated[field] = total;
+            }
+        }
+        result[resource] = aggregated;
+    }
+
+    return result;
+}
+
+function sumChildrenField(
+    children: Array<PoolTreeNode>,
+    field: keyof PoolTreeNode,
+): number | undefined {
+    let total = 0;
+    let hasValue = false;
+    for (const child of children) {
+        if (child.incomplete) continue;
+        const val = child[field];
+        if (typeof val === 'number' && !isNaN(val)) {
+            total += val;
+            hasValue = true;
+        }
+    }
+    return hasValue ? total : undefined;
+}
+
+export const selectSchedulingChildrenAggregatedRow = createSelector(
+    [selectCurrentPool],
+    (currentPool): RowData | undefined => {
+        const {children = []} = currentPool || {};
+        if (children.length < 1) {
+            return undefined;
+        }
+
+        const aggregationRow = {
+            type: 'pool' as const,
+            name: '##children-aggregation##',
+            isAggregationRow: true,
+            level: 1,
+            attributes: {},
+            leaves: [],
+            children: [],
+            resources: aggregateChildrenResources(children),
+            operationCount: sumChildrenField(children, 'operationCount'),
+            maxOperationCount: sumChildrenField(children, 'maxOperationCount'),
+            runningOperationCount: sumChildrenField(children, 'runningOperationCount'),
+            maxRunningOperationCount: sumChildrenField(children, 'maxRunningOperationCount'),
+            burstCPU: sumChildrenField(children, 'burstCPU'),
+            flowCPU: sumChildrenField(children, 'flowCPU'),
+            childrenBurstCPU: sumChildrenField(children, 'childrenBurstCPU'),
+            childrenFlowCPU: sumChildrenField(children, 'childrenFlowCPU'),
+            accumulated: sumChildrenField(children, 'accumulated'),
+            burstDuration: sumChildrenField(children, 'burstDuration'),
+            weight: sumChildrenField(children, 'weight'),
+            fairShareRatio: sumChildrenField(children, 'fairShareRatio'),
+            usageRatio: sumChildrenField(children, 'usageRatio'),
+        };
+
+        return aggregationRow as unknown as RowData;
     },
 );
 

--- a/packages/ui/src/ui/utils/scheduling/pool-child.ts
+++ b/packages/ui/src/ui/utils/scheduling/pool-child.ts
@@ -77,6 +77,7 @@ function preparePoolChildResource<T extends 'pool' | 'operation'>(
 export type PoolData<T extends 'pool' | 'operation'> = {
     type: T;
     pool?: string;
+    isAggregationRow?: boolean;
     attributes?: {
         accumulated_resource_volume?: Record<PoolResourceType, number | undefined>;
         integral_pool_capacity?: Record<PoolResourceType, number | undefined>;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/6VF-gGac7hPNjB
<!-- nda-end -->    ## Summary by Sourcery

Add an aggregated-by-children summary row to the scheduling overview table and adjust table footer and styling to display it correctly.

New Features:
- Display a footer row in the scheduling overview table that aggregates key metrics across child pools when applicable.

Enhancements:
- Refine DataTableGravity to support styled footer cells with pinned column background consistency.
- Prevent row actions from being available on synthetic aggregation rows in the scheduling overview table.

Tests:
- Update navigation screenshot test viewport and mouse positioning to align with the new table footer behavior and visual layout.