### PR TITLE
fix(makeDirectDownloadPath): do not ignore secure flag for proxy [YTFRONT-5795]

### DIFF
--- a/packages/ui/src/ui/common/yt-api.ts
+++ b/packages/ui/src/ui/common/yt-api.ts
@@ -13,7 +13,7 @@ import {toaster} from '../utils/toaster';
 
 export function initYTApiClusterParams(cluster: string) {
     const {clusters} = YT;
-    const config = getClusterConfig(clusters, cluster);
+    const config = {...getClusterConfig(clusters, cluster)};
 
     yt.setup.setGlobalOption('suppressAccessTracking', true);
     yt.setup.setGlobalOption('useEncodedParameters', true);

--- a/packages/ui/src/ui/pages/navigation/content/Table/DownloadManager/DownloadManager.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/DownloadManager/DownloadManager.tsx
@@ -302,7 +302,7 @@ export class DownloadManager extends React.Component<Props, State> {
     }
 
     getDownloadLink() {
-        const {cluster, proxy, externalProxy, uiSettings} = this.props;
+        const {cluster, clusterConfig, uiSettings} = this.props;
         const {format, number_precision_mode} = this.state;
         const {query, error} = this.getDownloadParams();
 
@@ -313,9 +313,7 @@ export class DownloadManager extends React.Component<Props, State> {
         }
 
         const base = makeDirectDownloadPath('read_table', {
-            cluster,
-            proxy,
-            externalProxy,
+            clusterConfig,
             uiSettings,
         });
 
@@ -978,7 +976,7 @@ const mapStateToProps = (state: RootState) => {
     const columns: typeof allColumns = selectColumns(state);
     const schema = selectSchema(state);
     const path = selectPath(state);
-    const {proxy, externalProxy} = selectCurrentClusterConfig(state);
+    const clusterConfig = selectCurrentClusterConfig(state);
     const transaction_id = selectTransaction(state);
     const uiSettings = selectMergedUiSettings(state);
 
@@ -996,8 +994,7 @@ const mapStateToProps = (state: RootState) => {
         columns,
         showDecoded,
         isSchematicTable,
-        proxy,
-        externalProxy,
+        clusterConfig,
         transaction_id,
         uiSettings,
     };

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/job-selector.ts
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/Jobs/job-selector.ts
@@ -43,9 +43,7 @@ export class Job implements RawJob {
         return Job.hasUserErrorCode(error) ? Job.USER_ERROR : Job.SYSTEM_ERROR;
     }
 
-    cluster: ClusterConfig['id'];
-    proxy: ClusterConfig['proxy'];
-    externalProxy: ClusterConfig['externalProxy'];
+    clusterConfig: ClusterConfig;
     operationId: string;
     job_id: string;
     id: string;
@@ -96,11 +94,7 @@ export class Job implements RawJob {
         operationId: string;
         clusterConfig: ClusterConfig;
     }) {
-        const {id: cluster, proxy, externalProxy} = clusterConfig ?? {};
-
-        this.cluster = cluster;
-        this.proxy = proxy;
-        this.externalProxy = externalProxy;
+        this.clusterConfig = clusterConfig;
         this.operationId = operationId;
         this.attributes = job;
 
@@ -163,9 +157,7 @@ export class Job implements RawJob {
         });
 
         const path = makeDirectDownloadPath(commandName, {
-            cluster: this.cluster,
-            proxy: this.proxy,
-            externalProxy: this.externalProxy,
+            clusterConfig: this.clusterConfig,
             uiSettings,
         });
 

--- a/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResults/QueryResultActions/QueryResultDownloadManager.tsx
@@ -1,7 +1,11 @@
 import {type QueryResultColumn} from '../../../../types/query-tracker/queryResult';
 import qs from 'qs';
 import React, {useMemo, useState} from 'react';
-import {selectCluster, selectMergedUiSettings} from '../../../../store/selectors/global';
+import {
+    selectCluster,
+    selectCurrentClusterConfig,
+    selectMergedUiSettings,
+} from '../../../../store/selectors/global';
 import {DownloadManager} from '../../../navigation/content/Table/DownloadManager/DownloadManager';
 import {getDownloadQueryResultURL} from '../../../../store/actions/query-tracker/api';
 import {selectQueryResult} from '../../../../store/selectors/query-tracker/queryResult';
@@ -109,6 +113,7 @@ export const QueryResultDownloadManager = React.memo(function QueryResultDownloa
     };
 
     const uiSettings = useSelector(selectMergedUiSettings);
+    const clusterConfig = useSelector(selectCurrentClusterConfig);
 
     return (
         <QueryResultTableDownloadManager
@@ -140,6 +145,7 @@ export const QueryResultDownloadManager = React.memo(function QueryResultDownloa
             downloadFile={handleDownload}
             downloadToClipboard={handleCopy}
             uiSettings={uiSettings}
+            clusterConfig={clusterConfig}
         />
     );
 });

--- a/packages/ui/src/ui/store/actions/query-tracker/api.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/api.ts
@@ -360,13 +360,10 @@ export function getDownloadQueryResultURL(
         }
         const clusterConfig = getClusterConfigByName(getQueryTrackerCluster() || cluster);
         if (clusterConfig) {
-            const {proxy, externalProxy} = clusterConfig;
             const uiSettings = selectMergedUiSettings(state);
             const base = makeDirectDownloadPath('read_query_result', {
-                cluster,
+                clusterConfig,
                 version: 'v4',
-                proxy,
-                externalProxy,
                 uiSettings,
             });
             return `${base}?${params.toString()}`;

--- a/packages/ui/src/ui/utils/navigation/index.ts
+++ b/packages/ui/src/ui/utils/navigation/index.ts
@@ -3,6 +3,7 @@ import {type CancelTokenSource} from 'axios';
 import ypath from '../../common/thor/ypath';
 
 import {type UISettings} from '../../../shared/ui-settings';
+import {type ClusterConfig} from '../../../shared/yt-types';
 import unipika from '../../common/thor/unipika';
 import {Page} from '../../constants/index';
 import {SUPPRESS_REDIRECT} from '../../constants/navigation/modals/delete-object';
@@ -153,19 +154,16 @@ export function makeDirectDownloadPath(
         | 'get_job_input'
         | 'get_job_stderr',
     {
-        cluster,
-        proxy,
-        externalProxy,
+        clusterConfig,
         uiSettings,
         version = 'v3',
     }: {
-        cluster: string;
-        proxy: string;
-        externalProxy: string | undefined;
+        clusterConfig: Pick<ClusterConfig, 'id' | 'proxy' | 'externalProxy'>;
         uiSettings: Pick<UISettings, 'directDownload'>;
         version?: 'v3' | 'v4';
     },
 ) {
+    const {id: cluster, proxy, externalProxy} = clusterConfig;
     return uiSettings.directDownload
         ? `//${externalProxy ?? proxy}/api/${version}/${command}`
         : `/api/yt/${cluster}/api/${version}/${command}`;

--- a/packages/ui/src/ui/utils/navigation/index.ts
+++ b/packages/ui/src/ui/utils/navigation/index.ts
@@ -158,13 +158,21 @@ export function makeDirectDownloadPath(
         uiSettings,
         version = 'v3',
     }: {
-        clusterConfig: Pick<ClusterConfig, 'id' | 'proxy' | 'externalProxy'>;
+        clusterConfig: Pick<ClusterConfig, 'id' | 'proxy' | 'externalProxy' | 'secure'>;
         uiSettings: Pick<UISettings, 'directDownload'>;
         version?: 'v3' | 'v4';
     },
 ) {
-    const {id: cluster, proxy, externalProxy} = clusterConfig;
-    return uiSettings.directDownload
-        ? `//${externalProxy ?? proxy}/api/${version}/${command}`
-        : `/api/yt/${cluster}/api/${version}/${command}`;
+    const {id: cluster, proxy, externalProxy, secure} = clusterConfig;
+
+    if (!uiSettings.directDownload) {
+        return `/api/yt/${cluster}/api/${version}/${command}`;
+    }
+
+    if (externalProxy) {
+        return `//${externalProxy}/api/${version}/${command}`;
+    }
+
+    const schema = secure ? 'https' : 'http';
+    return `${schema}://${proxy}/api/${version}/${command}`;
 }


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/JNb1NQ4d7kjmZP
<!-- nda-end -->## Summary by Sourcery

Make direct download paths respect cluster secure configuration and centralize cluster proxy data usage.

Bug Fixes:
- Ensure direct download URLs use HTTPS when the cluster is marked as secure instead of always using scheme-relative URLs.

Enhancements:
- Refactor direct download path construction to accept full cluster configuration rather than separate cluster and proxy fields.
- Propagate cluster configuration usage through job handling, navigation table download manager, and query result download manager.
- Adjust YT API cluster parameter initialization to work with the updated cluster configuration object.