### PR TITLE
feat(Flow): state viewer [YTFRONT-9999]

### DIFF
--- a/packages/ui/src/ui/constants/index.ts
+++ b/packages/ui/src/ui/constants/index.ts
@@ -41,6 +41,14 @@ export const TYPED_OUTPUT_FORMAT = {
     },
 };
 
+export const TYPED_INPUT_FORMAT = {
+    $value: 'json' as const,
+    $attributes: {
+        stringify: true,
+        annotate_with_types: true,
+    },
+};
+
 // Menu
 const MENU_PREFIX = createPrefix('MENU');
 

--- a/packages/ui/src/ui/pages/flow/Flow/Flow.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/Flow.tsx
@@ -10,11 +10,7 @@ import StatusLabel from '../../../components/StatusLabel/StatusLabel';
 import Tabs from '../../../components/Tabs/Tabs';
 import {YTErrorInline} from '../../../containers/YTErrorInline/YTErrorInline';
 import {useUpdater} from '../../../hooks/use-updater';
-import format from '../../../common/hammer/format';
-import {
-    useFlowAttributes,
-    useFlowLeaderControllerName,
-} from '../../../pages/flow/flow-hooks/use-flow-attributes';
+import {useFlowAttributes} from '../../../pages/flow/flow-hooks/use-flow-attributes';
 import {loadFlowStatus, updateFlowState} from '../../../store/actions/flow/status';
 import {useFlowExecuteQuery} from '../../../store/api/yt/flow';
 import {FlowTab} from '../../../store/reducers/flow/filters';
@@ -40,6 +36,17 @@ import {getFlowPathMetaItems} from '../flow-components/FlowMeta/FlowMeta';
 
 const block = cn('yt-flow');
 
+type FlowPipelineExtraTab = {
+    value: string;
+    title: string;
+    component: React.ComponentType<{pipeline_path: string}>;
+};
+
+const getExtraTabs = () =>
+    (
+        UIFactory as {getFlowPipelineExtraTabs?: () => Array<FlowPipelineExtraTab>}
+    ).getFlowPipelineExtraTabs?.() ?? [];
+
 export function Flow() {
     const currentComputation = useSelector(selectFlowCurrentComputation);
     const worker = useSelector(selectFlowCurrentWorker);
@@ -63,18 +70,21 @@ export function FlowTabs() {
     const tabsProps = React.useMemo(() => {
         const {urlTemplate, component} = UIFactory.getMonitoringComponentForNavigationFlow() ?? {};
         const showSettings = {
-            [FlowTab.GRAPH]: {title: i18n('graph')},
-            [FlowTab.COMPUTATIONS]: {title: i18n('computations')},
-            [FlowTab.WORKERS]: {title: i18n('workers')},
-            [FlowTab.MONITORING]: {
-                show: Boolean(component || urlTemplate),
-                title: i18n('monitoring'),
-            },
-            [FlowTab.STATIC_SPEC]: {title: i18n('static-spec')},
-            [FlowTab.DYNAMIC_SPEC]: {title: i18n('dynamic-spec')},
+            [FlowTab.MONITORING]: {show: Boolean(component || urlTemplate)},
         };
 
-        return makeTabProps(`/${cluster}/${Page.FLOWS}`, FlowTab, showSettings);
+        const props = makeTabProps(`/${cluster}/${Page.FLOWS}`, FlowTab, showSettings);
+        const extraItems = getExtraTabs().map(({value, title}) => ({
+            value,
+            text: title,
+            url: `/${cluster}/${Page.FLOWS}/${value}`,
+            show: true,
+        }));
+        const monitoringIndex = props.items.findIndex(({value}) => value === FlowTab.MONITORING);
+        const insertAt = monitoringIndex === -1 ? props.items.length : monitoringIndex + 1;
+        const items = [...props.items];
+        items.splice(insertAt, 0, ...extraItems);
+        return {...props, items};
     }, [cluster]);
 
     return <Tabs className={block('tabs')} routed routedPreserveLocation {...tabsProps} />;
@@ -113,6 +123,13 @@ function FlowContent() {
                 path={`/:cluster/${Page.FLOWS}/${FlowTab.MONITORING}`}
                 render={() => <FlowMonitoring pipeline_path={path} />}
             />
+            {getExtraTabs().map(({value, component: TabComponent}) => (
+                <Route
+                    key={value}
+                    path={`/:cluster/${Page.FLOWS}/${value}`}
+                    render={() => <TabComponent pipeline_path={path} />}
+                />
+            ))}
             <Redirect to={`/:cluster/${Page.FLOWS}/${FlowTab.GRAPH}`} />
         </Switch>
     );
@@ -157,9 +174,6 @@ function FlowState() {
     const pipeline_path = useSelector(selectFlowPipelinePath);
     const value = useSelector(selectFlowStatusData);
     const {leader_controller_address} = useFlowAttributes(pipeline_path).data ?? {};
-    const {data: leaderName, errorContent: leaderError} = useFlowLeaderControllerName(
-        pipeline_path + '/flow_control',
-    );
     return (
         <React.Fragment>
             <Flex alignItems="baseline" justifyContent="space-between" gap={2}>
@@ -174,23 +188,6 @@ function FlowState() {
                     items={[
                         getFlowPathMetaItems(pipeline_path),
                         [
-                            {
-                                key: 'leader_controller_name',
-                                label: i18n('leader-controller-name'),
-                                value: leaderError ? (
-                                    leaderError
-                                ) : (
-                                    <>
-                                        {leaderName ?? format.NO_VALUE}
-                                        <ClipboardButton
-                                            view="flat-secondary"
-                                            text={leaderName}
-                                            inlineMargins
-                                        />
-                                    </>
-                                ),
-                                className: block('meta-item'),
-                            },
                             {
                                 key: 'leader_controller_address',
                                 label: i18n('leader-controller-address'),
@@ -262,7 +259,7 @@ function FlowMonitoring({pipeline_path}: {pipeline_path: string}) {
                     monitoring_project,
                 })}
             >
-                {title || i18n('monitoring')}
+                {title || 'Monitoring'}
             </Link>
         );
     } else {

--- a/packages/ui/src/ui/pages/flow/Flow/FlowComputation/FlowComputation.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowComputation/FlowComputation.tsx
@@ -15,7 +15,7 @@ import {filtersSlice} from '../../../../store/reducers/flow/filters';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {selectFlowPipelinePath} from '../../../../store/selectors/flow/filters';
 import {selectCluster} from '../../../../store/selectors/global/cluster';
-import UIFactory from '../../../../UIFactory';
+import UIFactory, {type FlowComputationMonitorProps} from '../../../../UIFactory';
 import './FlowComputation.scss';
 import {FlowComputationPartitions} from './FlowComputationPartitions';
 import {FlowComputationPerformance} from './FlowComputationPerformance/FlowComputationPerformance';
@@ -23,6 +23,17 @@ import {FlowPartition} from './FlowPartition/FlowPartition';
 import i18n from './i18n';
 
 const block = cn('yt-flow-computation');
+
+type FlowComputationExtraTab = {
+    value: string;
+    title: string;
+    component: React.ComponentType<FlowComputationMonitorProps>;
+};
+
+const getExtraTabs = () =>
+    (
+        UIFactory as {getFlowComputationExtraTabs?: () => Array<FlowComputationExtraTab>}
+    ).getFlowComputationExtraTabs?.() ?? [];
 
 export function FlowComputation() {
     const dispatch = useDispatch();
@@ -41,6 +52,7 @@ export function FlowComputation() {
     }, [computation, dispatch]);
 
     const monitoringComponent = UIFactory.getMonitoringComponentForFlowComputation();
+    const extraTabs = getExtraTabs();
 
     return (
         <div className={block()}>
@@ -58,13 +70,44 @@ export function FlowComputation() {
                         render={() => <FlowComputationMonitor computation={computation} />}
                     />
                 )}
+                {extraTabs.map((tab) => (
+                    <Route
+                        key={tab.value}
+                        exact
+                        path={`${path}/${tab.value}`}
+                        render={() => (
+                            <FlowComputationExtraTabView computation={computation} tab={tab} />
+                        )}
+                    />
+                ))}
             </Switch>
+        </div>
+    );
+}
+
+function FlowComputationExtraTabView({
+    computation,
+    tab,
+}: {
+    computation: string;
+    tab: FlowComputationExtraTab;
+}) {
+    const pipeline_path = useSelector(selectFlowPipelinePath);
+    const {data} = useFlowComputationData({computation, pipeline_path});
+    const TabComponent = tab.component;
+
+    return (
+        <div className={block()}>
+            <FlowEntityTitle title={computation} status={data?.status} />
+            <FlowComputationTabs computation={computation} />
+            <TabComponent path={pipeline_path} computation={computation} />
         </div>
     );
 }
 
 function FlowComputationTabs({computation}: {computation: string}) {
     const cluster = useSelector(selectCluster);
+    const extraTabs = getExtraTabs();
 
     return (
         <Tabs
@@ -87,6 +130,12 @@ function FlowComputationTabs({computation}: {computation: string}) {
                     url: `/${cluster}/${Page.FLOWS}/computations/${encodeURIComponent(computation)}/monitor`,
                     show: true,
                 },
+                ...extraTabs.map((tab) => ({
+                    value: tab.value,
+                    text: tab.title,
+                    url: `/${cluster}/${Page.FLOWS}/computations/${encodeURIComponent(computation)}/${tab.value}`,
+                    show: true,
+                })),
             ]}
         />
     );


### PR DESCRIPTION
Supersedes #1733

## Summary by Sourcery

Add extensible extra tabs for flow pipelines and computations and adjust flow metadata and constants to support new monitoring and input format capabilities.

New Features:
- Allow UIFactory to provide additional tabs for flow pipeline view, including routing and tab configuration.
- Allow UIFactory to provide additional tabs for flow computation view, with corresponding routes and a shared layout for custom monitors.
- Introduce a typed input format constant for JSON requests with stringification and type annotations.

Enhancements:
- Simplify flow monitoring tab configuration and label handling.
- Streamline flow state metadata by removing leader controller name display.