### PR TITLE
fix(Flow/Worker): use 'worker_groups' instead of 'groups' [YTFRONT-5944]

### DIFF
--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -774,7 +774,7 @@ export type FlowWorkerData = {
     banned: boolean;
     bytes_per_second: number;
     cpu_usage: number;
-    groups: Array<unknown>;
+    worker_groups?: Array<unknown>;
     incarnation_id: string;
     memory_usage: number;
     messages_per_second: number;

--- a/packages/ui/src/ui/pages/flow/Flow/FlowWorker/FlowWorker.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowWorker/FlowWorker.tsx
@@ -306,7 +306,7 @@ function FlowWorkerMeta({data}: {data?: FlowWorkerData}) {
                           {
                               key: 'worker-groups',
                               label: i18n('worker-groups'),
-                              value: data.groups.join(',') || format.NO_VALUE,
+                              value: data.worker_groups?.join(',') || format.NO_VALUE,
                           },
                       ],
                       [


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/83Svx86j7kwvbX
<!-- nda-end --> ## Summary by Sourcery

Bug Fixes:
- Fix Flow worker details view failing when worker group data is only available under worker_groups.