### PR TITLE
fix(Accounts): last open tab [YTFRONT-5963]

### DIFF
--- a/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
@@ -94,7 +94,9 @@ export class Accounts extends React.Component<
             [AccountsTab.MONITOR]: monitoringTitle ?? i18n('title_monitoring'),
         });
 
-        const lastTab = lastVisitedTab in AccountsTab ? lastVisitedTab : undefined;
+        const lastTab = Object.values(AccountsTab).includes(lastVisitedTab)
+            ? lastVisitedTab
+            : undefined;
         const tabToRedirect = activeAccount && lastTab ? lastTab : AccountsTab.GENERAL;
 
         return (


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/OJgzZR0w7kuqUw
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Fix detection of the last visited accounts tab by checking against AccountsTab values instead of relying on the 'in' operator on the enum.