### PR TITLE
feat(Bundles/Cells): add `Details` button when `last_hydra_restart_reason` [YTFRONT-5842]

### DIFF
--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
@@ -7,6 +7,7 @@ import i18n from './i18n';
 
 import DataTable, {type Column, type Settings} from '@gravity-ui/react-data-table';
 
+import format from '../../../common/hammer/format';
 import ClickableAttributesButton from '../../../components/AttributesButton/ClickableAttributesButton';
 import {ClipboardButton, Tooltip} from '@ytsaurus/components';
 import {DataTableYT} from '../../../components/DataTableYT';
@@ -19,7 +20,6 @@ import {Health} from '../../../components/Health/Health';
 import {type OrderType} from '../../../utils/sort-helpers';
 import {Host} from '../../../containers/Host/Host';
 // @ts-ignore
-import hammer from '@ytsaurus/interface-helpers/lib/hammer';
 import {
     type TabletCell,
     type TabletsPartialAction,
@@ -125,12 +125,12 @@ class CellsTable extends React.Component<Props & ReduxProps> {
 
     renderNumber(colName: keyof BundleCell, data: {row: BundleCell}) {
         const {[colName]: value} = data?.row || {};
-        return hammer.format['Number'](value);
+        return format.Number(value);
     }
 
     renderBytes(colName: keyof BundleCell, data: {row: BundleCell}) {
         const {[colName]: value} = data?.row || {};
-        return hammer.format['Bytes'](value);
+        return format.Bytes(value);
     }
 
     renderHealth(data: {row: TabletCell}) {

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
@@ -1,32 +1,27 @@
-import React from 'react';
-import cn from 'bem-cn-lite';
-
-import capitalize_ from 'lodash/capitalize';
-
-import i18n from './i18n';
-
 import DataTable, {type Column, type Settings} from '@gravity-ui/react-data-table';
-
+import {Flex} from '@gravity-ui/uikit';
+import {ClipboardButton, Tooltip} from '@ytsaurus/components';
+import cn from 'bem-cn-lite';
+import capitalize_ from 'lodash/capitalize';
+import React from 'react';
 import format from '../../../common/hammer/format';
 import ClickableAttributesButton from '../../../components/AttributesButton/ClickableAttributesButton';
-import {ClipboardButton, Tooltip} from '@ytsaurus/components';
-import {DataTableYT} from '../../../components/DataTableYT';
+import {ClickableText} from '../../../components/ClickableText/ClickableText';
 import ColumnHeader from '../../../components/ColumnHeader/ColumnHeader';
+import {DataTableYT} from '../../../components/DataTableYT';
+import {Health} from '../../../components/Health/Health';
 import Icon from '../../../components/Icon/Icon';
 import Label, {type LabelTheme} from '../../../components/Label';
-import Link from '../../../containers/Link/Link';
 import {STICKY_TOOLBAR_BOTTOM} from '../../../components/WithStickyToolbar/WithStickyToolbar';
-import {Health} from '../../../components/Health/Health';
-import {type OrderType} from '../../../utils/sort-helpers';
 import {Host} from '../../../containers/Host/Host';
-// @ts-ignore
-import {
-    type TabletCell,
-    type TabletsPartialAction,
-} from '../../../store/reducers/tablet_cell_bundles';
+import Link from '../../../containers/Link/Link';
+import {type TabletsPartialAction} from '../../../store/reducers/tablet_cell_bundles';
+import {type BundleCell} from '../../../store/reducers/tablet_cell_bundles/types';
 import {type SortState} from '../../../types';
-
+import {type OrderType} from '../../../utils/sort-helpers';
+import {showErrorPopup} from '../../../utils/utils';
 import './CellsTable.scss';
+import i18n from './i18n';
 
 const block = cn('cells-table');
 
@@ -133,9 +128,23 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         return format.Bytes(value);
     }
 
-    renderHealth(data: {row: TabletCell}) {
-        const {health} = data?.row || {};
-        return <Health value={health} />;
+    renderHealth(data: {row: BundleCell}) {
+        const {health, lastHydraRestartReason} = data?.row || {};
+        return (
+            <Flex gap={1}>
+                <Health value={health} />
+                {health === 'failed' && lastHydraRestartReason ? (
+                    <ClickableText
+                        color="secondary"
+                        onClick={() => {
+                            showErrorPopup(lastHydraRestartReason);
+                        }}
+                    >
+                        {i18n('action_details')}
+                    </ClickableText>
+                ) : null}
+            </Flex>
+        );
     }
 
     renderId = (data: {row: BundleCell}) => {

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
@@ -119,16 +119,16 @@ class CellsTable extends React.Component<Props & ReduxProps> {
 
     onColumnSort = (column: string, order: OrderType) => {
         this.props.setTabletsPartial({
-            cellsSort: {column: column as keyof TabletCell, order},
+            cellsSort: {column: column as keyof BundleCell, order},
         });
     };
 
-    renderNumber(colName: keyof TabletCell, data: {row: TabletCell}) {
+    renderNumber(colName: keyof BundleCell, data: {row: BundleCell}) {
         const {[colName]: value} = data?.row || {};
         return hammer.format['Number'](value);
     }
 
-    renderBytes(colName: keyof TabletCell, data: {row: TabletCell}) {
+    renderBytes(colName: keyof BundleCell, data: {row: BundleCell}) {
         const {[colName]: value} = data?.row || {};
         return hammer.format['Bytes'](value);
     }
@@ -138,7 +138,7 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         return <Health value={health} />;
     }
 
-    renderId = (data: {row: TabletCell}) => {
+    renderId = (data: {row: BundleCell}) => {
         const {id} = data?.row || {};
         return (
             <div className={block('id')}>
@@ -150,7 +150,7 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         );
     };
 
-    renderHost(data: {row: TabletCell}) {
+    renderHost(data: {row: BundleCell}) {
         return (
             <Host
                 asTabletNode
@@ -160,7 +160,7 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         );
     }
 
-    renderBundle = (data: {row: TabletCell}) => {
+    renderBundle = (data: {row: BundleCell}) => {
         const {activeBundleLink, cluster} = this.props;
         const {bundle} = data?.row || {};
         return (
@@ -177,13 +177,13 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         );
     };
 
-    renderState = (data: {row: TabletCell}) => {
+    renderState = (data: {row: BundleCell}) => {
         const {state} = data?.row ?? {};
         const theme = state ? STATE_THEME[state] : undefined;
         return <Label theme={theme} type="text" text={state} capitalize />;
     };
 
-    renderActions = (data: {row: TabletCell}) => {
+    renderActions = (data: {row: BundleCell}) => {
         const {attributesPath, cellNavigationLink, cluster} = this.props;
         const {id} = data?.row || {};
         return (
@@ -208,7 +208,7 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         );
     };
 
-    column(name: string, sortable = false): Column<TabletCell> {
+    column(name: string, sortable = false): Column<BundleCell> {
         return {
             name,
             align: 'left',
@@ -218,7 +218,7 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         };
     }
 
-    sortableColumn(name: keyof TabletCell) {
+    sortableColumn(name: keyof BundleCell) {
         return this.column(name, true);
     }
 
@@ -243,27 +243,27 @@ class CellsTable extends React.Component<Props & ReduxProps> {
 }
 
 const Columns = {
-    id(this: CellsTable): Column<TabletCell> {
+    id(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('id'),
             render: this.renderId,
             width: 400,
         };
     },
-    bundle(this: CellsTable): Column<TabletCell> {
+    bundle(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('bundle'),
             render: wrapCell(this.renderBundle),
         };
     },
-    health(this: CellsTable): Column<TabletCell> {
+    health(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('health'),
             render: wrapCell(this.renderHealth),
             width: 80,
         };
     },
-    tablets(this: CellsTable): Column<TabletCell> {
+    tablets(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('tablets'),
             render: wrapCell(this.renderNumber.bind(this, 'tablets')),
@@ -271,7 +271,7 @@ const Columns = {
             width: 100,
         };
     },
-    memory(this: CellsTable): Column<TabletCell> {
+    memory(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('memory'),
             render: wrapCell(this.renderBytes.bind(this, 'memory')),
@@ -279,7 +279,7 @@ const Columns = {
             width: 100,
         };
     },
-    uncompressed(this: CellsTable): Column<TabletCell> {
+    uncompressed(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('uncompressed'),
             render: wrapCell(this.renderBytes.bind(this, 'uncompressed')),
@@ -287,7 +287,7 @@ const Columns = {
             width: 150,
         };
     },
-    compressed(this: CellsTable): Column<TabletCell> {
+    compressed(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('compressed'),
             render: wrapCell(this.renderBytes.bind(this, 'compressed')),
@@ -295,21 +295,21 @@ const Columns = {
             width: 130,
         };
     },
-    peerAddress(this: CellsTable): Column<TabletCell> {
+    peerAddress(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('peerAddress'),
             render: this.renderHost,
             width: 130,
         };
     },
-    state(this: CellsTable): Column<TabletCell> {
+    state(this: CellsTable): Column<BundleCell> {
         return {
             ...this.sortableColumn('state'),
             render: wrapCell(this.renderState),
             width: 100,
         };
     },
-    actions(this: CellsTable): Column<TabletCell> {
+    actions(this: CellsTable): Column<BundleCell> {
         return {
             ...this.column('actions'),
             render: this.renderActions,
@@ -322,8 +322,8 @@ export type ReduxProps = {
     cluster: string;
     loading: boolean;
     loaded: boolean;
-    data: TabletCell[];
-    sortState: SortState<keyof TabletCell>;
+    data: BundleCell[];
+    sortState: SortState<keyof BundleCell>;
     columns: Array<keyof typeof Columns>;
     activeBundleLink(cluster: string, bundle: string): string;
     attributesPath(id: string): string;

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/i18n/en.json
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/i18n/en.json
@@ -21,5 +21,6 @@
   "field_cell-id-placeholder": "Enter cell id...",
   "field_bundle-placeholder": "Enter bundle name...",
   "field_host-placeholder": "Enter host...",
-  "action_copy-host-list": "Copy host list"
+  "action_copy-host-list": "Copy host list",
+  "action_details": "Details"
 }

--- a/packages/ui/src/ui/store/reducers/chaos_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/reducers/chaos_cell_bundles/index.ts
@@ -10,13 +10,14 @@ import {
 import {mergeStateOnClusterChange} from '../../../store/reducers/utils';
 import {type BundleControllerConfig} from '../../../store/reducers/tablet_cell_bundles';
 import {type ActionD, type SortState, type YTError} from '../../../types';
+import {type BundleCell} from '../tablet_cell_bundles/types';
 
 export interface ChaosBundlesState {
     loaded: boolean;
     loading: boolean;
     error: YTError | undefined;
 
-    cells: Array<ChaosCell>;
+    cells: Array<BundleCell>;
     bundles: Array<ChaosBundle>;
 
     bundlesNameFilter: string;
@@ -28,7 +29,7 @@ export interface ChaosBundlesState {
     cellsHostFilter: string;
 
     bundlesSort: SortState<keyof ChaosBundle>;
-    cellsSort: SortState<keyof ChaosCell>;
+    cellsSort: SortState<keyof BundleCell>;
 
     activeBundle: string;
 
@@ -36,21 +37,6 @@ export interface ChaosBundlesState {
 }
 
 export type BundlesTableMode = 'default' | 'tablets' | 'tablets_memory';
-
-export interface ChaosCell {
-    id: string;
-    bundle: string;
-    health: ChaosBundle['health'];
-    memory: number;
-    compressed: number;
-    tablets: number;
-    uncompressed: number;
-    peerAddress: string;
-    state: string;
-
-    peer: ChaosCellPeer;
-    peers: Array<ChaosCellPeer>;
-}
 
 export interface ChaosCellPeer {
     address: string;
@@ -179,7 +165,7 @@ export type ChaosBundlesAction =
     | ActionD<typeof CHAOS_BUNDLES_LOAD_FAILURE, YTError>
     | ActionD<
           typeof CHAOS_BUNDLES_LOAD_SUCCESS,
-          {cells: Array<ChaosCell>; bundles: Array<ChaosBundle>}
+          {cells: Array<BundleCell>; bundles: Array<ChaosBundle>}
       >
     | ChaosPartialAction
     | ActionD<typeof CHAOS_BUNDLES_ACTIVE_ACCOUNT, Pick<ChaosBundlesState, 'activeBundle'>>;

--- a/packages/ui/src/ui/store/reducers/tablet_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/reducers/tablet_cell_bundles/index.ts
@@ -8,7 +8,7 @@ import {
     TABLETS_BUNDLES_PARTIAL,
 } from '../../../constants/tablets';
 import {type ActionD, type SortState, type YTError} from '../../../types';
-import {BundleCell} from './types';
+import {type BundleCell} from './types';
 
 export interface TabletsBundlesState {
     loaded: boolean;

--- a/packages/ui/src/ui/store/reducers/tablet_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/reducers/tablet_cell_bundles/index.ts
@@ -8,13 +8,14 @@ import {
     TABLETS_BUNDLES_PARTIAL,
 } from '../../../constants/tablets';
 import {type ActionD, type SortState, type YTError} from '../../../types';
+import {BundleCell} from './types';
 
 export interface TabletsBundlesState {
     loaded: boolean;
     loading: boolean;
     error: YTError | undefined;
 
-    cells: Array<TabletCell>;
+    cells: Array<BundleCell>;
     bundles: Array<TabletBundle>;
 
     writableByName: Map<string, boolean>;
@@ -28,7 +29,7 @@ export interface TabletsBundlesState {
     cellsHostFilter: string;
 
     bundlesSort: SortState<keyof TabletBundle>;
-    cellsSort: SortState<keyof TabletCell>;
+    cellsSort: SortState<keyof BundleCell>;
     instancesSort: SortState<keyof BundleInstance>;
     proxiesSort: SortState<keyof BundleInstance>;
 
@@ -39,27 +40,6 @@ export interface TabletsBundlesState {
 }
 
 export type BundlesTableMode = 'default' | 'tablets' | 'tablets_memory';
-
-export interface TabletCell {
-    id: string;
-    bundle: string;
-    health: TabletBundle['health'];
-    memory: number;
-    compressed: number;
-    tablets: number;
-    uncompressed: number;
-    peerAddress: string;
-    state: string;
-
-    peer: TabletCellPeer;
-    peers: Array<TabletCellPeer>;
-}
-
-export interface TabletCellPeer {
-    address: string;
-    last_seen: string;
-    state: string;
-}
 
 export interface BundleControllerConfig {
     cpu_limits: CPULimits;

--- a/packages/ui/src/ui/store/reducers/tablet_cell_bundles/types.ts
+++ b/packages/ui/src/ui/store/reducers/tablet_cell_bundles/types.ts
@@ -1,0 +1,26 @@
+import {type YTError} from '../../../../@types/types';
+
+export interface BundleCell {
+    id: string;
+    bundle: string;
+    health: BundleHealth;
+    memory: number;
+    compressed: number;
+    tablets: number;
+    uncompressed: number;
+    peerAddress: string;
+    state: string;
+    lastHydraRestartReason?: YTError;
+
+    peer: BundleCellPeer;
+    peers: Array<BundleCellPeer>;
+}
+
+export type BundleHealth = 'good' | 'failed' | 'initializing';
+
+export interface BundleCellPeer {
+    address: string;
+    last_seen: string;
+    state: string;
+    last_hydra_restart_reason?: YTError;
+}

--- a/packages/ui/src/ui/store/selectors/chaos_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/selectors/chaos_cell_bundles/index.ts
@@ -2,12 +2,11 @@ import filter_ from 'lodash/filter';
 import find_ from 'lodash/find';
 import map_ from 'lodash/map';
 import uniq_ from 'lodash/uniq';
-
 import {createSelector} from 'reselect';
-
 import {concatByAnd} from '../../../common/hammer/predicate';
 import {type RootState} from '../../../store/reducers';
-import {type ChaosBundle, type ChaosCell} from '../../../store/reducers/chaos_cell_bundles';
+import {type ChaosBundle} from '../../../store/reducers/chaos_cell_bundles';
+import {type BundleCell} from '../../../store/reducers/tablet_cell_bundles/types';
 import {selectCluster} from '../../../store/selectors/global';
 import {
     aggregateTotal,
@@ -160,7 +159,7 @@ export const selectChaosCellsFiltered = createSelector(
         selectChaosActiveBundle,
     ],
     (cells, idFilter, bundleFilter, hostFilter) => {
-        const predicates: Array<(item: ChaosCell) => boolean> = [];
+        const predicates: Array<(item: BundleCell) => boolean> = [];
         if (idFilter) {
             predicates.push((item) => {
                 return -1 !== item.id.indexOf(idFilter);
@@ -182,7 +181,7 @@ export const selectChaosCellsFiltered = createSelector(
     },
 );
 
-export function filterChaosCellsByBundle(bundle: string, cells: Array<ChaosCell>) {
+export function filterChaosCellsByBundle(bundle: string, cells: Array<BundleCell>) {
     if (!bundle) {
         return [];
     }
@@ -207,7 +206,7 @@ export const selectChaosCellsHosts = createSelector([selectChaosCellsOfActiveAcc
 
 export const selectChaosCellsHostsOfActiveBundle = createSelector(
     [selectChaosActiveBundle, selectChaosCellsFiltered],
-    (activeBundle: string, cells: Array<ChaosCell>) => {
+    (activeBundle: string, cells: Array<BundleCell>) => {
         if (!activeBundle) {
             return '';
         }

--- a/packages/ui/src/ui/store/selectors/tablet_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/selectors/tablet_cell_bundles/index.ts
@@ -318,7 +318,7 @@ const selectTabletsCellsFiltered = createSelector(
         selectTabletsActiveBundle,
     ],
     (cells, idFilter, bundleFilter, hostFilter) => {
-        const predicates: Array<(item: TabletCell) => boolean> = [];
+        const predicates: Array<(item: BundleCell) => boolean> = [];
         if (idFilter) {
             predicates.push((item) => {
                 return -1 !== item.id.indexOf(idFilter);
@@ -360,7 +360,7 @@ export const selectTabletsCellsHosts = createSelector(
 
 export const selectTabletsCellsHostsOfActiveBundle = createSelector(
     [selectTabletsActiveBundle, selectTabletsCellsFiltered],
-    (activeBundle: string, cells: Array<TabletCell>) => {
+    (activeBundle: string, cells: Array<BundleCell>) => {
         if (!activeBundle) {
             return '';
         }

--- a/packages/ui/src/ui/store/selectors/tablet_cell_bundles/index.ts
+++ b/packages/ui/src/ui/store/selectors/tablet_cell_bundles/index.ts
@@ -2,36 +2,35 @@ import filter_ from 'lodash/filter';
 import find_ from 'lodash/find';
 import map_ from 'lodash/map';
 import uniq_ from 'lodash/uniq';
-
+import {createSelector} from 'reselect';
+import {concatByAnd} from '../../../common/hammer/predicate';
 import {type RootState} from '../../../store/reducers';
-import {
-    aggregateTotal,
-    tabletActiveBundleLink,
-    tabletCellBundleRootLink,
-} from '../../../utils/components/tablet-cells';
 import {
     type AllocatedInstancesMap,
     type BundleInstance,
     type InProgressInstancesMap,
     type TabletBundle,
-    type TabletCell,
 } from '../../../store/reducers/tablet_cell_bundles';
-import {createSelector} from 'reselect';
-import {concatByAnd} from '../../../common/hammer/predicate';
-import {selectCluster} from '../global';
+import {type BundleControllerInstanceDetails} from '../../../store/reducers/tablet_cell_bundles/tablet-cell-bundle-editor';
+import {type BundleCell} from '../../../store/reducers/tablet_cell_bundles/types';
+import UIFactory from '../../../UIFactory';
+import {makeComponentsNodesUrl, makeProxyUrl} from '../../../utils/app-url';
+import {
+    aggregateTotal,
+    tabletActiveBundleLink,
+    tabletCellBundleRootLink,
+} from '../../../utils/components/tablet-cells';
 import {sortArrayBySortState} from '../../../utils/sort-helpers';
 import {
     prepareBundleHostsByName,
     prepareHostsFromCells,
     sortTableBundles,
 } from '../../../utils/tablet_cell_bundles';
-import {makeComponentsNodesUrl, makeProxyUrl} from '../../../utils/app-url';
+import {selectCluster} from '../global';
 import {
     selectTabletCellBundleControllerInstanceDetailsMap,
     selectTabletCellBundleEditorState,
 } from './tablet-cell-bundle-editor';
-import {type BundleControllerInstanceDetails} from '../../../store/reducers/tablet_cell_bundles/tablet-cell-bundle-editor';
-import UIFactory from '../../../UIFactory';
 
 export const selectTabletsIsLoaded = (state: RootState) => state.tablet_cell_bundles.loaded;
 

--- a/packages/ui/src/ui/utils/components/tablet-cells/index.js
+++ b/packages/ui/src/ui/utils/components/tablet-cells/index.js
@@ -29,11 +29,13 @@ export function prepareTabletCells(tabletCells) {
         let peer;
         let peerAddress;
         let state;
+        let lastHydraRestartReason;
 
         if (peerCount) {
             peer = find_(peers, (peer) => peer.state === 'leading') || peers[0];
             peerAddress = peer.address;
             state = peer.state;
+            lastHydraRestartReason = peer.last_hydra_restart_reason;
         }
 
         return {
@@ -48,6 +50,7 @@ export function prepareTabletCells(tabletCells) {
             peers,
             peer,
             peerAddress,
+            lastHydraRestartReason,
         };
     });
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/YVwjZLnk7k5PEu
<!-- nda-end -->## Summary by Sourcery

Add support for displaying Hydra restart error details for failed bundle cells and unify tablet and chaos cell types around a shared BundleCell model.

New Features:
- Show a Details action in the cells table that opens the last Hydra restart error when a cell is in failed health state and has a restart reason.

Enhancements:
- Introduce a shared BundleCell type used across tablet and chaos cell bundles, and update selectors, reducers, and table components accordingly.
- Propagate lastHydraRestartReason from cell peers into prepared tablet cell data and adjust health rendering layout.
- Replace legacy hammer number/byte formatting utilities with the shared format helper in the cells table.