### PR TITLE
fix(Dockerfile): do not show nginx weilcome page [#1694]

### DIFF
--- a/packages/ui/deploy/nginx/nginx.conf
+++ b/packages/ui/deploy/nginx/nginx.conf
@@ -40,7 +40,6 @@ http {
     gzip on;
     gzip_types text/plain text/css application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript application/json;
 
-    include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;
 
     fastcgi_intercept_errors on;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Disable inclusion of /etc/nginx/conf.d/*.conf to avoid serving the nginx default welcome page in the UI deployment.