### PR TITLE
YTFLOWSUPPORT-146: preserve 64-bit spec versions

### DIFF
--- a/packages/ui/src/shared/yt-types.d.ts
+++ b/packages/ui/src/shared/yt-types.d.ts
@@ -519,14 +519,17 @@ export interface ConfigData {
 
 export type PipelineParams = {
     pipeline_path: string;
+    output_format?: 'web_json';
 };
 
 export type TableParams = {
     path: string;
 };
 
+export type Int64 = string | number | {$type: 'int64'; $value: string};
+
 export type ExpectedVersion = {
-    expected_version?: string | number;
+    expected_version?: Int64;
 };
 
 export type GetPipelineStateData =

--- a/packages/ui/src/ui/store/actions/flow/specs.spec.ts
+++ b/packages/ui/src/ui/store/actions/flow/specs.spec.ts
@@ -1,0 +1,93 @@
+import {ytApiV4} from '../../../rum/rum-wrap-api';
+import {dynamicSpecActions, staticSpecActions} from '../../../store/reducers/flow/specs';
+
+import {
+    loadFlowDynamicSpec,
+    loadFlowStaticSpec,
+    updateFlowDynamicSpec,
+    updateFlowStaticSpec,
+} from './specs';
+
+jest.mock('../../../rum/rum-wrap-api', () => ({
+    ytApiV4: {
+        getPipelineSpec: jest.fn(),
+        setPipelineSpec: jest.fn(),
+        getPipelineDynamicSpec: jest.fn(),
+        setPipelineDynamicSpec: jest.fn(),
+    },
+}));
+
+jest.mock('../../../store/selectors/flow/specs', () => ({
+    selectFlowDynamicSpecPath: jest.fn(() => '//home/flow'),
+    selectFlowStaticSpecPath: jest.fn(() => '//home/flow'),
+}));
+
+const pipelinePath = '//home/flow';
+const version = {$type: 'int64' as const, $value: '1917083822153720177'};
+const spec = {job_manager: {resource_limits: {user_slots: 2}}};
+
+describe('Flow specs actions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it.each([
+        {
+            load: loadFlowStaticSpec,
+            get: ytApiV4.getPipelineSpec,
+            actions: staticSpecActions,
+        },
+        {
+            load: loadFlowDynamicSpec,
+            get: ytApiV4.getPipelineDynamicSpec,
+            actions: dynamicSpecActions,
+        },
+    ])('loads a spec with a lossless version using web_json', async ({load, get, actions}) => {
+        jest.mocked(get).mockResolvedValue({spec, version});
+        const dispatch = jest.fn();
+
+        await load(pipelinePath)(dispatch, jest.fn(), undefined);
+
+        expect(get).toHaveBeenCalledWith({
+            parameters: {pipeline_path: pipelinePath, output_format: 'web_json'},
+            cancellation: expect.any(Function),
+        });
+        expect(dispatch).toHaveBeenNthCalledWith(
+            1,
+            actions.onRequest({pipeline_path: pipelinePath}),
+        );
+        expect(dispatch).toHaveBeenNthCalledWith(2, actions.onSuccess({data: {spec, version}}));
+    });
+
+    it.each([
+        {
+            update: updateFlowStaticSpec,
+            set: ytApiV4.setPipelineSpec,
+            options: {force: true},
+        },
+        {
+            update: updateFlowDynamicSpec,
+            set: ytApiV4.setPipelineDynamicSpec,
+            options: undefined,
+        },
+    ])('sends the lossless version back when updating a spec', async ({update, set, options}) => {
+        jest.mocked(set).mockResolvedValue(undefined);
+        const dispatch = jest.fn();
+        const data = {spec, version};
+
+        const action =
+            options === undefined
+                ? update({data, path: pipelinePath})
+                : update({data, path: pipelinePath}, options);
+        await action(dispatch, jest.fn(), undefined);
+
+        expect(set).toHaveBeenCalledWith(
+            {
+                pipeline_path: pipelinePath,
+                expected_version: version,
+                ...(options ?? {}),
+            },
+            spec,
+        );
+    });
+});

--- a/packages/ui/src/ui/store/actions/flow/specs.ts
+++ b/packages/ui/src/ui/store/actions/flow/specs.ts
@@ -22,7 +22,7 @@ export function loadFlowStaticSpec(pipeline_path: string): AsyncAction {
         dispatch(staticSpecActions.onRequest({pipeline_path}));
         return ytApiV4
             .getPipelineSpec({
-                parameters: {pipeline_path},
+                parameters: {pipeline_path, output_format: 'web_json'},
                 cancellation: cancelHelper.removeAllAndSave,
             })
             .then(
@@ -68,7 +68,7 @@ export function loadFlowDynamicSpec(pipeline_path: string): AsyncAction {
         dispatch(dynamicSpecActions.onRequest({pipeline_path}));
         return ytApiV4
             .getPipelineDynamicSpec({
-                parameters: {pipeline_path},
+                parameters: {pipeline_path, output_format: 'web_json'},
                 cancellation: cancelHelper.removeAllAndSave,
             })
             .then(

--- a/packages/ui/src/ui/store/reducers/flow/specs.ts
+++ b/packages/ui/src/ui/store/reducers/flow/specs.ts
@@ -1,6 +1,7 @@
 import {type PayloadAction, createSlice} from '@reduxjs/toolkit';
 
 import {type YTError} from '../../../../@types/types';
+import {type Int64} from '../../../../shared/yt-types';
 
 export type FlowSpecState = {
     loaded: boolean;
@@ -8,7 +9,7 @@ export type FlowSpecState = {
     error: YTError | undefined;
 
     pipeline_path: string | undefined;
-    data: {spec: unknown; version: number} | undefined;
+    data: {spec: unknown; version: Int64} | undefined;
 };
 
 const initialState: FlowSpecState = {


### PR DESCRIPTION
## Summary by Sourcery

Preserve lossless 64-bit spec versions in flow pipeline specs and ensure they round-trip through the UI.

New Features:
- Add Int64 union type to represent lossless 64-bit versions in UI types.
- Support optional web_json output format in pipeline API parameters for flow spec loading.

Enhancements:
- Update flow specs state and actions to store spec versions using the Int64 type instead of plain numbers.

Tests:
- Add unit tests for flow spec load and update actions to verify web_json usage and lossless version round-tripping.