### PR TITLE
fix(Queries/Hitory): minimal attributes set [YTFRONT-5946]

### DIFF
--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -145,6 +145,19 @@ export async function generateQueryFromTable(
     return undefined;
 }
 
+// Minimal set of QueryItem fields actually rendered by the queries list UI
+const QUERIES_LIST_ATTRIBUTES = [
+    'id',
+    'state',
+    'start_time',
+    'finish_time',
+    'user',
+    'engine',
+    'annotations',
+    'is_tutorial',
+    'access_control_objects',
+];
+
 export function loadQueriesList({
     params,
     cursor,
@@ -154,12 +167,16 @@ export function loadQueriesList({
     return async (_dispatch, getState) => {
         const state = getState();
         const {stage} = selectQueryTrackerRequestOptions(state);
+        const attributes = params.use_full_text_search
+            ? [...QUERIES_LIST_ATTRIBUTES, 'query']
+            : QUERIES_LIST_ATTRIBUTES;
         return ytApiV4Id.listQueries(YTApiId.listQueries, {
             parameters: {
                 stage,
                 ...params,
                 ...cursor,
                 limit,
+                attributes,
                 output_format: 'json',
             },
             setup: {...getQTApiSetup(), JSONSerializer},


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/WgFdnQRF7khUPN
<!-- nda-end -->## Summary by Sourcery

Enhancements:
- Define a minimal attribute set for query list items and pass it to the listQueries API, conditionally adding the query text when full-text search is enabled.