### PR TITLE
fix(Operation): wrong suspended status [YTFRONT-5948]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -106,7 +106,7 @@ function getSpecialWaitingStatuses(
     type: string | undefined,
     isGpuOperation: boolean | undefined,
 ): {isWaitingForJobs?: boolean; isWaitingForResources?: boolean} {
-    if (state !== 'running') {
+    if (state !== 'running' || suspended) {
         return {};
     }
 
@@ -118,8 +118,7 @@ function getSpecialWaitingStatuses(
 
     switch (type) {
         case 'vanilla': {
-            const isSpecialStatus = state === 'running' && isGpuOperation && !suspended;
-            if (!isSpecialStatus || !isSingleTree) {
+            if (!isGpuOperation || !isSingleTree) {
                 return {};
             }
             const isWaitingForResources = fairShareRatio === usageRatio && fairShareRatio === 0;
@@ -225,12 +224,12 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
 
         const label = suspended ? 'suspended' : state;
 
+        const isWaiting = isWaitingForJobs || isWaitingForResources;
         const mainStatusProps:
             | {label: typeof label}
-            | {state: 'unknown'; iconState: 'running'; text: string} =
-            isWaitingForJobs || isWaitingForResources
-                ? {state: 'unknown', iconState: 'running', text: i18n('value_running')}
-                : {label};
+            | {state: 'unknown'; iconState: 'running'; text: string} = isWaiting
+            ? {state: 'unknown', iconState: 'running', text: i18n('value_running')}
+            : {label};
 
         return (
             <div className={detailBlock('header', 'elements-section')}>


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/rJ7u-5rB7kAEAp
<!-- nda-end -->## Summary by Sourcery

Fix operation detail status handling for suspended and GPU operations so that waiting states and labels are shown correctly.

Bug Fixes:
- Correct special waiting status calculation to ignore suspended operations and properly handle GPU vanilla operations.
- Ensure main status label and running icon state are consistent when operations are waiting for jobs or resources.