### PR TITLE
fix(Accounts/general): fix ProgressStack tooltip max-width [YTFRONT-5816]

### DIFF
--- a/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.scss
+++ b/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.scss
@@ -22,8 +22,4 @@
     &__progress-tooltip {
         display: block;
     }
-
-    &__progress-tooltip-popup {
-        max-width: unset;
-    }
 }

--- a/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
+++ b/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
@@ -78,7 +78,6 @@ class AccountQuotaEditor extends React.Component<Props & ReduxProps, State> {
                             type={type}
                             mediumType={mediumType}
                             className={block('progress-tooltip')}
-                            popupClassName={block('progress-tooltip-popup')}
                         />
                     </div>
                     <ClickableText

--- a/packages/ui/src/ui/pages/accounts/tabs/general/ProgressStack.js
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/ProgressStack.js
@@ -80,14 +80,7 @@ function prepareProgressStack(treeItem, useChildren, getTreeItemInfoFn) {
     return {progressText, progressStack, tooltipInfo, limit};
 }
 
-function ProgressStackImpl({
-    treeItem,
-    infoGetter,
-    useChildren,
-    className,
-    formatNumber,
-    popupClassName,
-}) {
+function ProgressStackImpl({treeItem, infoGetter, useChildren, className, formatNumber}) {
     if (!treeItem || treeItem.isAggregation) {
         return hammer.format.NO_VALUE;
     }
@@ -120,7 +113,7 @@ function ProgressStackImpl({
                     <ProgressTooltip info={tooltipInfo} limit={limit} formatNumber={formatNumber} />
                 }
                 placement={['right', 'left', 'top', 'bottom']}
-                tooltipClassName={popupClassName}
+                style={{maxWidth: 600}}
             >
                 {progress}
             </Tooltip>
@@ -136,7 +129,6 @@ const ProgressStackTypeProp = PropTypes.oneOf(values_(AccountResourceName));
 
 ProgressStackByTreeItem.propTypes = {
     className: PropTypes.string,
-    popupClassName: PropTypes.string,
     activeAccount: PropTypes.string,
     mediumType: PropTypes.string,
 
@@ -144,14 +136,7 @@ ProgressStackByTreeItem.propTypes = {
     treeItem: PropTypes.object.isRequired,
 };
 
-export function ProgressStackByTreeItem({
-    treeItem,
-    activeAccount,
-    type,
-    mediumType,
-    className,
-    popupClassName,
-}) {
+export function ProgressStackByTreeItem({treeItem, activeAccount, type, mediumType, className}) {
     const accountName = getAccountName(treeItem);
     const isActiveAccount = activeAccount === accountName;
     const {format = 'Number', getInfo} = ACCOUNT_RESOURCE_TYPES_DESCRIPTION[type];
@@ -169,7 +154,6 @@ export function ProgressStackByTreeItem({
                     useChildren: isActiveAccount,
                     formatNumber,
                     className,
-                    popupClassName,
                 }}
             />
         </ErrorBoundary>


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/ZmXGxub97ir2jW
<!-- nda-end -->## Summary by Sourcery

Constrain the Accounts general progress tooltip width and simplify its configuration.

Bug Fixes:
- Limit ProgressStack tooltip width to prevent overly wide tooltips in the Accounts general tab.

Enhancements:
- Remove the dedicated popupClassName prop and related CSS, relying on a consistent inline max-width for the progress tooltip.