### PR TITLE
fix(Queries): cyrillic name in history [YTFRONT-5881]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/Columns/ColumnCells.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/Columns/ColumnCells.tsx
@@ -2,7 +2,6 @@ import React, {type FC} from 'react';
 import {Text} from '@gravity-ui/uikit';
 import block from 'bem-cn-lite';
 import hammer from '../../../../../common/hammer';
-import unipika from '../../../../../common/thor/unipika';
 import {QueryStatusIcon} from '../../../../../components/QueryStatus';
 import {formatTime} from '../../../../../components/common/Timeline/util';
 import {type QueryItem} from '../../../../../types/query-tracker/api';
@@ -19,8 +18,7 @@ type CellProps = {
 };
 
 export const QueryHistoryNameCell: FC<CellProps> = ({row}) => {
-    const title = row.annotations?.title;
-    const name = title ? unipika.decode(title) : title;
+    const name = row.annotations?.title;
 
     return (
         <div className={b('name')} title={name}>

--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -162,7 +162,7 @@ export function loadQueriesList({
                 limit,
                 output_format: 'json',
             },
-            setup: getQTApiSetup(),
+            setup: {...getQTApiSetup(), JSONSerializer},
             cancellation,
         });
     };


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/liPCnUHA7i28vA
<!-- nda-end -->## Summary by Sourcery

Fix incorrect display of query history names by adjusting title handling and API JSON serialization.

Bug Fixes:
- Display query history item titles as stored without unipika decoding to preserve characters such as Cyrillic.
- Include JSONSerializer in query tracker API setup for the queries list to correctly handle JSON-encoded titles.