### PR TITLE
fix(Operations/Details): edit operation attributes weight format [YTFRONT-5902]

### DIFF
--- a/packages/ui/src/ui/pages/operations/PoolsWeightsEditModal/PoolsWeightsEditModal.tsx
+++ b/packages/ui/src/ui/pages/operations/PoolsWeightsEditModal/PoolsWeightsEditModal.tsx
@@ -97,7 +97,8 @@ export function PoolsWeightsEditModal() {
                                         min: 0,
                                         hidePrettyValue: true,
                                         disabled: !editable,
-                                        decimalPlaces: 2,
+                                        formatFn: (value: number | undefined) =>
+                                            value === undefined ? '' : String(value),
                                     },
                                 },
                             ],

--- a/packages/ui/src/ui/pages/operations/PoolsWeightsEditModal/i18n/en.json
+++ b/packages/ui/src/ui/pages/operations/PoolsWeightsEditModal/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "title_edit-operation-pools": "Edit operation attributs",
+  "title_edit-operation-pools": "Edit operation attributes",
   "section_general": "General",
   "section_resource-limits": "Resource Limits",
   "field_tree": "Tree",


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/tCfiWiqK7kBzrN
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Prevent unwanted decimal formatting when editing pool weight attributes by using a custom value-to-string formatter.