### PR TITLE
fix(Scheduling): operation attributes [YTFRONT-5954]

### DIFF
--- a/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
+++ b/packages/ui/src/ui/pages/scheduling/Content/tabs/Overview/SchedulingTable/SchedulingTable.tsx
@@ -882,32 +882,45 @@ function RowActions({item}: {item: RowData}) {
     const {type, isEphemeral, isAggregationRow} = item;
     const editable = !isEphemeral && type === 'pool' && !isAggregationRow;
 
+    if (isAggregationRow) {
+        return null;
+    }
+
     return (
-        editable && (
-            <DropdownMenu
-                switcherWrapperClassName={block('actions')}
-                items={[
-                    {
-                        text: i18n('action_attributes'),
-                        action: () => {
+        <DropdownMenu
+            switcherWrapperClassName={block('actions')}
+            items={[
+                {
+                    text: i18n('action_attributes'),
+                    action: () => {
+                        if (type === 'pool') {
                             const exactPath = dispatch(getPoolPathsByName(item.name))?.orchidPath;
-                            if (type === 'pool') {
-                                dispatch(openAttributesModal({title: item.name, exactPath}));
-                            }
-                        },
+                            dispatch(openAttributesModal({title: item.name, exactPath}));
+                        } else {
+                            dispatch(
+                                openAttributesModal({
+                                    title: item.name,
+                                    attributes: item.attributes,
+                                }),
+                            );
+                        }
                     },
-                    {
-                        action: () => dispatch(openEditModal(item)),
-                        text: i18n('action_edit'),
-                    },
-                    {
-                        action: () => dispatch(openPoolDeleteModal(item)),
-                        text: i18n('action_delete'),
-                        theme: 'danger' as const,
-                    },
-                ]}
-            />
-        )
+                },
+                ...(editable
+                    ? [
+                          {
+                              action: () => dispatch(openEditModal(item)),
+                              text: i18n('action_edit'),
+                          },
+                          {
+                              action: () => dispatch(openPoolDeleteModal(item)),
+                              text: i18n('action_delete'),
+                              theme: 'danger' as const,
+                          },
+                      ]
+                    : []),
+            ]}
+        />
     );
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust scheduling row actions to correctly handle aggregation and non-pool rows when opening the attributes modal.

Bug Fixes:
- Prevent actions menu from appearing on aggregation rows in the scheduling table.
- Enable the attributes dialog for non-pool rows by passing their inline attributes instead of resolving pool paths.