### PR TITLE
fix: incorrect removal of the page favicon [YTFRONT-5965]

### DIFF
--- a/packages/ui/src/ui/appearance.ts
+++ b/packages/ui/src/ui/appearance.ts
@@ -1,3 +1,4 @@
+import {type Required} from 'utility-types';
 import {type ClusterTheme} from '../shared/yt-types';
 import {YT} from './config/yt-config';
 import UIFactory from './UIFactory';
@@ -22,41 +23,43 @@ export const favicons: Record<ClusterTheme, string> = {
     electricviolet: require('./assets/img/favicon-electricviolet.png'),
 };
 
-export interface ClusterAppearance {
+export type ClusterAppearance = {
     favicon?: string;
     icon: string;
     icon2x: string;
     iconbig?: string;
-}
+};
 
-export const defaultClusterAppearance: ClusterAppearance = {
+type RequiredClusterAppearance = Required<ClusterAppearance, 'favicon'>;
+
+export const defaultClusterAppearance: RequiredClusterAppearance = {
     icon: require('./assets/img/cluster.svg'),
     icon2x: require('./assets/img/cluster-2x.svg'),
     favicon,
 };
 
-const localClusterAppearance: ClusterAppearance = {
+const localClusterAppearance: RequiredClusterAppearance = {
     favicon,
     icon: require('./assets/img/ui.jpg'),
     icon2x: require('./assets/img/ui-2x.jpg'),
     iconbig: require('./assets/img/ui-big.jpg'),
 };
 
-const cache: Record<string, ClusterAppearance> = {};
+const cache: Record<string, RequiredClusterAppearance> = {};
 
-export function getClusterAppearance(cluster = ''): ClusterAppearance {
+export function getClusterAppearance(cluster = ''): RequiredClusterAppearance {
     if (!cache[cluster]) {
         const {theme} = YT.clusters[cluster] ?? {};
 
-        const item = (cache[cluster] = {
+        const item = {
             ...(YT.isLocalCluster ? localClusterAppearance : defaultClusterAppearance),
-        });
+        };
 
-        Object.assign(
-            item,
-            {favicon: favicons[theme] ?? item.favicon},
-            UIFactory.getClusterAppearance(cluster),
-        );
+        cache[cluster] = {
+            ...item,
+            favicon: favicons[theme] ?? item.favicon,
+            ...UIFactory.getClusterAppearance(cluster),
+        };
     }
 
     return cache[cluster];

--- a/packages/ui/src/ui/components/PageHead/PageHead.tsx
+++ b/packages/ui/src/ui/components/PageHead/PageHead.tsx
@@ -1,27 +1,29 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, {useLayoutEffect} from 'react';
 import {Helmet} from 'react-helmet';
 import {useSelector} from '../../store/redux-hooks';
 import {type RootState} from '../../store/reducers';
 import {getClusterAppearance} from '../../appearance';
 
-PageHead.propTypes = {
-    title: PropTypes.string,
-    cluster: PropTypes.string,
-};
+function PageHead({title, favicon}: {title: string; favicon?: string}) {
+    /*
+     * Removes stale <link rel="icon"> tags added by the HTML template.
+     * Use useLayoutEffect (not useEffect) to remove the stale icon before react-helmet
+     * commits the new one, so both never coexist in <head>.
+     */
+    useLayoutEffect(() => {
+        if (!favicon) {
+            return;
+        }
 
-function PageHead({title, cluster}: {title: string; cluster?: string}) {
-    const {favicon} = getClusterAppearance(cluster) || {};
-
-    React.useLayoutEffect(() => {
-        const links = document.head.querySelectorAll<HTMLLinkElement>('link[rel="icon"]');
-        links.forEach((link) => link.parentNode?.removeChild(link));
-    }, []);
+        document.head
+            .querySelectorAll<HTMLLinkElement>('link[rel="icon"]:not([data-react-helmet])')
+            .forEach((link) => link.remove());
+    }, [favicon]);
 
     return (
         <Helmet>
-            <link rel="icon" href={favicon} />
             <title>{title}</title>
+            {favicon ? <link rel="icon" href={favicon} /> : null}
         </Helmet>
     );
 }
@@ -30,7 +32,9 @@ export default React.memo(PageHead);
 
 function PageHeadByClusterImpl({cluster}: {cluster: string}) {
     const title = useSelector((state: RootState) => state.global.title);
-    return <PageHead title={title} cluster={cluster} />;
+    const {favicon} = getClusterAppearance(cluster);
+
+    return <PageHead title={title} favicon={favicon} />;
 }
 
 export const PageHeadByCluster = React.memo(PageHeadByClusterImpl);


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/NygH72Fd7kwezB
<!-- nda-end -->

## Summary by Sourcery

Ensure cluster-based pages set and maintain a favicon correctly without removing valid icons from the document head.

New Features:
- Allow PageHead to accept an explicit favicon prop and render the icon conditionally based on its presence.

Bug Fixes:
- Prevent removal of non-react-helmet favicon links by only deleting stale template icons when a new favicon is provided.

Enhancements:
- Make cluster appearance favicons required and centralize favicon resolution in PageHeadByCluster.
- Refine cluster appearance caching logic to construct and store fully-resolved favicon-aware entries.