### PR TITLE
chore: minor fixes

### DIFF
--- a/packages/ui/src/server/components/cluster-params.ts
+++ b/packages/ui/src/server/components/cluster-params.ts
@@ -114,7 +114,7 @@ function fetchClusterParams(cluster: string, {ctx}: {ctx?: AppContext}) {
                 return Promise.reject(error.data);
             });
 
-        const [mediumList, schedulerVersion, uiConfig, uiDevConfig, masterVersion] = await yt.v3
+        const [mediumList, uiConfig, uiDevConfig, masterVersion] = await yt.v3
             .executeBatch({
                 setup: {
                     ...configSetup,
@@ -140,13 +140,6 @@ function fetchClusterParams(cluster: string, {ctx}: {ctx?: AppContext}) {
                             command: 'list',
                             parameters: {
                                 path: '//sys/media',
-                                ...USE_SUPRESS_SYNC,
-                            },
-                        },
-                        {
-                            command: 'get',
-                            parameters: {
-                                path: '//sys/scheduler/orchid/service/version',
                                 ...USE_SUPRESS_SYNC,
                             },
                         },
@@ -204,11 +197,6 @@ function fetchClusterParams(cluster: string, {ctx}: {ctx?: AppContext}) {
             delete uiDevConfig.error;
         }
 
-        if (schedulerVersion?.error?.code === yt.codes.NODE_DOES_NOT_EXIST) {
-            delete schedulerVersion.error;
-            schedulerVersion.output = '0.0.0-unknown';
-        }
-
         if (masterVersion?.error?.code === yt.codes.NODE_DOES_NOT_EXIST) {
             delete masterVersion.error;
             masterVersion.output = '0.0.0-unknown';
@@ -216,7 +204,6 @@ function fetchClusterParams(cluster: string, {ctx}: {ctx?: AppContext}) {
 
         const response = {
             mediumList,
-            schedulerVersion,
             uiConfig: outputUiSettingsToCamelCase(uiConfig),
             uiDevConfig: outputUiSettingsToCamelCase(uiDevConfig),
             masterVersion: masterVersion ?? mastersList,
@@ -224,7 +211,6 @@ function fetchClusterParams(cluster: string, {ctx}: {ctx?: AppContext}) {
 
         if (
             mediumList.error ||
-            schedulerVersion.error ||
             (uiConfig.error && uiConfig.error.code !== yt.codes.NODE_DOES_NOT_EXIST) ||
             (uiDevConfig.error && uiDevConfig.error.code !== yt.codes.NODE_DOES_NOT_EXIST) ||
             (masterVersion?.error && masterVersion.error.code !== yt.codes.NODE_DOES_NOT_EXIST) ||
@@ -233,7 +219,6 @@ function fetchClusterParams(cluster: string, {ctx}: {ctx?: AppContext}) {
             cx.logError('Unacceptable response', undefined, {
                 cluster,
                 mediumList: {error: mediumList.error},
-                schedulerVersion: {error: schedulerVersion.error},
                 uiConfig: {error: uiConfig.error},
                 uiDevConfig: {error: uiDevConfig.error},
                 masterVersion: {error: masterVersion?.error},

--- a/packages/ui/src/ui/config/index.ts
+++ b/packages/ui/src/ui/config/index.ts
@@ -64,10 +64,6 @@ export function getExportTableBaseUrl({cluster}: {cluster: string}) {
     return clusterSpecificUISettings.exportTableBaseUrl;
 }
 
-export function allowDirectDownload() {
-    return uiSettings.directDownload;
-}
-
 export function createAdminReqTicketUrl(params: Record<string, string> = {}) {
     const {trackerBaseUrl, trackerAdminRequestQueue: queue} = uiSettings;
     return createTrackerUrl(trackerBaseUrl, queue, params);

--- a/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
@@ -41,7 +41,6 @@ import SettingsMenuInput from '../SettingsMenu/SettingsMenuInput';
 import {
     selectCurrentUserName,
     selectGlobalMasterVersion,
-    selectGlobalSchedulerVersion,
     selectHttpProxyVersion,
 } from '../../store/selectors/global';
 import {selectIsDeveloperOrWatchmen} from '../../store/selectors/global/is-developer';
@@ -90,7 +89,6 @@ function useSettings(cluster: string, isAdmin: boolean): Array<SettingsPage> {
     const clusterNS = useSelector(selectCurrentClusterNS);
 
     const httpProxyVersion = useSelector(selectHttpProxyVersion);
-    const schedulerVersion = useSelector(selectGlobalSchedulerVersion);
     const masterVersion = useSelector(selectGlobalMasterVersion);
     const vcsConfig = useSelector(selectVcsConfig);
     const isVcsVisible = useSelector(selectIsVcsVisible);
@@ -598,13 +596,6 @@ function useSettings(cluster: string, isAdmin: boolean): Array<SettingsPage> {
                         i18n('field_http-proxy-version'),
                         undefined,
                         httpProxyVersion,
-                    ),
-                Boolean(cluster) &&
-                    makeItem(
-                        'schedulerVersion',
-                        i18n('field_scheduler-version'),
-                        undefined,
-                        schedulerVersion,
                     ),
                 Boolean(cluster) &&
                     makeItem(

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeCpuAndMemory/NodeCpuAndMemory.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeCpuAndMemory/NodeCpuAndMemory.tsx
@@ -16,6 +16,7 @@ interface NodeCpuAndMemoryProps {
     networkProgress: Node['networkProgress'];
     networkText: Node['networkText'];
     gpu?: Node['gpu'];
+    flavors?: Node['flavors'];
 }
 
 export const hasCpuAndMemoryMeta = (node: NodeCpuAndMemoryProps) =>
@@ -23,6 +24,11 @@ export const hasCpuAndMemoryMeta = (node: NodeCpuAndMemoryProps) =>
 
 function NodeCpuAndMemory({node}: {node: NodeCpuAndMemoryProps}): ReturnType<React.VFC> {
     const {memoryData, memoryText, cpuProgress, cpuText, networkProgress, networkText, gpu} = node;
+
+    const isExecNode = React.useMemo(() => {
+        return Boolean(node.flavors?.includes('exec'));
+    }, [node.flavors]);
+
     return (
         <MetaTable
             items={[
@@ -30,6 +36,7 @@ function NodeCpuAndMemory({node}: {node: NodeCpuAndMemoryProps}): ReturnType<Rea
                     key: 'cpu',
                     label: i18n('field_cpu'),
                     value: <Progress value={cpuProgress || 0} text={cpuText} theme="success" />,
+                    visible: isExecNode,
                 },
                 {
                     key: 'memory',
@@ -46,7 +53,7 @@ function NodeCpuAndMemory({node}: {node: NodeCpuAndMemoryProps}): ReturnType<Rea
                             theme="success"
                         />
                     ),
-                    visible: gpu !== undefined,
+                    visible: isExecNode && gpu !== undefined,
                 },
                 {
                     key: 'network',
@@ -54,6 +61,7 @@ function NodeCpuAndMemory({node}: {node: NodeCpuAndMemoryProps}): ReturnType<Rea
                     value: (
                         <Progress value={networkProgress || 0} text={networkText} theme="success" />
                     ),
+                    visible: isExecNode,
                 },
             ]}
         />

--- a/packages/ui/src/ui/pages/job/JobActions/JobActions.tsx
+++ b/packages/ui/src/ui/pages/job/JobActions/JobActions.tsx
@@ -20,6 +20,7 @@ import {selectJob, selectJobActions} from '../../../store/selectors/job/detail';
 import {loadJobData} from '../../../store/actions/job/general';
 import {promptAction} from '../../../store/actions/actions';
 import {selectCluster} from '../../../store/selectors/global';
+import {selectMergedUiSettings} from '../../../store/selectors/global/cluster';
 import {type RootState} from '../../../store/reducers';
 import {type PreparedJob} from '../../../types/operations/job';
 import {showErrorPopup} from '../../../utils/utils';
@@ -67,17 +68,18 @@ const getAdditionalActions = (
     job: Job | undefined,
     openJobShellModal: () => void,
     openDumpContextModal: () => void,
+    uiSettings: {directDownload?: boolean},
 ) => {
     const infoActions = [
         {
             action: () => {
-                window.open(job?.prepareCommandURL?.('get_job_input') || window.location.href);
+                window.open(job?.prepareCommandURL?.('get_job_input', uiSettings) || window.location.href);
             },
             text: 'get_job_input',
         },
         {
             action: () => {
-                window.open(job?.prepareCommandURL?.('get_job_stderr') || window.location.href);
+                window.open(job?.prepareCommandURL?.('get_job_stderr', uiSettings) || window.location.href);
             },
             text: 'get_job_stderr',
         },
@@ -87,7 +89,7 @@ const getAdditionalActions = (
         infoActions.push({
             action: () => {
                 window.open(
-                    job?.prepareCommandURL?.('get_job_fail_context') || window.location.href,
+                    job?.prepareCommandURL?.('get_job_fail_context', uiSettings) || window.location.href,
                 );
             },
             text: 'get_job_fail_context',
@@ -217,6 +219,7 @@ export default function JobActions({className}: {className?: string}) {
     const job = useSelector(selectJob);
     const {loaded} = useSelector((state: RootState) => state.job.general);
     const cluster = useSelector(selectCluster);
+    const mergedUiSettings = useSelector(selectMergedUiSettings);
     const jobId = (job as PreparedJob).id;
 
     const jobShellCommand = `yt run-job-shell ${jobId}`;
@@ -250,8 +253,8 @@ export default function JobActions({className}: {className?: string}) {
 
     const actions = useSelector(selectJobActions);
     const additionalActions = useMemo(
-        () => getAdditionalActions(job, openJobShellModal, openDumpContextModal),
-        [job, openJobShellModal, openDumpContextModal],
+        () => getAdditionalActions(job, openJobShellModal, openDumpContextModal, mergedUiSettings),
+        [job, openJobShellModal, openDumpContextModal, mergedUiSettings],
     );
 
     if (!loaded) {

--- a/packages/ui/src/ui/pages/job/JobActions/JobActions.tsx
+++ b/packages/ui/src/ui/pages/job/JobActions/JobActions.tsx
@@ -73,13 +73,17 @@ const getAdditionalActions = (
     const infoActions = [
         {
             action: () => {
-                window.open(job?.prepareCommandURL?.('get_job_input', uiSettings) || window.location.href);
+                window.open(
+                    job?.prepareCommandURL?.('get_job_input', uiSettings) || window.location.href,
+                );
             },
             text: 'get_job_input',
         },
         {
             action: () => {
-                window.open(job?.prepareCommandURL?.('get_job_stderr', uiSettings) || window.location.href);
+                window.open(
+                    job?.prepareCommandURL?.('get_job_stderr', uiSettings) || window.location.href,
+                );
             },
             text: 'get_job_stderr',
         },
@@ -89,7 +93,8 @@ const getAdditionalActions = (
         infoActions.push({
             action: () => {
                 window.open(
-                    job?.prepareCommandURL?.('get_job_fail_context', uiSettings) || window.location.href,
+                    job?.prepareCommandURL?.('get_job_fail_context', uiSettings) ||
+                        window.location.href,
                 );
             },
             text: 'get_job_fail_context',

--- a/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
+++ b/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
@@ -34,6 +34,7 @@ import ChartLink from '../../../components/ChartLink/ChartLink';
 import {selectJob} from '../../../store/selectors/job/detail';
 import {ClipboardButton, MetaTable} from '@ytsaurus/components';
 import {selectCluster, selectClusterUiConfig} from '../../../store/selectors/global';
+import {selectMergedUiSettings} from '../../../store/selectors/global/cluster';
 import UIFactory from '../../../UIFactory';
 import {StaleJobIcon} from '../../../pages/operations/OperationDetail/tabs/Jobs/StaleJobIcon';
 import {Host} from '../../../containers/Host/Host';
@@ -51,6 +52,7 @@ export default function JobGeneral() {
     const settings = useSelector(selectJobGeneralYsonSettings);
     const job = useSelector(selectJob);
     const {loaded} = useSelector((state: RootState) => state.job.general);
+    const mergedUiSettings = useSelector(selectMergedUiSettings);
 
     const {url: traceUrl, title: traceTitle} = useJobProfilingUrl({
         operationId: job?.operationId,
@@ -225,7 +227,7 @@ export default function JobGeneral() {
                                 value: (
                                     <ClickableText
                                         onClick={() =>
-                                            window.open(job?.prepareCommandURL('get_job_input'))
+                                            window.open(job?.prepareCommandURL('get_job_input', mergedUiSettings))
                                         }
                                     >
                                         {'get_job_input'}
@@ -237,7 +239,7 @@ export default function JobGeneral() {
                                 value: (
                                     <ClickableText
                                         onClick={() =>
-                                            window.open(job?.prepareCommandURL('get_job_stderr'))
+                                            window.open(job?.prepareCommandURL('get_job_stderr', mergedUiSettings))
                                         }
                                     >
                                         {'get_job_stderr'}
@@ -255,6 +257,7 @@ export default function JobGeneral() {
                                                       window.open(
                                                           job?.prepareCommandURL(
                                                               'get_job_fail_context',
+                                                              mergedUiSettings,
                                                           ),
                                                       )
                                                   }

--- a/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
+++ b/packages/ui/src/ui/pages/job/JobGeneral/JobGeneral.tsx
@@ -227,7 +227,12 @@ export default function JobGeneral() {
                                 value: (
                                     <ClickableText
                                         onClick={() =>
-                                            window.open(job?.prepareCommandURL('get_job_input', mergedUiSettings))
+                                            window.open(
+                                                job?.prepareCommandURL(
+                                                    'get_job_input',
+                                                    mergedUiSettings,
+                                                ),
+                                            )
                                         }
                                     >
                                         {'get_job_input'}
@@ -239,7 +244,12 @@ export default function JobGeneral() {
                                 value: (
                                     <ClickableText
                                         onClick={() =>
-                                            window.open(job?.prepareCommandURL('get_job_stderr', mergedUiSettings))
+                                            window.open(
+                                                job?.prepareCommandURL(
+                                                    'get_job_stderr',
+                                                    mergedUiSettings,
+                                                ),
+                                            )
                                         }
                                     >
                                         {'get_job_stderr'}

--- a/packages/ui/src/ui/pages/navigation/content/Table/DownloadManager/DownloadManager.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/DownloadManager/DownloadManager.tsx
@@ -29,6 +29,7 @@ import {selectRowsPerTablePage, selectShowDecoded} from '../../../../../store/se
 import {selectSchema} from '../../../../../store/selectors/navigation/tabs/schema';
 import {selectPath, selectTransaction} from '../../../../../store/selectors/navigation';
 import {selectCluster, selectCurrentClusterConfig} from '../../../../../store/selectors/global';
+import {selectMergedUiSettings} from '../../../../../store/selectors/global/cluster';
 import withVisible, {type WithVisibleProps} from '../../../../../hocs/withVisible';
 import {
     selectAllColumns,
@@ -301,7 +302,7 @@ export class DownloadManager extends React.Component<Props, State> {
     }
 
     getDownloadLink() {
-        const {cluster, proxy, externalProxy} = this.props;
+        const {cluster, proxy, externalProxy, uiSettings} = this.props;
         const {format, number_precision_mode} = this.state;
         const {query, error} = this.getDownloadParams();
 
@@ -311,7 +312,12 @@ export class DownloadManager extends React.Component<Props, State> {
             return {url: `${base}?${params}&${query}`, error};
         }
 
-        const base = makeDirectDownloadPath('read_table', {cluster, proxy, externalProxy});
+        const base = makeDirectDownloadPath('read_table', {
+            cluster,
+            proxy,
+            externalProxy,
+            uiSettings,
+        });
 
         return {url: `${base}?${query}`, error};
     }
@@ -974,6 +980,7 @@ const mapStateToProps = (state: RootState) => {
     const path = selectPath(state);
     const {proxy, externalProxy} = selectCurrentClusterConfig(state);
     const transaction_id = selectTransaction(state);
+    const uiSettings = selectMergedUiSettings(state);
 
     const isSchematicTable = schema.length > 0;
 
@@ -992,6 +999,7 @@ const mapStateToProps = (state: RootState) => {
         proxy,
         externalProxy,
         transaction_id,
+        uiSettings,
     };
 };
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/JobTemplate.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/JobTemplate.tsx
@@ -4,7 +4,8 @@ import Link from '../../../../../../containers/Link/Link';
 import {Template} from '../../../../../../components/MetaTable/templates/Template';
 import {showErrorModal} from '../../../../../../store/actions/actions';
 import {showInputPaths} from '../../../../../../store/actions/operations/jobs';
-import {useDispatch} from '../../../../../../store/redux-hooks';
+import {useDispatch, useSelector} from '../../../../../../store/redux-hooks';
+import {selectMergedUiSettings} from '../../../../../../store/selectors/global/cluster';
 import {type Job} from '../job-selector';
 import i18n from './i18n';
 
@@ -33,7 +34,8 @@ function JobInputPaths({job}: {job: Job}) {
 /* ----------------------------------------------------------------------------------------------------------------- */
 
 function JobDebugInfo({type, job}: {type: 'stderr' | 'fail_context' | 'full_input'; job: Job}) {
-    const {size, url} = job.getDebugInfo(type)!;
+    const mergedUiSettings = useSelector(selectMergedUiSettings);
+    const {size, url} = job.getDebugInfo(type, mergedUiSettings)!;
     return <Template.DownloadLink url={url} size={size} />;
 }
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/OperationJobsTable/OperationJobsTable.js
@@ -37,6 +37,7 @@ import {
     selectOperationId,
     selectOperationTasksNames,
 } from '../../../../../../store/selectors/operations/operation';
+import {selectMergedUiSettings} from '../../../../../../store/selectors/global/cluster';
 import UIFactory from '../../../../../../UIFactory';
 import {StaleJobIcon} from '../StaleJobIcon';
 
@@ -244,6 +245,7 @@ class OperationJobsTable extends React.Component {
     };
 
     renderErrorAndDebug = (item) => {
+        const {uiSettings} = this.props;
         const items = [
             {
                 key: 'error',
@@ -258,12 +260,12 @@ class OperationJobsTable extends React.Component {
             {
                 key: 'stderr',
                 value: <JobTemplate.DebugInfo job={item} type="stderr" />,
-                visible: item.getDebugInfo('stderr').size > 0,
+                visible: item.getDebugInfo('stderr', uiSettings).size > 0,
             },
             {
                 key: 'fail_context',
                 value: <JobTemplate.DebugInfo job={item} type="fail_context" />,
-                visible: item.getDebugInfo('fail_context').size > 0,
+                visible: item.getDebugInfo('fail_context', uiSettings).size > 0,
             },
             {
                 key: 'full_input',
@@ -567,6 +569,7 @@ function mapStateToProps(state, props) {
     const jobsOperationId = selectJobsOperationId(state);
     const operationId = selectOperationId(state);
     const {jobs, job, competitiveJobs, inputPaths} = operations.jobs;
+    const uiSettings = selectMergedUiSettings(state);
     return {
         jobs: operationId !== jobsOperationId ? [] : jobs,
         job,
@@ -579,6 +582,7 @@ function mapStateToProps(state, props) {
         collapsibleSize: UI_COLLAPSIBLE_SIZE,
         isLoading: props.isLoading || operationId !== jobsOperationId,
         taskNamesNumber,
+        uiSettings,
     };
 }
 

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/job-selector.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/job-selector.ts
@@ -7,7 +7,7 @@ import moment from 'moment';
 // @ts-expect-error
 import ypath from '@ytsaurus/interface-helpers/lib/ypath';
 
-import {UISettings} from '../../../../../../shared/ui-settings';
+import {type UISettings} from '../../../../../../shared/ui-settings';
 import {
     type ClusterConfig,
     type ListJobsItem,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/job-selector.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/job-selector.ts
@@ -7,7 +7,7 @@ import moment from 'moment';
 // @ts-expect-error
 import ypath from '@ytsaurus/interface-helpers/lib/ypath';
 
-import {makeDirectDownloadPath} from '../../../../../utils/navigation';
+import {UISettings} from '../../../../../../shared/ui-settings';
 import {
     type ClusterConfig,
     type ListJobsItem,
@@ -20,6 +20,7 @@ import {
     type RawJob,
     type RawJobEvent,
 } from '../../../../../types/operations/job';
+import {makeDirectDownloadPath} from '../../../../../utils/navigation';
 
 type JobsData = ListJobsItem | RawJob;
 
@@ -151,7 +152,10 @@ export class Job implements RawJob {
         this.brief_statistics['processed_input_uncompressed_data_size'] = uncompressedSize;
     }
 
-    prepareCommandURL(commandName: 'get_job_stderr' | 'get_job_fail_context' | 'get_job_input') {
+    prepareCommandURL(
+        commandName: 'get_job_stderr' | 'get_job_fail_context' | 'get_job_input',
+        uiSettings: Pick<UISettings, 'directDownload'>,
+    ) {
         const params = qs.stringify({
             operation_id: this.operationId,
             job_id: this.id,
@@ -162,26 +166,30 @@ export class Job implements RawJob {
             cluster: this.cluster,
             proxy: this.proxy,
             externalProxy: this.externalProxy,
+            uiSettings,
         });
 
         return `${path}?${params}`;
     }
 
-    getDebugInfo(name: 'stderr' | 'fail_context' | 'full_input') {
+    getDebugInfo(
+        name: 'stderr' | 'fail_context' | 'full_input',
+        uiSettings: Pick<UISettings, 'directDownload'>,
+    ) {
         switch (name) {
             case 'stderr':
                 return {
                     size: (this.attributes as ListJobsItem).stderr_size,
-                    url: this.prepareCommandURL('get_job_stderr'),
+                    url: this.prepareCommandURL('get_job_stderr', uiSettings),
                 };
             case 'fail_context':
                 return {
                     size: (this.attributes as ListJobsItem).fail_context_size,
-                    url: this.prepareCommandURL('get_job_fail_context'),
+                    url: this.prepareCommandURL('get_job_fail_context', uiSettings),
                 };
             case 'full_input':
                 return {
-                    url: this.prepareCommandURL('get_job_input'),
+                    url: this.prepareCommandURL('get_job_input', uiSettings),
                 };
         }
     }

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
@@ -1,7 +1,7 @@
 import {type QueryResultColumn} from '../../../../types/query-tracker/queryResult';
 import qs from 'qs';
 import React, {useMemo, useState} from 'react';
-import {selectCluster} from '../../../../store/selectors/global';
+import {selectCluster, selectMergedUiSettings} from '../../../../store/selectors/global';
 import {DownloadManager} from '../../../navigation/content/Table/DownloadManager/DownloadManager';
 import {getDownloadQueryResultURL} from '../../../../store/actions/query-tracker/api';
 import {selectQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
@@ -108,6 +108,8 @@ export const QueryResultDownloadManager = React.memo(function QueryResultDownloa
         await dispatch(downloadFile(url, filename, true));
     };
 
+    const uiSettings = useSelector(selectMergedUiSettings);
+
     return (
         <QueryResultTableDownloadManager
             {...{
@@ -137,6 +139,7 @@ export const QueryResultDownloadManager = React.memo(function QueryResultDownloa
             isSchematicTable={true}
             downloadFile={handleDownload}
             downloadToClipboard={handleCopy}
+            uiSettings={uiSettings}
         />
     );
 });

--- a/packages/ui/src/ui/store/actions/cluster-params.ts
+++ b/packages/ui/src/ui/store/actions/cluster-params.ts
@@ -97,7 +97,7 @@ export function initClusterParams(cluster: string): GlobalThunkAction<Promise<vo
 
         return getClusterParams(rumId, cluster)
             .then(({data}) => {
-                const {mediumList, schedulerVersion, masterVersion, uiConfig, uiDevConfig} = data;
+                const {mediumList, masterVersion, uiConfig, uiDevConfig} = data;
                 const error = getBatchError([mediumList], 'Cluster initialization failure');
                 if (error) {
                     throw error;
@@ -113,7 +113,6 @@ export function initClusterParams(cluster: string): GlobalThunkAction<Promise<vo
                         mediumList: ypath.getValue(mediumList.output),
                         clusterUiConfig,
                         clusterUiDevConfig,
-                        schedulerVersion: schedulerVersion.output,
                         masterVersion: masterVersion.output,
                     },
                 });

--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -7,6 +7,7 @@ import {type BatchResultsItem, type BatchSubRequest} from '../../../../shared/yt
 import {YTApiId, ytApiV3, ytApiV4Id} from '../../../rum/rum-wrap-api';
 import ypath from '../../../common/thor/ypath';
 import {getClusterConfigByName, getClusterProxy} from '../../selectors/global';
+import {selectMergedUiSettings} from '../../selectors/global/cluster';
 import {type RootState} from '../../reducers';
 import {makeDirectDownloadPath} from '../../../utils/navigation';
 import {UPDATE_QUERIES_LIST} from '../../reducers/query-tracker/query-tracker-contants';
@@ -343,11 +344,13 @@ export function getDownloadQueryResultURL(
         const clusterConfig = getClusterConfigByName(getQueryTrackerCluster() || cluster);
         if (clusterConfig) {
             const {proxy, externalProxy} = clusterConfig;
+            const uiSettings = selectMergedUiSettings(state);
             const base = makeDirectDownloadPath('read_query_result', {
                 cluster,
                 version: 'v4',
                 proxy,
                 externalProxy,
+                uiSettings,
             });
             return `${base}?${params.toString()}`;
         }

--- a/packages/ui/src/ui/store/reducers/global/index.ts
+++ b/packages/ui/src/ui/store/reducers/global/index.ts
@@ -70,7 +70,6 @@ export type GlobalState = {
 
     version?: RawVersion;
     masterVersion?: RawVersion;
-    schedulerVersion?: RawVersion;
 
     login: string;
     authWay: AuthWay;
@@ -137,7 +136,6 @@ const initialState: GlobalState = {
     error: EMPTY_OBJECT,
 
     version: YT.parameters.version,
-    schedulerVersion: undefined,
     masterVersion: undefined,
     login: YT.parameters.login,
     authWay: YT.parameters.authWay,
@@ -234,7 +232,6 @@ export default (state = initialState, action: GloablStateAction): GlobalState =>
         case INIT_CLUSTER_PARAMS.SUCCESS: {
             const {
                 mediumList,
-                schedulerVersion,
                 masterVersion,
                 accounts,
                 clusterUiConfig,
@@ -252,7 +249,6 @@ export default (state = initialState, action: GloablStateAction): GlobalState =>
                 paramsLoaded: true,
                 paramsLoading: false,
                 paramsError: undefined,
-                schedulerVersion,
                 masterVersion,
             };
         }
@@ -340,7 +336,6 @@ export type GloablStateAction =
           Pick<
               GlobalState,
               | 'mediumList'
-              | 'schedulerVersion'
               | 'masterVersion'
               | 'accounts'
               | 'clusterUiConfig'

--- a/packages/ui/src/ui/store/selectors/global/cluster.ts
+++ b/packages/ui/src/ui/store/selectors/global/cluster.ts
@@ -78,13 +78,6 @@ export const selectHttpProxyVersion = createSelector(
     },
 );
 
-export const selectGlobalSchedulerVersion = createSelector(
-    [selectCluster, (state: RootState) => state.global.schedulerVersion],
-    (cluster, version) => {
-        return cluster ? version : '';
-    },
-);
-
 export const selectGlobalMasterVersion = createSelector(
     [selectCluster, (state: RootState) => state.global.masterVersion],
     (cluster, version) => {

--- a/packages/ui/src/ui/store/selectors/navigation/content/file.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/file.js
@@ -2,14 +2,15 @@ import ypath from '@ytsaurus/interface-helpers/lib/ypath';
 import {createSelector} from 'reselect';
 import {selectAttributes, selectPath} from '../../../../store/selectors/navigation';
 import {selectCurrentClusterConfig} from '../../../../store/selectors/global';
+import {selectMergedUiSettings} from '../../../../store/selectors/global/cluster';
 import {MAX_FILE_SIZE} from '../../../../constants/navigation/content/file';
 import {calculateLoadingStatus} from '../../../../utils/utils';
 import {makeDirectDownloadPath} from '../../../../utils/navigation';
 
 export const selectDownloadPath = createSelector(
-    [selectPath, selectCurrentClusterConfig],
-    (cypressPath, {id: cluster, proxy, externalProxy}) => {
-        const path = makeDirectDownloadPath('read_file', {cluster, proxy, externalProxy});
+    [selectPath, selectCurrentClusterConfig, selectMergedUiSettings],
+    (cypressPath, {id: cluster, proxy, externalProxy}, uiSettings) => {
+        const path = makeDirectDownloadPath('read_file', {cluster, proxy, externalProxy, uiSettings});
         const query = [
             'path=' + encodeURIComponent(cypressPath),
             'disposition=attachment',

--- a/packages/ui/src/ui/store/selectors/navigation/content/file.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/file.js
@@ -10,7 +10,12 @@ import {makeDirectDownloadPath} from '../../../../utils/navigation';
 export const selectDownloadPath = createSelector(
     [selectPath, selectCurrentClusterConfig, selectMergedUiSettings],
     (cypressPath, {id: cluster, proxy, externalProxy}, uiSettings) => {
-        const path = makeDirectDownloadPath('read_file', {cluster, proxy, externalProxy, uiSettings});
+        const path = makeDirectDownloadPath('read_file', {
+            cluster,
+            proxy,
+            externalProxy,
+            uiSettings,
+        });
         const query = [
             'path=' + encodeURIComponent(cypressPath),
             'disposition=attachment',

--- a/packages/ui/src/ui/types/operations/job.ts
+++ b/packages/ui/src/ui/types/operations/job.ts
@@ -1,4 +1,4 @@
-import {UISettings} from '../../../shared/ui-settings';
+import {type UISettings} from '../../../shared/ui-settings';
 import {type OperationType} from '../../../shared/yt-types';
 import {type Acl, type YTError} from '../../types';
 

--- a/packages/ui/src/ui/types/operations/job.ts
+++ b/packages/ui/src/ui/types/operations/job.ts
@@ -1,3 +1,4 @@
+import {UISettings} from '../../../shared/ui-settings';
 import {type OperationType} from '../../../shared/yt-types';
 import {type Acl, type YTError} from '../../types';
 
@@ -74,7 +75,7 @@ export interface PreparedJob extends Partial<RawJob> {
     duration: number;
     error?: JobError;
 
-    prepareCommandURL: (command: string) => string;
+    prepareCommandURL: (command: string, uiSettings: Pick<UISettings, 'directDownload'>) => string;
 }
 
 export interface PreparedJobEvent {

--- a/packages/ui/src/ui/utils/navigation/index.ts
+++ b/packages/ui/src/ui/utils/navigation/index.ts
@@ -2,7 +2,7 @@ import {type CancelTokenSource} from 'axios';
 // @ts-ignore
 import ypath from '../../common/thor/ypath';
 
-import {UISettings} from '../../../shared/ui-settings';
+import {type UISettings} from '../../../shared/ui-settings';
 import unipika from '../../common/thor/unipika';
 import {Page} from '../../constants/index';
 import {SUPPRESS_REDIRECT} from '../../constants/navigation/modals/delete-object';

--- a/packages/ui/src/ui/utils/navigation/index.ts
+++ b/packages/ui/src/ui/utils/navigation/index.ts
@@ -1,12 +1,11 @@
-import unipika from '../../common/thor/unipika';
+import {type CancelTokenSource} from 'axios';
 // @ts-ignore
 import ypath from '../../common/thor/ypath';
 
-import {type CancelTokenSource} from 'axios';
-
+import {UISettings} from '../../../shared/ui-settings';
+import unipika from '../../common/thor/unipika';
 import {Page} from '../../constants/index';
 import {SUPPRESS_REDIRECT} from '../../constants/navigation/modals/delete-object';
-import {allowDirectDownload} from '../../config';
 
 export function autoCorrectPath(path: string) {
     // 1) Strip slash from the end
@@ -157,10 +156,17 @@ export function makeDirectDownloadPath(
         cluster,
         proxy,
         externalProxy,
+        uiSettings,
         version = 'v3',
-    }: {cluster: string; proxy: string; externalProxy: string | undefined; version?: 'v3' | 'v4'},
+    }: {
+        cluster: string;
+        proxy: string;
+        externalProxy: string | undefined;
+        uiSettings: Pick<UISettings, 'directDownload'>;
+        version?: 'v3' | 'v4';
+    },
 ) {
-    return allowDirectDownload()
+    return uiSettings.directDownload
         ? `//${externalProxy ?? proxy}/api/${version}/${command}`
         : `/api/yt/${cluster}/api/${version}/${command}`;
 }

--- a/packages/ui/tests/e2e/pages/table.static.base.spec.ts
+++ b/packages/ui/tests/e2e/pages/table.static.base.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '@playwright/test';
 import {E2E_DIR, makeClusterTille, makeClusterUrl} from '../../utils';
+import {basePage} from '../../widgets/BasePage';
 
 const PATH = `${E2E_DIR}/static-table`;
 
@@ -60,17 +61,12 @@ test('Static table: column selector work properly', async ({page}) => {
 });
 
 test('Static table: externalProxy', async ({page}) => {
+    await basePage(page).override_window__DATA__({directDownload: true}, {});
+
     const url = makeClusterUrl(`navigation?path=${PATH}`);
     await page.goto(url);
 
-    await page.waitForSelector('.navigation');
-    await page.waitForFunction(() => {
-        window.__DATA__.uiSettings.directDownload = true;
-        return window.__DATA__.uiSettings;
-    });
-
     await page.click('button[data-qa="show-download-static-table"]');
-
     await page.waitForSelector(
         `a[href^="//external.proxy.my/api/v3/read_table?path=${encodeURIComponent(PATH)}"]`,
     );


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/8tFtMId67khtqZ
<!-- nda-end --> ## Summary by Sourcery

Route all data and debug download URLs through cluster-specific UI settings and remove unused scheduler version handling from cluster metadata and settings UI.

Enhancements:
- Respect per-cluster direct download UI setting when generating job, table, file, and query result download URLs, and thread this setting through relevant components and selectors.
- Hide CPU, GPU, and network utilization rows on non-exec nodes in the node CPU and memory meta table.
- Simplify global cluster state and settings by dropping scheduler version fetching, storage, and display.

Tests:
- Update static table external proxy E2E test to configure direct download via the shared base page helper instead of mutating global window data at runtime.