### PR TITLE
test: set playwright threshold for screen tests [YTFRONT-5914]

### DIFF
--- a/packages/ui/tests/playwright.config.ts
+++ b/packages/ui/tests/playwright.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
     expect: {
         toHaveScreenshot: {
             caret: 'hide',
+            threshold: 0.1,
         },
     },
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/3ZfGJd0B7kwczH
<!-- nda-end -->## Summary by Sourcery

Tests:
- Set a 0.1 threshold for Playwright toHaveScreenshot assertions in UI visual regression tests.