### PR TITLE
fix(ACL): allow tvm apps as responsibles [YTFRONT-5933]

### DIFF
--- a/packages/ui/src/ui/store/selectors/acl/acl.ts
+++ b/packages/ui/src/ui/store/selectors/acl/acl.ts
@@ -41,19 +41,11 @@ function prepareApprovers(
     type: 'read_approver' | 'responsible' | 'auditor',
 ) {
     return map_(approvers, (subject) => {
-        const extra = {
-            type,
-            subjects: [subject.value],
-            subjectType: subject.type === 'users' ? ('user' as const) : ('group' as const),
-            groupInfo:
-                subject.type === 'groups'
-                    ? {name: subject.group_name, url: subject.url, group: subject.group}
-                    : undefined,
-            action: undefined,
-        };
         return {
             ...subject,
-            ...extra,
+            type,
+            subjects: [subject.value],
+            action: undefined,
         };
     });
 }

--- a/packages/ui/src/ui/store/selectors/groups.ts
+++ b/packages/ui/src/ui/store/selectors/groups.ts
@@ -224,6 +224,7 @@ export const selectGroupEditorRoles = createSelector(
                     subject: {
                         user: member,
                     },
+                    subjectType: 'user',
                 };
             }),
         };

--- a/packages/ui/src/ui/utils/acl/index.ts
+++ b/packages/ui/src/ui/utils/acl/index.ts
@@ -10,6 +10,7 @@ import {
     type InheritedFrom,
     type ResponsibleType,
     type Subject,
+    type TypedAclSubject,
 } from '../../utils/acl/acl-types';
 import {type YTPermissionTypeUI} from './acl-api';
 import {makeRegexpFromSettings} from '../../../shared/utils';
@@ -78,10 +79,9 @@ export function normalizeIdmParams(idmKind: IdmKindType, path = '') {
 
 export type SubjectGroupType = 'service' | 'department' | string;
 
-export interface PreparedRole {
-    type?: 'users' | 'groups';
+export type PreparedRole = TypedAclSubject & {
+    type?: 'users' | 'groups' | 'app';
     subject: Subject;
-    subjectUrl?: string;
     inherited?: boolean;
     inheritedFrom?: InheritedFrom;
     idmLink?: string;
@@ -99,6 +99,7 @@ export interface PreparedRole {
     group_type?: SubjectGroupType;
     user?: string;
     name?: string;
+
     tvm_id?: string;
 
     state?: string;
@@ -110,13 +111,10 @@ export interface PreparedRole {
     member?: boolean;
     deprive_date?: string;
 
-    internal?: boolean;
-
     url?: string;
 
     types?: undefined;
-    subjectType?: undefined;
-}
+};
 
 export function prepareAclSubject(item: ResponsibleType): Subject {
     switch (item.type) {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/vo5JNJrE7kizHd
<!-- nda-end -->  ## Summary by Sourcery

Support application (TVM) subjects as ACL responsibles and align prepared role typings with shared ACL subject types.

New Features:
- Allow ACL prepared roles to represent application (TVM) subjects in addition to users and groups.

Bug Fixes:
- Ensure group editor roles explicitly set subject type for user members to avoid missing or incorrect ACL subject metadata.

Enhancements:
- Reuse the shared TypedAclSubject type for PreparedRole to unify ACL subject modeling across the UI codebase.
- Simplify approver preparation logic by removing redundant per-subject metadata now covered by shared ACL types.