### PR TITLE
chore(UI): rename tablet selectors [YTFRONT-5653]

### DIFF
--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.tsx
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Overview.tsx
@@ -20,7 +20,7 @@ import Label, {type LabelTheme} from '../../../components/Label';
 import {Yson} from '../../../components/Yson/Yson';
 
 import {histogramItems} from '../../../utils/tablet/tablet';
-import {getActiveHistogram, selectHistogram} from '../../../store/selectors/tablet/tablet';
+import {selectActiveHistogram, selectHistogram} from '../../../store/selectors/tablet/tablet';
 import {changeActiveHistogram} from '../../../store/actions/tablet/tablet';
 import {Tab as NavigationTab} from '../../../constants/navigation';
 import {Page} from '../../../constants/index';
@@ -209,7 +209,7 @@ function Overview({id, block}: Props) {
     };
     const stateTheme: LabelTheme | undefined = stateThemeMap[state as string];
 
-    const activeHistogram = useSelector(getActiveHistogram);
+    const activeHistogram = useSelector(selectActiveHistogram);
     const histogram = useSelector(selectHistogram);
 
     const handleHistogramChange = useCallback(

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Partitions.js
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Partitions.js
@@ -19,7 +19,7 @@ import {StickyContainer} from '../../../components/StickyContainer/StickyContain
 
 import {TABLET_PARTITIONS_TABLE_ID} from '../../../constants/tablet';
 import {tabletChangeContentMode} from '../../../store/actions/tablet/tablet';
-import {getPartitions} from '../../../store/selectors/tablet/tablet';
+import {selectPartitions} from '../../../store/selectors/tablet/tablet';
 import {partitionsTableItems} from '../../../utils/tablet/table';
 import StoresDialog from './StoresDialog';
 
@@ -280,7 +280,7 @@ const mapDispatchToProps = {
 
 const mapStateToProps = (state) => {
     const {contentMode, tabletPath, unorderedDynamicTable} = state.tablet.tablet;
-    const partitions = getPartitions(state);
+    const partitions = selectPartitions(state);
 
     return {contentMode, tabletPath, partitions, unorderedDynamicTable};
 };

--- a/packages/ui/src/ui/pages/tablet/TabletDetails/Stores.js
+++ b/packages/ui/src/ui/pages/tablet/TabletDetails/Stores.js
@@ -15,7 +15,7 @@ import LoadDataHandler from '../../../containers/LoadDataHandler/LoadDataHandler
 import {abortAndReset, loadStoresData} from '../../../store/actions/tablet/stores';
 import {TABLET_PARTITION_STORES_TABLE_ID} from '../../../constants/tablet';
 import {storesTableItems} from '../../../utils/tablet/table';
-import {getStores} from '../../../store/selectors/tablet/stores';
+import {selectStores} from '../../../store/selectors/tablet/stores';
 
 import i18n from './i18n';
 import './Stores.scss';
@@ -238,7 +238,7 @@ class Stores extends Component {
 
 const mapStateToProps = (state) => {
     const {loading, loaded, error, errorData} = state.tablet.stores;
-    const stores = getStores(state);
+    const stores = selectStores(state);
 
     return {loading, loaded, error, errorData, stores};
 };

--- a/packages/ui/src/ui/store/selectors/tablet/stores.js
+++ b/packages/ui/src/ui/store/selectors/tablet/stores.js
@@ -3,9 +3,10 @@ import {createSelector} from 'reselect';
 import {storesTableItems} from '../../../utils/tablet/table';
 import {TABLET_PARTITION_STORES_TABLE_ID} from '../../../constants/tablet';
 
-const getRawStores = (state) => state.tablet.stores.stores;
-const getSortState = (state) => state.tables[TABLET_PARTITION_STORES_TABLE_ID];
+const selectRawStores = (state) => state.tablet.stores.stores;
+const selectSortState = (state) => state.tables[TABLET_PARTITION_STORES_TABLE_ID];
 
-export const getStores = createSelector([getRawStores, getSortState], (stores, sortState) =>
-    hammer.utils.sort(stores, sortState, storesTableItems),
+export const selectStores = createSelector(
+    [selectRawStores, selectSortState],
+    (stores, sortState) => hammer.utils.sort(stores, sortState, storesTableItems),
 );

--- a/packages/ui/src/ui/store/selectors/tablet/tablet.js
+++ b/packages/ui/src/ui/store/selectors/tablet/tablet.js
@@ -7,16 +7,16 @@ import {histogramItems} from '../../../utils/tablet/tablet';
 import {partitionsTableItems} from '../../../utils/tablet/table';
 import {TABLET_PARTITIONS_TABLE_ID} from '../../../constants/tablet';
 
-const getRawPartitions = (state) => state.tablet.tablet.partitions;
-const getSortState = (state) => state.tables[TABLET_PARTITIONS_TABLE_ID];
-export const getActiveHistogram = (state) => state.tablet.tablet.activeHistogram;
+const selectRawPartitions = (state) => state.tablet.tablet.partitions;
+const selectSortState = (state) => state.tables[TABLET_PARTITIONS_TABLE_ID];
+export const selectActiveHistogram = (state) => state.tablet.tablet.activeHistogram;
 
-export const getSortedPartitions = createSelector(
-    [getRawPartitions, getSortState],
+export const selectSortedPartitions = createSelector(
+    [selectRawPartitions, selectSortState],
     (partitions, sortState) => hammer.utils.sort(partitions, sortState, partitionsTableItems),
 );
 
-export const getPartitions = createSelector(getSortedPartitions, (sortedPartitions) => {
+export const selectPartitions = createSelector(selectSortedPartitions, (sortedPartitions) => {
     const aggregation = hammer.aggregation.prepare(sortedPartitions, [
         {name: 'stores', type: 'concat-array'},
         {name: 'storeCount', type: 'sum'},
@@ -31,7 +31,7 @@ export const getPartitions = createSelector(getSortedPartitions, (sortedPartitio
     return [aggregation, ...sortedPartitions];
 });
 
-const selectHistograms = createSelector(getRawPartitions, (partitions) =>
+const selectHistograms = createSelector(selectRawPartitions, (partitions) =>
     mapValues_(histogramItems, (settings, key) => {
         const partitionsWithoutEden = partitions.slice(1);
 
@@ -47,6 +47,6 @@ const selectHistograms = createSelector(getRawPartitions, (partitions) =>
 );
 
 export const selectHistogram = createSelector(
-    [selectHistograms, getActiveHistogram],
+    [selectHistograms, selectActiveHistogram],
     (histograms, activeHistogram) => histograms[activeHistogram],
 );


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/do2TmYbM7hykkS
<!-- nda-end --> ## Summary by Sourcery

Enhancements:
- Standardize naming of tablet partitions, stores, and histogram selectors to the `select*` convention across UI store and pages.