### PR TITLE
feat(Queries/Navigation): add external schema columns [YTFRONT-5891]

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -86,7 +86,7 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/type-is": "^1.6.3",
         "@vitejs/plugin-react": "^4.6.0",
-        "@ytsaurus/components": "^1.1.0",
+        "@ytsaurus/components": "^1.2.0",
         "bem-cn-lite": "^4.1.0",
         "bignumber.js": "^9.1.2",
         "colord": "^2.9.1",
@@ -13835,9 +13835,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ytsaurus/components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ytsaurus/components/-/components-1.1.0.tgz",
-      "integrity": "sha512-BbyltUDlkjMxC3ygueJhcr0CD72xQmZpOiDUGuFWsXpFZCvjDrSS2Io7cokYzkM/QUJoeW0fBxexkuuEDimoLw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ytsaurus/components/-/components-1.2.0.tgz",
+      "integrity": "sha512-qQqPBM7rkJRsXgSs8seA+C7ADcYAcM4+rgvatI5Cct7UO/9M/O92AR+LJJIxqoBIut2J+9+4rkF2uSXaUBjDgw==",
       "dev": true,
       "dependencies": {
         "@gravity-ui/i18n": "^1.8.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -153,7 +153,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/type-is": "^1.6.3",
     "@vitejs/plugin-react": "^4.6.0",
-    "@ytsaurus/components": "^1.1.0",
+    "@ytsaurus/components": "^1.2.0",
     "bem-cn-lite": "^4.1.0",
     "bignumber.js": "^9.1.2",
     "colord": "^2.9.1",

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/NavigationTable.tsx
@@ -2,6 +2,7 @@ import React, {type FC, useCallback} from 'react';
 import {useDispatch, useSelector} from '../../../../store/redux-hooks';
 import {NavigationTable as NavigationTableComponent} from '@ytsaurus/components/modules';
 import {
+    selectNavigationCluster,
     selectNavigationClusterConfig,
     selectNavigationFilter,
     selectNavigationPath,
@@ -16,17 +17,21 @@ import {createTableSelect} from '../helpers/createTableSelect';
 import {insertTextWhereCursor} from '../helpers/insertTextWhereCursor';
 import {rumLogError} from '../../../../rum/rum-counter';
 import ErrorBoundary from '../../../../containers/ErrorBoundary/ErrorBoundary';
+import {useExternalSchemaColumns} from './useExternalSchemaColumns';
 
 export const NavigationTable: FC = () => {
     const dispatch = useDispatch();
     const ysonSettings = useSelector(selectYsonSettingsDisableDecode);
     const clusterConfig = useSelector(selectNavigationClusterConfig);
+    const cluster = useSelector(selectNavigationCluster);
     const table = useSelector(selectNavigationTable);
     const engine = useSelector(selectQueryEngine);
     const limit = useSelector(selectPageSize);
     const path = useSelector(selectNavigationPath);
     const filter = useSelector(selectNavigationFilter);
     const {getEditor} = useMonaco();
+
+    const additionalSchemaColumns = useExternalSchemaColumns(cluster, path);
 
     const handleInsertTableSelect = useCallback(async () => {
         if (!clusterConfig) return;
@@ -49,6 +54,7 @@ export const NavigationTable: FC = () => {
             onFilterChange={handleFilterChange}
             onInsertTableSelect={handleInsertTableSelect}
             ysonSettings={ysonSettings}
+            additionalSchemaColumns={additionalSchemaColumns}
             logError={rumLogError}
             ErrorBoundaryComponent={ErrorBoundary}
         />

--- a/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/useExternalSchemaColumns.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Navigation/NavigationTable/useExternalSchemaColumns.tsx
@@ -1,0 +1,91 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import type {ExternalSchemaColumn} from '@ytsaurus/components/modules';
+
+import UIFactory from '../../../../UIFactory';
+import type {ExternalSchemaDescriptionResponse} from '../../../../UIFactory';
+import type {ExternalSchemaDescription} from '../../../navigation/tabs/Schema/ExternalDescription/ExternalDescription';
+import {ExternalDescription} from '../../../navigation/tabs/Schema/ExternalDescription/ExternalDescription';
+import Icon from '../../../../components/Icon/Icon';
+import {RoutedLink} from '../../../../containers/RoutedLink/RoutedLink';
+import ErrorIcon from '../../../../components/ErrorIcon/ErrorIcon';
+import type {YTError} from '@ytsaurus/components';
+
+const EXTERNAL_COLUMNS = ['title', 'description'] as const;
+
+type ExternalColumn = (typeof EXTERNAL_COLUMNS)[number];
+
+type State = {
+    externalSchema?: Map<string, ExternalSchemaDescription>;
+    externalSchemaUrl?: string;
+    externalSchemaError?: YTError;
+};
+
+const renderHeader = (caption: string, url?: string, error?: YTError) => (
+    <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+        <span>{caption}</span>
+        {url ? (
+            <RoutedLink href={url} target="_blank" disablePreserveLocation>
+                <Icon awesome="external-link" />
+            </RoutedLink>
+        ) : null}
+        {error ? <ErrorIcon error={error} /> : null}
+    </div>
+);
+
+export function useExternalSchemaColumns(
+    cluster?: string,
+    path?: string,
+): ExternalSchemaColumn[] | undefined {
+    const [state, setState] = useState<State>({});
+
+    useEffect(() => {
+        let cancelled = false;
+
+        if (!cluster || !path) {
+            setState({});
+            return undefined;
+        }
+
+        UIFactory.externalSchemaDescriptionSetup
+            .load(cluster, path)
+            .then(({url, externalSchema}: ExternalSchemaDescriptionResponse) => {
+                if (!cancelled) {
+                    setState({externalSchemaUrl: url, externalSchema});
+                }
+            })
+            .catch((error: YTError) => {
+                if (!cancelled) {
+                    setState({externalSchema: new Map(), externalSchemaError: error});
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [cluster, path]);
+
+    const {externalSchema, externalSchemaUrl, externalSchemaError} = state;
+
+    return useMemo(() => {
+        if (!externalSchema) {
+            return undefined;
+        }
+
+        const {columns} = UIFactory.externalSchemaDescriptionSetup;
+
+        return EXTERNAL_COLUMNS.map((column: ExternalColumn): ExternalSchemaColumn => {
+            const caption = columns?.[column] ?? `External ${column}`;
+            return {
+                name: column,
+                header: renderHeader(caption, externalSchemaUrl, externalSchemaError),
+                sortable: false,
+                render: ({row}) => {
+                    const data = externalSchema.get(row.name);
+                    return data ? (
+                        <ExternalDescription type={row.type} data={data} column={column} />
+                    ) : null;
+                },
+            };
+        });
+    }, [externalSchema, externalSchemaUrl, externalSchemaError]);
+}


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Wze5W9wo7k5BX9
<!-- nda-end --> ## Summary by Sourcery

Extend navigation query table to display external schema metadata for columns using data loaded from UIFactory.

New Features:
- Add support for external schema-based columns (title and description) in navigation query table using a reusable hook.
- Fetch and render external schema descriptions per column with links to the source schema and inline error indication.

Enhancements:
- Update @ytsaurus/components dependency to a newer minor version to enable external schema column support.