### PR TITLE
feat(Flow/Graph): add partitions distribution dialog for computation nodes [#1753]

### DIFF
--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/FlowGraph.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/FlowGraph.tsx
@@ -198,7 +198,14 @@ function FlowGraphDataButton() {
 function renderContent({item, ...rest}: {item: FlowGraphBlock; detailed?: boolean}) {
     switch (item.is) {
         case 'computation':
-            return <Computation className={block('item')} item={item} {...rest} />;
+            return (
+                <Computation
+                    className={block('item')}
+                    item={item}
+                    showPartitionsDistribution
+                    {...rest}
+                />
+            );
         case 'stream':
             return <Stream className={block('item')} item={item} {...rest} />;
         case 'computation-group':

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/i18n/en.json
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/i18n/en.json
@@ -4,5 +4,6 @@
   "context_high-consumption": "High consumption",
   "field_zoom-to": "Zoom to:",
   "action_graph-data": "Graph data",
-  "action_messages": "Messages ({{count}})"
+  "action_messages": "Messages ({{count}})",
+  "action_partitions-distribution": "Partitions distribution"
 }

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/Computation.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/Computation.tsx
@@ -1,4 +1,6 @@
-import {Flex, Progress, type ProgressTheme, Text} from '@gravity-ui/uikit';
+import {ChartColumn} from '@gravity-ui/icons';
+import {Button, Flex, Icon, Progress, type ProgressTheme, Text} from '@gravity-ui/uikit';
+import {Tooltip} from '@ytsaurus/components';
 import cn from 'bem-cn-lite';
 import React from 'react';
 import {type FlowComputationType} from '../../../../../../shared/yt-types';
@@ -10,6 +12,7 @@ import {selectFlowPipelinePath} from '../../../../../store/selectors/flow/filter
 import {makeFlowLink} from '../../../../../utils/app-url';
 import {addProgressStackSpacers} from '../../../../../utils/progress';
 import {type FlowGraphBlockItem} from '../FlowGraph';
+import i18n from '../i18n';
 import './Computation.scss';
 import {
     FlowCaption1,
@@ -18,6 +21,7 @@ import {
     TextWithHighConsumption,
 } from './FlowGraphRenderer';
 import {FlowMeta} from './FlowMeta';
+import {useFlowPartitionsDistributionDialogContext} from './FlowPartitionsDistributionDialogContext/FlowPartitionsDistributionDialogContext';
 
 const block = cn('yt-flow-computation');
 
@@ -26,10 +30,17 @@ type ComputationProps = {
 
     detailed?: boolean;
 
+    showPartitionsDistribution?: boolean;
+
     item: Omit<FlowGraphBlockItem<'computation'>, 'is'>;
 };
 
-export function Computation({detailed, item, className}: ComputationProps) {
+export function Computation({
+    detailed,
+    item,
+    className,
+    showPartitionsDistribution,
+}: ComputationProps) {
     const path = useSelector(selectFlowPipelinePath);
 
     const {cpu_usage, memory_usage, highlight_cpu_usage, hightlight_memory_usage} = item.meta ?? {};
@@ -87,7 +98,10 @@ export function Computation({detailed, item, className}: ComputationProps) {
                     },
                 ]}
             />
-            <ComputaionProgress stats={item.meta?.partitions_stats} />
+            <ComputaionProgress
+                stats={item.meta?.partitions_stats}
+                computationId={showPartitionsDistribution ? item.name : undefined}
+            />
             {detailed && <FlowMessages data={item.meta.messages} />}
         </div>
     );
@@ -95,6 +109,7 @@ export function Computation({detailed, item, className}: ComputationProps) {
 
 type ComputationProgressProps = {
     stats?: FlowComputationType['partitions_stats'];
+    computationId?: string;
 };
 
 type FlowComputationPartitionStates = keyof Required<
@@ -107,7 +122,8 @@ const STATE_TO_THEME: Record<FlowComputationPartitionStates, ProgressTheme> = {
     interrupted: 'default',
 };
 
-function ComputaionProgress({stats}: ComputationProgressProps) {
+function ComputaionProgress({stats, computationId}: ComputationProgressProps) {
+    const {setVisibleDistribution} = useFlowPartitionsDistributionDialogContext();
     const {count = NaN, count_by_state} = stats ?? {};
     const {stack, history} = React.useMemo(() => {
         const history: ComputationProgressHistoryProps['data'] = [];
@@ -132,6 +148,18 @@ function ComputaionProgress({stats}: ComputationProgressProps) {
                         partitions
                     </Text>
                 </FlowCaption2>
+                {computationId !== undefined && count > 0 && (
+                    <Tooltip content={i18n('action_partitions-distribution')}>
+                        <Button
+                            view="flat-secondary"
+                            size="xs"
+                            onClick={() => setVisibleDistribution(computationId)}
+                            extraProps={{'aria-label': i18n('action_partitions-distribution')}}
+                        >
+                            <Icon data={ChartColumn} size={12} />
+                        </Button>
+                    </Tooltip>
+                )}
                 <ComputationProgressHistory data={history} />
             </Flex>
         </div>

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/FlowPartitionsDistributionDialogContext.scss
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/FlowPartitionsDistributionDialogContext.scss
@@ -1,0 +1,14 @@
+.yt-flow-partitions-distribution {
+    &__dialog {
+        max-height: 90vh;
+    }
+
+    &__body {
+        min-width: 50vw;
+        overflow: auto;
+    }
+
+    &__chart {
+        height: 320px;
+    }
+}

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/FlowPartitionsDistributionDialogContext.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/FlowPartitionsDistributionDialogContext.tsx
@@ -1,0 +1,120 @@
+import {Flex, SegmentedRadioGroup, Text} from '@gravity-ui/uikit';
+import cn from 'bem-cn-lite';
+import React from 'react';
+import format from '../../../../../../common/hammer/format';
+import {DialogWrapper} from '../../../../../../components/DialogWrapper/DialogWrapper';
+import Loader from '../../../../../../components/Loader/Loader';
+import {YTChartKitHistogram} from '../../../../../../components/YTChartKit';
+import {FlowError} from '../../../../../../pages/flow/flow-components/FlowError/FlowError';
+import {useFlowExecuteQuery} from '../../../../../../store/api/yt';
+import {useSelector} from '../../../../../../store/redux-hooks';
+import {selectFlowPipelinePath} from '../../../../../../store/selectors/flow/filters';
+import './FlowPartitionsDistributionDialogContext.scss';
+import i18n from './i18n';
+
+const block = cn('yt-flow-partitions-distribution');
+
+const METRICS = ['cpu_usage', 'memory_usage', 'messages_per_second', 'bytes_per_second'] as const;
+type DistributionMetric = (typeof METRICS)[number];
+
+type FlowPartitionsDistributionDialogContextValue = {
+    computationId?: string;
+    setVisibleDistribution: (computationId?: string) => void;
+};
+
+const FlowPartitionsDistributionDialogCtx =
+    React.createContext<FlowPartitionsDistributionDialogContextValue>({
+        computationId: undefined,
+        setVisibleDistribution: () => {},
+    });
+
+export function useFlowPartitionsDistributionDialogContext() {
+    const {setVisibleDistribution} = React.useContext(FlowPartitionsDistributionDialogCtx);
+    return {setVisibleDistribution};
+}
+
+export function FlowPartitionsDistributionDialogContext({children}: {children: React.ReactNode}) {
+    const [computationId, setVisibleDistribution] = React.useState<string>();
+    return (
+        <FlowPartitionsDistributionDialogCtx.Provider
+            value={{computationId, setVisibleDistribution}}
+        >
+            {children}
+            {computationId && (
+                <DialogWrapper
+                    className={block('dialog')}
+                    open={true}
+                    onClose={() => setVisibleDistribution(undefined)}
+                >
+                    <DialogWrapper.Header
+                        caption={i18n('title_distribution', {computation: computationId})}
+                    />
+                    <DialogWrapper.Body className={block('body')}>
+                        <FlowPartitionsDistributionContent computationId={computationId} />
+                    </DialogWrapper.Body>
+                </DialogWrapper>
+            )}
+        </FlowPartitionsDistributionDialogCtx.Provider>
+    );
+}
+
+function FlowPartitionsDistributionContent({computationId}: {computationId: string}) {
+    const pipeline_path = useSelector(selectFlowPipelinePath);
+    const [metric, setMetric] = React.useState<DistributionMetric>('cpu_usage');
+
+    const {data, error, isLoading} = useFlowExecuteQuery<'describe-computation'>({
+        parameters: {
+            flow_command: 'describe-computation',
+            pipeline_path,
+        },
+        body: {
+            computation_id: computationId,
+        },
+    });
+
+    const {values, allEqual} = React.useMemo(() => {
+        const res = (data?.partitions?.map((partition) => partition[metric]) ?? []).filter(
+            Number.isFinite,
+        );
+        return {values: res, allEqual: res.every((value) => value === res[0])};
+    }, [data, metric]);
+
+    if (isLoading) {
+        return <Loader visible centered />;
+    }
+
+    if (error) {
+        return <FlowError error={error} />;
+    }
+
+    return (
+        <Flex direction="column" gap={3}>
+            <Flex gap={4} alignItems="center">
+                <SegmentedRadioGroup<DistributionMetric>
+                    value={metric}
+                    onUpdate={setMetric}
+                    options={METRICS.map((value) => ({value, content: i18n(value)}))}
+                />
+                <Text color="secondary">
+                    {i18n('context_partitions-count', {count: values.length})}
+                </Text>
+            </Flex>
+            <div className={block('chart')}>
+                {!values.length ? (
+                    <Text color="secondary">{i18n('context_no-partitions')}</Text>
+                ) : allEqual ? (
+                    <Text color="secondary">
+                        {i18n('context_all-values-equal', {
+                            value: format.Number(values[0], {digits: 2}),
+                        })}
+                    </Text>
+                ) : (
+                    <YTChartKitHistogram
+                        data={values}
+                        xPlotLines={{average: data?.performance_metrics?.average?.[metric]}}
+                    />
+                )}
+            </div>
+        </Flex>
+    );
+}

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/i18n/dicts.ts
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/i18n/dicts.ts
@@ -1,0 +1,3 @@
+import en from './en.json';
+
+export default {en};

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/i18n/en.json
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/i18n/en.json
@@ -1,0 +1,10 @@
+{
+  "title_distribution": "Partitions distribution: {{computation}}",
+  "context_partitions-count": "{{count}} partitions",
+  "context_no-partitions": "There are no partitions to display",
+  "context_all-values-equal": "All partitions have the same value: {{value}}",
+  "cpu_usage": "CPU usage",
+  "memory_usage": "Memory usage",
+  "messages_per_second": "Messages per second",
+  "bytes_per_second": "Bytes per second"
+}

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/i18n/index.ts
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/i18n/index.ts
@@ -1,0 +1,5 @@
+import {addI18Keysets} from '../../../../../../../i18n';
+
+import dicts from './dicts';
+
+export default addI18Keysets('yt:flow-partitions-distribution-dialog-context', dicts);

--- a/packages/ui/src/ui/pages/flow/FlowPage/FlowPage.tsx
+++ b/packages/ui/src/ui/pages/flow/FlowPage/FlowPage.tsx
@@ -4,6 +4,7 @@ import cn from 'bem-cn-lite';
 import {Flow} from '../../../pages/flow/Flow';
 import './FlowPage.scss';
 import {FlowMessagesDialogContext} from '../Flow/FlowGraph/renderers/FlowMessagesDialogContext/FlowMessagesDialogContext';
+import {FlowPartitionsDistributionDialogContext} from '../Flow/FlowGraph/renderers/FlowPartitionsDistributionDialogContext/FlowPartitionsDistributionDialogContext';
 
 const block = cn('yt-flow-page');
 
@@ -11,7 +12,9 @@ export function FlowPage() {
     return (
         <div className={block(null, 'elements-main-section')}>
             <FlowMessagesDialogContext>
-                <Flow />
+                <FlowPartitionsDistributionDialogContext>
+                    <Flow />
+                </FlowPartitionsDistributionDialogContext>
             </FlowMessagesDialogContext>
         </div>
     );


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/mzLolgBR7n5kKi
<!-- nda-end --> Closes #1753.

Adds a chart-icon button next to the partition counter on every computation node of the Flow **Graph** page (both the node overlay and the hover popup). Clicking it opens a dialog with a histogram of the selected metric over all partitions of that computation:

- metric switcher: CPU usage / Memory usage / Messages per second / Bytes per second;
- the computation average is drawn as a vertical plot line;
- degenerate cases (no partitions; all values equal / single partition) show a text summary instead of a chart.

Data comes from the existing `describe-computation` command — no backend changes. The dialog follows the `FlowMessagesDialogContext` pattern (provider at `FlowPage` root), the chart reuses `YTChartKitHistogram`. The button is rendered only for real computation nodes, not for computation groups.

Based on `ui-v3.21.1` (the current arc `ytsaurus_base_branch` pin) so an internal stand can build against this PR head.

## Summary by Sourcery

Add a partitions distribution dialog for individual computations on the Flow Graph, showing per-partition metrics in a histogram with a metric selector and average line, opened via a chart button on computation nodes.

New Features:
- Introduce a Flow partitions distribution dialog that visualizes per-partition metrics (CPU, memory, messages per second, bytes per second) for a selected computation.
- Add a chart icon control to computation nodes in the Flow Graph to open the partitions distribution dialog when partition stats are available.

Enhancements:
- Wire a dedicated FlowPartitionsDistributionDialogContext at the Flow page level to manage visibility and data fetching for the new distribution dialog.
- Reuse existing describe-computation query and YTChartKitHistogram component to display partition distributions, with graceful handling of empty or degenerate datasets.