### PR TITLE
fix(MetaTable): template component lost className [YTFRONT-5942]

### DIFF
--- a/packages/components/src/components/MetaTable/templates/TemplateFormattedValue.tsx
+++ b/packages/components/src/components/MetaTable/templates/TemplateFormattedValue.tsx
@@ -1,8 +1,7 @@
 import type {ReactNode} from 'react';
-import cn from 'bem-cn-lite';
 import {format as hammerFormat} from '../../../utils';
 
-const block = cn('meta-table-item');
+import {metaTableItemBlock} from '../utils';
 
 type FormatSettings = Record<string, unknown>;
 
@@ -24,7 +23,7 @@ export function TemplateFormattedValue({value, format, settings}: Props) {
     const formatFn = isFn ? format : hammerFormat[format as keyof typeof hammerFormat];
 
     return (
-        <span className={block('value', {format: formatModifier})}>
+        <span className={metaTableItemBlock('value', {format: formatModifier})}>
             {formatFn(value, settings)}
         </span>
     );

--- a/packages/components/src/components/MetaTable/templates/TemplateId.tsx
+++ b/packages/components/src/components/MetaTable/templates/TemplateId.tsx
@@ -2,13 +2,15 @@ import {Flex, Text} from '@gravity-ui/uikit';
 
 import {ClipboardButton} from '../../ClipboardButton';
 
+import {metaTableItemBlock} from '../utils';
+
 type Props = {
     id: string;
 };
 
 export function TemplateId({id}: Props) {
     return (
-        <Flex gap={1} wrap="nowrap" alignItems="center">
+        <Flex gap={1} wrap="nowrap" alignItems="center" className={metaTableItemBlock('id')}>
             <Text ellipsis>{id}</Text>
             <ClipboardButton view="flat-secondary" text={id} size="s" />
         </Flex>

--- a/packages/components/src/components/MetaTable/templates/TemplateLink.tsx
+++ b/packages/components/src/components/MetaTable/templates/TemplateLink.tsx
@@ -4,6 +4,8 @@ import {Flex, Icon, type IconData, Link, Text} from '@gravity-ui/uikit';
 
 import {ClipboardButton} from '../../ClipboardButton';
 
+import {metaTableItemBlock} from '../utils';
+
 type Props = {
     url: string;
     text: string;
@@ -24,7 +26,13 @@ export function TemplateLink({
     maxWidth,
 }: Props) {
     return (
-        <Flex gap={1} wrap="nowrap" alignItems="center" style={{maxWidth}}>
+        <Flex
+            gap={1}
+            wrap="nowrap"
+            alignItems="center"
+            className={metaTableItemBlock('link')}
+            style={{maxWidth}}
+        >
             <Text ellipsis>
                 <Link title={url} href={url}>
                     {IconComponent && <Icon data={IconComponent} size={14} />}

--- a/packages/components/src/components/MetaTable/templates/TemplateReadable.tsx
+++ b/packages/components/src/components/MetaTable/templates/TemplateReadable.tsx
@@ -1,9 +1,15 @@
 import {format as hammerFormat} from '../../../utils';
 
+import {metaTableItemBlock} from '../utils';
+
 type Props = {
     value?: string;
 };
 
 export function TemplateReadable({value = hammerFormat.NO_VALUE}: Props) {
-    return <span>{hammerFormat['ReadableField'](value)}</span>;
+    return (
+        <span className={metaTableItemBlock('readable')}>
+            {hammerFormat['ReadableField'](value)}
+        </span>
+    );
 }

--- a/packages/components/src/components/MetaTable/templates/TemplateTime.tsx
+++ b/packages/components/src/components/MetaTable/templates/TemplateTime.tsx
@@ -1,9 +1,7 @@
-import cn from 'bem-cn-lite';
-
 import {Flex, Text as GravityText} from '@gravity-ui/uikit';
 import {format} from '../../../utils';
 
-const itemBlock = cn('meta-table-item');
+import {metaTableItemBlock} from '../utils';
 
 export type ValueFormat = 'DateTime' | 'TimeDuration' | 'DateTimeTwoLines';
 
@@ -35,7 +33,7 @@ export function TemplateTime<T extends ValueFormat = 'DateTime'>({
     settings,
     ...rest
 }: TemplateTimeProps<T>) {
-    const className = itemBlock('time', rest.className);
+    const className = metaTableItemBlock('time', rest.className);
 
     if (valueFormat === 'DateTimeTwoLines') {
         const title = format['DateTime'](time, settings);

--- a/packages/components/src/components/MetaTable/utils.ts
+++ b/packages/components/src/components/MetaTable/utils.ts
@@ -1,0 +1,3 @@
+import cn from 'bem-cn-lite';
+
+export const metaTableItemBlock: ReturnType<typeof cn> = cn('meta-table-item');


### PR DESCRIPTION
## Summary by Sourcery

Restore and standardize MetaTable item styling by wiring template components to a shared BEM class helper.

Bug Fixes:
- Fix missing CSS classes on MetaTable link, readable text, time, formatted value, and ID templates so their styles are correctly applied.

Enhancements:
- Introduce a shared metaTableItemBlock BEM utility for MetaTable item templates to centralize class name generation.