### PR TITLE
chore(System): minor fix for i18n [YTFRONT-5069]

### DIFF
--- a/packages/ui/src/ui/pages/system/Masters/InstanceState/i18n/en.json
+++ b/packages/ui/src/ui/pages/system/Masters/InstanceState/i18n/en.json
@@ -1,4 +1,7 @@
 {
+  "value_active": "Active",
+  "value_connected": "Connected",
+  "value_disconnected": "Disconnected",
   "value_elections": "Elections",
   "value_follower_recovery": "Follower recovery",
   "value_following": "Following",
@@ -6,6 +9,7 @@
   "value_leading": "Leading",
   "value_offline": "Offline",
   "value_online": "Online",
+  "value_standby": "Standby",
   "value_stopped": "Stopped",
   "value_unknown": "Unknown"
 }

--- a/packages/ui/src/ui/pages/system/SchedulersAndAgents/Scheduler/Scheduler.tsx
+++ b/packages/ui/src/ui/pages/system/SchedulersAndAgents/Scheduler/Scheduler.tsx
@@ -14,6 +14,7 @@ import {ChangeMaintenanceButton} from '../../Masters/ChangeMaintenanceButton';
 import {makeShortSystemAddress} from '../../helpers/makeShortSystemAddress';
 import {useDispatch} from '../../../../store/redux-hooks';
 import {changeSchedulerMaintenance} from '../../../../store/actions/system/schedulers';
+import {InstanceState} from '../../Masters/InstanceState/InstanceState';
 
 const b = block('system');
 
@@ -60,7 +61,9 @@ export default function Scheduler({
         <div className={b('scheduler')}>
             <NodeQuad theme={theme} />
 
-            <div className={b('scheduler-status')}>{hammer.format['ReadableField'](state)}</div>
+            <div className={b('scheduler-status')}>
+                <InstanceState state={state} />
+            </div>
 
             <div className={b('maintenance')}>
                 {maintenanceMessage && (

--- a/packages/ui/src/ui/store/selectors/system/masters.ts
+++ b/packages/ui/src/ui/store/selectors/system/masters.ts
@@ -7,7 +7,14 @@ import {
 import {type RootState} from '../../reducers';
 import {getPathByMasterType} from '../../actions/system/masters';
 
-export type MasterInstanceState = MasterAddress['state'] | MasterDataItem['state'];
+type QueueAgentState = 'active' | 'standby';
+type SchedulerState = 'connected' | 'disconnected';
+
+export type MasterInstanceState =
+    | MasterAddress['state']
+    | MasterDataItem['state']
+    | QueueAgentState
+    | SchedulerState;
 
 export class MasterInstance {
     $attributes: {


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/elBfz45x7maKmS
<!-- nda-end -->## Summary by Sourcery

Unify and extend master instance state handling to support scheduler and queue agent states, and use the shared InstanceState component to render scheduler status.

Enhancements:
- Extend the master instance state type to include queue agent and scheduler-specific states.
- Update scheduler UI to render its status via the shared InstanceState component for consistent i18n-aware state display.