### PR TITLE
fix(Queries): wrong clique in shared query [YTFRONT-5924]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryTrackerTopRow/QuerySelectorsByEngine.tsx
@@ -60,7 +60,8 @@ export const QuerySelectorsByEngine: FC = () => {
 
     const clusterCliqueList =
         settings.cluster && settings.cluster in cliqueMap ? cliqueMap[settings.cluster] : {};
-    const cliqueList = engine in clusterCliqueList ? clusterCliqueList[engine] : [];
+    const hasLoadedCliqueList = engine in clusterCliqueList;
+    const cliqueList = hasLoadedCliqueList ? clusterCliqueList[engine] : [];
 
     if (engine === QueryEngine.YQL && availableYql.length) {
         return (
@@ -74,20 +75,35 @@ export const QuerySelectorsByEngine: FC = () => {
         );
     }
 
-    if (engine === QueryEngine.SPYT && hasSpytConnect) {
-        return null;
-    }
+    if (engine === QueryEngine.SPYT) {
+        if (hasSpytConnect) return null;
 
-    if (engine === QueryEngine.CHYT || engine === QueryEngine.SPYT) {
-        const isChyt = engine === QueryEngine.CHYT;
         return (
             <QueryCliqueSelector
                 loading={cliqueLoading}
                 cliqueList={cliqueList}
-                value={isChyt ? settings.clique : settings.discovery_group}
-                onChange={isChyt ? handleCliqueChange : handlePathChange}
-                showStatus={isChyt}
-                placeholder={isChyt ? undefined : 'Discovery path'}
+                value={settings.discovery_group}
+                onChange={handlePathChange}
+                placeholder="Discovery path"
+            />
+        );
+    }
+
+    if (engine === QueryEngine.CHYT) {
+        const cliqueListIsReady = !cliqueLoading && hasLoadedCliqueList;
+        const queryClique = settings.clique;
+
+        const isQueryCliqueInCliqueList = cliqueList.some(({alias}) => alias === queryClique);
+        const cliqueToDisplay =
+            !cliqueListIsReady || isQueryCliqueInCliqueList ? queryClique : undefined;
+
+        return (
+            <QueryCliqueSelector
+                loading={cliqueLoading}
+                cliqueList={cliqueList}
+                value={cliqueToDisplay}
+                onChange={handleCliqueChange}
+                showStatus
             />
         );
     }

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -139,12 +139,24 @@ export const setUserLastChoice =
             delete newSettings.clique;
         }
 
-        if (engine === QueryEngine.SPYT && lastPath && !isSpytConnectAvailable) {
-            newSettings.discovery_group = lastPath;
+        // Settings last choice in SPYT (without Connect)
+        if (engine === QueryEngine.SPYT && !isSpytConnectAvailable) {
+            const queryHasDiscoveryPath = Boolean(newSettings.discovery_group);
+            const shouldUseLastDiscoveryPath = !queryHasDiscoveryPath && Boolean(lastPath);
+
+            if (shouldUseLastDiscoveryPath) {
+                newSettings.discovery_group = lastPath;
+            }
         }
 
-        if (engine === QueryEngine.CHYT && lastClique) {
-            newSettings.clique = lastClique;
+        // Settings last choice in CHYT
+        if (engine === QueryEngine.CHYT) {
+            const queryHasClique = Boolean(newSettings.clique);
+            const shouldUseLastClique = !queryHasClique && Boolean(lastClique);
+
+            if (shouldUseLastClique) {
+                newSettings.clique = lastClique;
+            }
         }
 
         if (engine === QueryEngine.YQL && !settings?.yql_version) {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/_YVx4tL97i8Vgs
<!-- nda-end -->   ## Summary by Sourcery

Adjust query tracker engine-specific clique selection behavior to correctly handle CHYT and SPYT discovery settings and persisted user choices.

New Features:
- Show a clique selector for SPYT queries when SPYT connect is unavailable, using the discovery path field.

Bug Fixes:
- Prevent CHYT queries from showing a stale or invalid clique when the currently selected clique is no longer present in the loaded list.
- Ensure SPYT queries only restore the last discovery path when no discovery group is already set.
- Ensure CHYT queries only restore the last clique when no clique is already set.