### PR TITLE
feat(MetaTable): render nirvana block url and fixes [YTFRONT-5942]

### DIFF
--- a/packages/components/.eslintrc
+++ b/packages/components/.eslintrc
@@ -1,6 +1,9 @@
 {
     "extends": ["@gravity-ui/eslint-config", "@gravity-ui/eslint-config/prettier"],
     "root": true,
+    "parserOptions": {
+        "sourceType": "module"
+    },
     "rules": {
         "new-cap": 0,
         "import/order": 0

--- a/packages/components/src/api/navigation/loadTableAttributesByPath.ts
+++ b/packages/components/src/api/navigation/loadTableAttributesByPath.ts
@@ -21,7 +21,7 @@ export const loadTableAttributesByPath = async (
         useYqlTypes?: boolean;
         docsUrls?: Record<string, string>;
         showDecoded?: boolean;
-        navigationTableConfig?: Partial<TYComponentsNavigationMetaConfig>;
+        navigationTableConfig?: TYComponentsNavigationMetaConfig;
     },
 ): Promise<NavigationTable> => {
     const attributes = await loadTableAttributes(path, setup);

--- a/packages/components/src/components/MetaTable/MetaTable.scss
+++ b/packages/components/src/components/MetaTable/MetaTable.scss
@@ -72,8 +72,7 @@
         display: block;
     }
 
-    &__id,
-    &__link_clickable {
+    &__id {
         display: flex;
         align-items: center;
     }

--- a/packages/components/src/components/MetaTable/presets/helpers/commonFields.tsx
+++ b/packages/components/src/components/MetaTable/presets/helpers/commonFields.tsx
@@ -32,7 +32,7 @@ export const getCommonFields = ({
     tableType: string;
     tabletErrorCount: number;
     onEditEnableReplicatedTableTracker?: MetaTableAutomaticModeSwitchOnEdit;
-    config?: Partial<TYComponentsNavigationMetaConfig>;
+    config?: TYComponentsNavigationMetaConfig;
 }) => {
     const [sorted, chaosCellBundle, enableReplicatedTableTracker] = ypath.getValues(attributes, [
         '/sorted',

--- a/packages/components/src/components/MetaTable/presets/main.tsx
+++ b/packages/components/src/components/MetaTable/presets/main.tsx
@@ -5,7 +5,9 @@ import type {TYComponentsNavigationMetaConfig} from '../../../types';
 import {MetaTableItem} from '../MetaTable';
 import i18n from './i18n';
 
-const normalizeMetaOperationLinkItems = (
+const LINK_MAX_WIDTH = 400;
+
+const normalizeMetaTableItems = (
     result: MetaTableItem | MetaTableItem[] | null | undefined,
 ): MetaTableItem[] => {
     if (!result) return [];
@@ -16,33 +18,58 @@ const normalizeMetaOperationLinkItems = (
 type Props = (
     attributes: any,
     cluster: string,
-    config?: Partial<TYComponentsNavigationMetaConfig>,
+    config?: TYComponentsNavigationMetaConfig,
 ) => MetaTableItem[];
 
 export const metaTablePresetMain: Props = (attributes, cluster, config = {}) => {
-    const SubjectCard = config.SubjectCard;
-    const AccountLink = config.AccountLink;
-    const renderMetaOperationLink = config.renderMetaOperationLink ?? null;
-    const [id, owner, account, creationTime, modificationTime, accessTime, yqlOpId] =
-        ypath.getValues(attributes, [
-            '/id',
-            '/owner',
-            '/account',
-            '/creation_time',
-            '/modification_time',
-            '/access_time',
-            '/_yql_op_id',
-        ]);
+    const {SubjectCard, AccountLink, renderMetaOperationLink, renderMarkdown} = config;
+    const [
+        id,
+        owner,
+        account,
+        creationTime,
+        modificationTime,
+        accessTime,
+        yqlOpId,
+        nirvanaBlockUrl,
+    ] = ypath.getValues(attributes, [
+        '/id',
+        '/owner',
+        '/account',
+        '/creation_time',
+        '/modification_time',
+        '/access_time',
+        '/_yql_op_id',
+        '/_nirvana_meta/block_url',
+    ]);
 
     const operationLinkItems =
         yqlOpId && renderMetaOperationLink
-            ? normalizeMetaOperationLinkItems(
+            ? normalizeMetaTableItems(
                   renderMetaOperationLink({
                       operationId: yqlOpId,
                       cluster,
                   }),
               )
             : [];
+
+    const nirvanaMetaItems = nirvanaBlockUrl
+        ? [
+              {
+                  key: 'nirvana_block_url',
+                  value: renderMarkdown ? (
+                      renderMarkdown({text: nirvanaBlockUrl})
+                  ) : (
+                      <Template.Link
+                          url={nirvanaBlockUrl}
+                          text={nirvanaBlockUrl}
+                          maxWidth={LINK_MAX_WIDTH}
+                          withClipboard
+                      />
+                  ),
+              },
+          ]
+        : [];
 
     return [
         {
@@ -87,5 +114,6 @@ export const metaTablePresetMain: Props = (attributes, cluster, config = {}) => 
             visible: Boolean(accessTime),
         },
         ...operationLinkItems,
+        ...nirvanaMetaItems,
     ];
 };

--- a/packages/components/src/components/MetaTable/presets/presets.tsx
+++ b/packages/components/src/components/MetaTable/presets/presets.tsx
@@ -91,7 +91,7 @@ export function dynTableInfo(
     attributes: any,
     cluster: string,
     tabletErrorCount: number,
-    config?: Partial<TYComponentsNavigationMetaConfig>,
+    config?: TYComponentsNavigationMetaConfig,
 ) {
     const [tabletCellBundle, tabletState, inMemoryMode] = ypath.getValues(attributes, [
         '/tablet_cell_bundle',
@@ -162,7 +162,7 @@ export const makeMetaItems = ({
     tabletErrorCount?: number;
     onEditEnableReplicatedTableTracker?: (currentValue?: boolean) => Promise<void>;
     docsUrls?: Record<string, string>;
-    navigationTableConfig?: Partial<TYComponentsNavigationMetaConfig>;
+    navigationTableConfig?: TYComponentsNavigationMetaConfig;
 }) => {
     const config = navigationTableConfig
         ? {...navigationTableConfig, docsUrls: docsUrls ?? navigationTableConfig.docsUrls}

--- a/packages/components/src/components/MetaTable/presets/ttl.tsx
+++ b/packages/components/src/components/MetaTable/presets/ttl.tsx
@@ -28,7 +28,7 @@ export function makeTTLItems(
         showTTLLabel?: boolean;
         docsUrls?: Record<string, string>;
         cluster?: string;
-        config?: Partial<TYComponentsNavigationMetaConfig>;
+        config?: TYComponentsNavigationMetaConfig;
     } = {},
 ) {
     const expirationTime = ypath.getValue(attrs, '/expiration_time');

--- a/packages/components/src/components/MetaTable/presets/ttl.tsx
+++ b/packages/components/src/components/MetaTable/presets/ttl.tsx
@@ -17,6 +17,8 @@ import './ttl.scss';
 
 const block = cn('meta-table-ttl');
 
+const LINK_MAX_WIDTH = 400;
+
 export function makeTTLItems(
     attrs: unknown,
     {
@@ -52,8 +54,17 @@ export function makeTTLItems(
         res.push({
             key: 'effective_expiration_time_path',
             label: i18n('field_effective-expiration-time-path'),
-            qa: 'expiration_timeout_path',
-            value: timePathUrl ? <Template.Link url={timePathUrl} text={time.path} /> : time.path,
+            qa: 'expiration_time_path',
+            value: timePathUrl ? (
+                <Template.Link
+                    url={timePathUrl}
+                    text={time.path}
+                    maxWidth={LINK_MAX_WIDTH}
+                    withClipboard
+                />
+            ) : (
+                time.path
+            ),
         });
     }
     if (expirationTime) {
@@ -82,7 +93,12 @@ export function makeTTLItems(
             label: i18n('field_effective-expiration-timeout-path'),
             qa: 'expiration_timeout_path',
             value: timeoutPathUrl ? (
-                <Template.Link url={timeoutPathUrl} text={timeout.path} />
+                <Template.Link
+                    url={timeoutPathUrl}
+                    text={timeout.path}
+                    maxWidth={LINK_MAX_WIDTH}
+                    withClipboard
+                />
             ) : (
                 timeout.path
             ),

--- a/packages/components/src/components/MetaTable/templates/Template.tsx
+++ b/packages/components/src/components/MetaTable/templates/Template.tsx
@@ -1,7 +1,7 @@
-import React, {Fragment} from 'react';
+import React from 'react';
 import cn from 'bem-cn-lite';
 
-import {Text as GravityText, Icon, Link} from '@gravity-ui/uikit';
+import {Flex, Icon, type IconData, Link, Text} from '@gravity-ui/uikit';
 
 import {format as hammerFormat} from '../../../utils';
 import {ClipboardButton} from '../../ClipboardButton';
@@ -15,7 +15,7 @@ const itemBlock = cn('meta-table-item');
 export function TemplateId({id}: {id?: string}) {
     return (
         <div className={itemBlock('id')}>
-            <GravityText ellipsis>{id}</GravityText>
+            <Text ellipsis>{id}</Text>
             &nbsp;
             <ClipboardButton view="flat-secondary" text={id ?? ''} size="s" />
         </div>
@@ -59,46 +59,50 @@ export function TemplateReadable({value = hammerFormat.NO_VALUE}: {value?: strin
 
 /* ----------------------------------------------------------------------------------------------------------------- */
 
-type IconData = React.ComponentType<React.SVGProps<SVGSVGElement>>;
-
-function TemplateLink({
-    url,
-    icon: IconComponent,
-    text = '',
-    shiftText = undefined,
-    withClipboard = false,
-    hoverContent = undefined,
-}: {
+type TampleteLinkProps = {
     url: string;
     text?: string;
     icon?: IconData;
     withClipboard?: boolean;
     shiftText?: string;
     hoverContent?: React.ReactNode;
-}) {
+    maxWidth?: number;
+};
+
+function TemplateLink({
+    url,
+    icon: IconComponent,
+    text = '',
+    shiftText,
+    withClipboard,
+    hoverContent,
+    maxWidth,
+}: TampleteLinkProps) {
     return (
-        <Fragment>
-            <div className={itemBlock('link', {clickable: withClipboard})}>
-                <GravityText ellipsis>
-                    <Link title={url} href={url}>
-                        {IconComponent && <Icon data={IconComponent as never} size={14} />}
-                        {text}
-                    </Link>
-                </GravityText>
-                {withClipboard && (
-                    <Fragment>
-                        &nbsp;
-                        <ClipboardButton
-                            view="flat-secondary"
-                            text={text}
-                            shiftText={shiftText}
-                            hoverContent={hoverContent}
-                            size="s"
-                        />
-                    </Fragment>
-                )}
-            </div>
-        </Fragment>
+        <Flex
+            gap={2}
+            wrap="nowrap"
+            alignItems="center"
+            className={itemBlock('link')}
+            style={{maxWidth}}
+        >
+            <Text ellipsis>
+                <Link title={url} href={url}>
+                    {IconComponent && <Icon data={IconComponent} size={14} />}
+                    {text}
+                </Link>
+            </Text>
+
+            {withClipboard && (
+                <ClipboardButton
+                    view="flat-secondary"
+                    text={text}
+                    shiftText={shiftText}
+                    hoverContent={hoverContent}
+                    size="s"
+                />
+            )}
+        </Flex>
     );
 }
 

--- a/packages/components/src/types/navigationMeta.ts
+++ b/packages/components/src/types/navigationMeta.ts
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import type {MetaTableItem} from '../components';
 
 export type MetaTableAutomaticModeSwitchOnEdit = (currentValue?: boolean) => Promise<void>;
@@ -39,6 +40,11 @@ export type MetaTableOperationLinkParams = {
     cluster: string;
 };
 
+export type MetaTableRenderMarkdownParams = {
+    text: string;
+    allowHTML?: boolean;
+};
+
 export type MetaTableAutomaticModeSwitchParams = {
     value?: boolean;
     cluster: string;
@@ -52,17 +58,16 @@ export type NavigationLinkTemplate = (params: {
 
 export type YtComponentsDocsUrlKey = 'cypress:ttl' | 'storage:replication#erasure';
 
-export type TYComponentsNavigationMetaConfig = {
-    SubjectCard?: (props: SubjectCardProps) => React.ReactNode;
-    AccountLink?: (props: MetaTableAccountLinkProps) => React.ReactNode;
-    TabletCellBundleLink?: (props: MetaTableTabletCellBundleLinkProps) => React.ReactNode;
-    ChaosCellBundleLink?: (props: MetaTableChaosCellBundleLinkProps) => React.ReactNode;
-    renderMetaOperationLink?: (
+export type TYComponentsNavigationMetaConfig = Partial<{
+    SubjectCard: (props: SubjectCardProps) => ReactNode;
+    AccountLink: (props: MetaTableAccountLinkProps) => ReactNode;
+    TabletCellBundleLink: (props: MetaTableTabletCellBundleLinkProps) => ReactNode;
+    ChaosCellBundleLink: (props: MetaTableChaosCellBundleLinkProps) => ReactNode;
+    renderMetaOperationLink: (
         params: MetaTableOperationLinkParams,
     ) => MetaTableItem | MetaTableItem[] | null | undefined;
-    renderMetaTableAutomaticModeSwitch?: (
-        params: MetaTableAutomaticModeSwitchParams,
-    ) => React.ReactNode;
-    navigationLinkTemplate?: NavigationLinkTemplate;
-    docsUrls?: Record<YtComponentsDocsUrlKey, string>;
-};
+    renderMarkdown: (params: MetaTableRenderMarkdownParams) => ReactNode;
+    renderMetaTableAutomaticModeSwitch: (params: MetaTableAutomaticModeSwitchParams) => ReactNode;
+    navigationLinkTemplate: NavigationLinkTemplate;
+    docsUrls: Record<YtComponentsDocsUrlKey, string>;
+}>;


### PR DESCRIPTION
## Summary by Sourcery

Render Nirvana block URL and other meta-related links in MetaTable with improved layout and configuration flexibility.

New Features:
- Display Nirvana block URL in MetaTable when available, using either a provided markdown renderer or a styled link with clipboard support.
- Support optional markdown rendering for MetaTable values via a new renderMarkdown callback in the navigation meta config.

Bug Fixes:
- Fix QA attribute name for effective expiration time path and remove obsolete clickable link styling from MetaTable styles.

Enhancements:
- Refine MetaTable link rendering to use Flex/Text components with consistent ellipsis, spacing, and optional clipboard button, including a configurable max link width.
- Unify and broaden the navigation meta config type usage across MetaTable presets and loaders instead of partially-typed configs.
- Limit TTL-related link widths and add clipboard support for expiration path links for better usability.