### PR TITLE
chore: rename selectors

### DIFF
--- a/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/NodesColumnHeader.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/NodesColumnHeader.tsx
@@ -7,7 +7,7 @@ import ColumnHeader, {
     type HasSortColumn,
 } from '../../../../../components/ColumnHeader/ColumnHeader';
 import {toggleColumnSortOrder} from '../../../../../store/actions/tables';
-import {getTables} from '../../../../../store/selectors/tables';
+import {selectTables} from '../../../../../store/selectors/tables';
 import {type NodesTableColumnNames} from '../../../../../pages/components/tabs/nodes/tables';
 import {oldSortStateToOrderType} from '../../../../../utils/sort-helpers';
 
@@ -15,7 +15,7 @@ export function NodesColumnHeader(
     props: HasSortColumn<NodesTableColumnNames> & Pick<ColumnHeaderProps, 'align'>,
 ) {
     const dispatch = useDispatch();
-    const sortState = useSelector(getTables)[COMPONENTS_NODES_TABLE_ID];
+    const sortState = useSelector(selectTables)[COMPONENTS_NODES_TABLE_ID];
     const order = oldSortStateToOrderType(sortState);
 
     const column = props.options?.find(({column}) => sortState.field === column);

--- a/packages/ui/src/ui/pages/scheduling/Scheduling/Scheduling.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Scheduling/Scheduling.tsx
@@ -24,7 +24,7 @@ import {
 import './Scheduling.scss';
 import {useAppRumMeasureStart} from '../../../rum/rum-app-measures';
 import {RumMeasureTypes} from '../../../rum/rum-measure-types';
-import {getSchedulingIsFinalLoadingState} from '../../../store/selectors/scheduling';
+import {selectSchedulingIsFinalLoadingState} from '../../../store/selectors/scheduling';
 import SchedulingResources from '../Content/SchedulingResources';
 import {PoolEditorDialog} from './PoolEditorDialog/PoolEditorDialog';
 import {type RootState} from '../../../store/reducers';
@@ -73,7 +73,7 @@ function Scheduling() {
 const SchedulingMemo = React.memo(Scheduling);
 
 export default function SchedulingWithRum() {
-    const isFinalState = useSelector(getSchedulingIsFinalLoadingState);
+    const isFinalState = useSelector(selectSchedulingIsFinalLoadingState);
 
     useAppRumMeasureStart({
         type: RumMeasureTypes.SCHEDULING,

--- a/packages/ui/src/ui/store/selectors/accounts/accounts.js
+++ b/packages/ui/src/ui/store/selectors/accounts/accounts.js
@@ -7,7 +7,7 @@ import set_ from 'lodash/set';
 
 import {createSelector} from 'reselect';
 import {ACCOUNTS_TABLE_ID, ROOT_ACCOUNT_NAME} from '../../../constants/accounts/accounts';
-import {getTables} from '../../../store/selectors/tables';
+import {selectTables} from '../../../store/selectors/tables';
 import hammer from '../../../common/hammer';
 import ypath from '../../../common/thor/ypath';
 import {
@@ -27,7 +27,7 @@ export const selectUsableAccounts = (state) => state.accounts.accounts.usableAcc
 export const selectAccountsNameFilter = (state) => state.accounts.accounts.activeNameFilter;
 export const selectAccountsAbcServiceIdSlugFilter = (state) =>
     state.accounts.accounts.abcServiceFilter;
-export const selectAccountsSortInfo = (state) => getTables(state)[ACCOUNTS_TABLE_ID];
+export const selectAccountsSortInfo = (state) => selectTables(state)[ACCOUNTS_TABLE_ID];
 
 export const selectEditableAccount = (state) => state.accounts.accounts.editableAccount;
 

--- a/packages/ui/src/ui/store/selectors/navigation/content/transaction-map.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/transaction-map.js
@@ -4,12 +4,12 @@ import {tableItems} from '../../../../utils/navigation/content/transaction-map/t
 import {NAVIGATION_TRANSACTION_MAP_TABLE_ID} from '../../../../constants/navigation/content/transaction-map';
 import {calculateLoadingStatus} from '../../../../utils/utils';
 
-const getRawTransactions = (state) => state.navigation.content.transactionMap.transactions;
-const getSortState = (state) => state.tables[NAVIGATION_TRANSACTION_MAP_TABLE_ID];
-const getFilter = (state) => state.navigation.content.transactionMap.filter;
+const selectRawTransactions = (state) => state.navigation.content.transactionMap.transactions;
+const selectSortState = (state) => state.tables[NAVIGATION_TRANSACTION_MAP_TABLE_ID];
+const selectFilter = (state) => state.navigation.content.transactionMap.filter;
 
 const selectFilteredTransactions = createSelector(
-    [getRawTransactions, getFilter],
+    [selectRawTransactions, selectFilter],
     (rawTransactions, filter) =>
         hammer.filter.filter({
             data: rawTransactions,
@@ -19,7 +19,7 @@ const selectFilteredTransactions = createSelector(
 );
 
 export const selectTransactions = createSelector(
-    [selectFilteredTransactions, getSortState],
+    [selectFilteredTransactions, selectSortState],
     (filteredTransactions, sortState) =>
         hammer.utils.sort(filteredTransactions, sortState, tableItems),
 );

--- a/packages/ui/src/ui/store/selectors/scheduling/index.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/index.ts
@@ -2,7 +2,7 @@ import {type RootState} from '../../../store/reducers';
 import {calculateLoadingStatus, isFinalLoadingStatus} from '../../../utils/utils';
 import {createSelector} from 'reselect';
 
-export const getSchedulingIsFinalLoadingState = createSelector(
+export const selectSchedulingIsFinalLoadingState = createSelector(
     [
         (store: RootState) => store.scheduling.scheduling.loading,
         (store: RootState) => store.scheduling.scheduling.loaded,

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
@@ -23,7 +23,7 @@ export const selectTree = (state: RootState) => state.scheduling.scheduling.tree
 const selectPoolsRaw = (state: RootState) => state.scheduling.expandedPools.rawPools;
 const selectTreeResources = (state: RootState) => state.scheduling.scheduling.treeResources;
 
-const getSchedulingTreeOperations = createSelector(
+const selectSchedulingTreeOperations = createSelector(
     [selectSchedulingOperations, selectExpandedPoolsTree, selectTree],
     (rawOperations, expandedPoolsTree, tree) => {
         if (tree !== expandedPoolsTree) {
@@ -35,7 +35,7 @@ const getSchedulingTreeOperations = createSelector(
 );
 
 const selectOperationsFiltered = createSelector(
-    [selectPoolsRaw, getSchedulingTreeOperations],
+    [selectPoolsRaw, selectSchedulingTreeOperations],
     (rawPools, rawOperations) => {
         return reduce_(
             rawOperations,

--- a/packages/ui/src/ui/store/selectors/tables.ts
+++ b/packages/ui/src/ui/store/selectors/tables.ts
@@ -1,4 +1,4 @@
 import {type RootState} from '../../store/reducers';
 import {initialState} from '../../store/reducers/tables';
 
-export const getTables = (state: RootState) => state.tables || initialState;
+export const selectTables = (state: RootState) => state.tables || initialState;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/podCeLj57iS5PX
<!-- nda-end -->## Summary by Sourcery

Rename selector functions to use a consistent `select*` naming convention across tables, scheduling, accounts, navigation transaction map, and update all related usages accordingly.

Enhancements:
- Standardize selector names by replacing `get*` naming with `select*` for tables, scheduling, accounts, and navigation transaction map.
- Improve readability of scheduling pool selectors by renaming intermediate selector to `selectSchedulingTreeOperations`.