### PR TITLE
chore(lint): fix 'no-param-reassign' warnings [YTFRONT-5587]

### DIFF
--- a/packages/ui/src/server/controllers/clusters.ts
+++ b/packages/ui/src/server/controllers/clusters.ts
@@ -21,20 +21,20 @@ export function clusterAuthStatus(req: Request, res: Response) {
     if (allowPasswordAuth) {
         const clusters = getClustersFromConfig();
 
-        data = Object.keys(clusters).reduce((ret, cluster) => {
-            ret[cluster] = {
+        data = Object.keys(clusters).reduce((accRet, cluster) => {
+            accRet[cluster] = {
                 authorized: Boolean(req.cookies[makeAuthClusterCookieName(cluster)]),
             };
 
-            return ret;
+            return accRet;
         }, {} as ClusterAuthStatus);
     } else {
         const clusters = getClustersFromConfig();
 
-        data = Object.keys(clusters).reduce((ret, clusterName) => {
-            ret[clusterName] = {authorized: true};
+        data = Object.keys(clusters).reduce((accRet, clusterName) => {
+            accRet[clusterName] = {authorized: true};
 
-            return ret;
+            return accRet;
         }, {} as ClusterAuthStatus);
     }
 

--- a/packages/ui/src/server/controllers/login.ts
+++ b/packages/ui/src/server/controllers/login.ts
@@ -48,9 +48,9 @@ export async function handleLogin(req: Request, res: Response) {
                     res,
                     response,
                     undefined,
-                    (headers: Record<string, string[]>) => {
-                        if (headers['set-cookie']) {
-                            headers['set-cookie'] = headers['set-cookie'].reduce<string[]>(
+                    (accHeaders: Record<string, string[]>) => {
+                        if (accHeaders['set-cookie']) {
+                            accHeaders['set-cookie'] = accHeaders['set-cookie'].reduce<string[]>(
                                 (ret, item) => {
                                     ret.push(item);
 
@@ -69,7 +69,7 @@ export async function handleLogin(req: Request, res: Response) {
                             );
                         }
 
-                        return removeSecureFlagIfOriginInsecure(req, headers);
+                        return removeSecureFlagIfOriginInsecure(req, accHeaders);
                     },
                 );
                 if (!pipedSize) {

--- a/packages/ui/src/server/controllers/login.ts
+++ b/packages/ui/src/server/controllers/login.ts
@@ -48,28 +48,27 @@ export async function handleLogin(req: Request, res: Response) {
                     res,
                     response,
                     undefined,
-                    (accHeaders: Record<string, string[]>) => {
-                        if (accHeaders['set-cookie']) {
-                            accHeaders['set-cookie'] = accHeaders['set-cookie'].reduce<string[]>(
-                                (ret, item) => {
-                                    ret.push(item);
+                    (draftHeaders: Record<string, string[]>) => {
+                        if (draftHeaders['set-cookie']) {
+                            draftHeaders['set-cookie'] = draftHeaders['set-cookie'].reduce<
+                                string[]
+                            >((ret, item) => {
+                                ret.push(item);
 
-                                    if (item.startsWith(YT_CYPRESS_COOKIE_NAME)) {
-                                        ret.push(
-                                            item.replace(
-                                                YT_CYPRESS_COOKIE_NAME,
-                                                makeAuthClusterCookieName(ytAuthCluster),
-                                            ),
-                                        );
-                                    }
+                                if (item.startsWith(YT_CYPRESS_COOKIE_NAME)) {
+                                    ret.push(
+                                        item.replace(
+                                            YT_CYPRESS_COOKIE_NAME,
+                                            makeAuthClusterCookieName(ytAuthCluster),
+                                        ),
+                                    );
+                                }
 
-                                    return ret;
-                                },
-                                [],
-                            );
+                                return ret;
+                            }, []);
                         }
 
-                        return removeSecureFlagIfOriginInsecure(req, accHeaders);
+                        return removeSecureFlagIfOriginInsecure(req, draftHeaders);
                     },
                 );
                 if (!pipedSize) {

--- a/packages/ui/src/server/utils/configs/apply-missing-fields.ts
+++ b/packages/ui/src/server/utils/configs/apply-missing-fields.ts
@@ -1,12 +1,12 @@
-export function applyMissingFields<T extends object>(accDst: T, src: Partial<T>) {
+export function applyMissingFields<T extends object>(draftDst: T, src: Partial<T>) {
     Object.keys(src).forEach((k) => {
         const key = k as keyof typeof src;
-        if (key in accDst) {
+        if (key in draftDst) {
             return;
         } else {
             const v = src[key];
             if (v !== undefined) {
-                accDst[key] = v;
+                draftDst[key] = v;
             }
         }
     });

--- a/packages/ui/src/server/utils/configs/apply-missing-fields.ts
+++ b/packages/ui/src/server/utils/configs/apply-missing-fields.ts
@@ -1,12 +1,12 @@
-export function applyMissingFields<T extends object>(dst: T, src: Partial<T>) {
+export function applyMissingFields<T extends object>(accDst: T, src: Partial<T>) {
     Object.keys(src).forEach((k) => {
         const key = k as keyof typeof src;
-        if (key in dst) {
+        if (key in accDst) {
             return;
         } else {
             const v = src[key];
             if (v !== undefined) {
-                dst[key] = v;
+                accDst[key] = v;
             }
         }
     });

--- a/packages/ui/src/server/utils/index.ts
+++ b/packages/ui/src/server/utils/index.ts
@@ -170,7 +170,7 @@ export async function pipeReadableToWriteable(
             pipedDataSize += chunk?.length;
         });
         src.on('error', (e: any) => {
-            resolve = () => {};
+            resolve = () => {}; // eslint-disable-line no-param-reassign
             reject(e);
         });
         src.on('close', () => {

--- a/packages/ui/src/ui/common/hammer/aggregation.js
+++ b/packages/ui/src/ui/common/hammer/aggregation.js
@@ -2,46 +2,46 @@ import each_ from 'lodash/each';
 import map_ from 'lodash/map';
 import reduce_ from 'lodash/reduce';
 
-function aggregateSimple(aggregation, item, name, type) {
+function aggregateSimple(accAggregation, item, name, type) {
     switch (type) {
         case 'sum':
-            aggregation[name] = aggregation[name] || 0;
+            accAggregation[name] = accAggregation[name] || 0;
             if (typeof item[name] === 'number') {
-                aggregation[name] += item[name];
+                accAggregation[name] += item[name];
             }
             break;
 
         case 'max':
-            aggregation[name] = aggregation[name] || -Infinity;
+            accAggregation[name] = accAggregation[name] || -Infinity;
             if (typeof item[name] === 'number') {
-                aggregation[name] = Math.max(aggregation[name], item[name]);
+                accAggregation[name] = Math.max(accAggregation[name], item[name]);
             }
             break;
 
         case 'min':
-            aggregation[name] = aggregation[name] || Infinity;
+            accAggregation[name] = accAggregation[name] || Infinity;
             if (typeof item[name] === 'number') {
-                aggregation[name] = Math.min(aggregation[name], item[name]);
+                accAggregation[name] = Math.min(accAggregation[name], item[name]);
             }
             break;
 
         case 'concat-array':
-            aggregation[name] = aggregation[name] || [];
+            accAggregation[name] = accAggregation[name] || [];
             if (Array.isArray(item[name])) {
-                aggregation[name] = aggregation[name].concat(item[name]);
+                accAggregation[name] = accAggregation[name].concat(item[name]);
             }
             break;
 
         case 'concat-string':
-            aggregation[name] = aggregation[name] || '';
+            accAggregation[name] = accAggregation[name] || '';
             if (typeof item[name] === 'string') {
-                aggregation[name] += item[name];
+                accAggregation[name] += item[name];
             }
             break;
 
         case 'count':
-            aggregation[name] = aggregation[name] || 0;
-            aggregation[name]++;
+            accAggregation[name] = accAggregation[name] || 0;
+            accAggregation[name]++;
             break;
 
         default:
@@ -49,28 +49,28 @@ function aggregateSimple(aggregation, item, name, type) {
     }
 }
 
-function aggregateNested(aggregation, item, parts, type) {
+function aggregateNested(accAggregation, item, parts, type) {
     let name;
     if (parts.length > 1) {
         name = parts.shift();
-        aggregation[name] = aggregation[name] || {};
-        aggregateNested(aggregation[name], item[name], parts.slice(), type);
+        accAggregation[name] = accAggregation[name] || {};
+        aggregateNested(accAggregation[name], item[name], parts.slice(), type);
     } else {
         name = parts[0];
-        aggregateSimple(aggregation, item, name, type);
+        aggregateSimple(accAggregation, item, name, type);
     }
 }
 
-function aggregate(aggregation, item, property, lastItem) {
+function aggregate(accAggregation, item, property, lastItem) {
     const name = property.name;
     const type = property.type;
 
     if (typeof type === 'function') {
-        type(aggregation, item, name, lastItem);
+        type(accAggregation, item, name, lastItem);
     } else if (type.startsWith('nested/')) {
-        aggregateNested(aggregation, item, name.split('.'), type.slice('nested/'.length));
+        aggregateNested(accAggregation, item, name.split('.'), type.slice('nested/'.length));
     } else {
-        aggregateSimple(aggregation, item, name, type);
+        aggregateSimple(accAggregation, item, name, type);
     }
 }
 
@@ -89,29 +89,34 @@ function aggregate(aggregation, item, property, lastItem) {
 export function prepare(items, properties, byProperty) {
     let prepared = reduce_(
         items,
-        function (aggregation, item, index) {
+        function (accAggregation, item, index) {
             const lastItem = index === items.length - 1;
 
             each_(properties, function (property) {
-                aggregate(aggregation.total, item, property, lastItem);
+                aggregate(accAggregation.total, item, property, lastItem);
 
                 if (byProperty) {
                     const aggregateByValue = item[byProperty];
-                    aggregation.byProperty[aggregateByValue] =
-                        aggregation.byProperty[aggregateByValue] || {};
-                    aggregate(aggregation.byProperty[aggregateByValue], item, property, lastItem);
+                    accAggregation.byProperty[aggregateByValue] =
+                        accAggregation.byProperty[aggregateByValue] || {};
+                    aggregate(
+                        accAggregation.byProperty[aggregateByValue],
+                        item,
+                        property,
+                        lastItem,
+                    );
                 }
             });
 
-            return aggregation;
+            return accAggregation;
         },
         {total: {}, byProperty: {}},
     );
 
     prepared = [prepared.total].concat(
-        map_(prepared.byProperty, function (value, name) {
-            value[byProperty] = name;
-            return value;
+        map_(prepared.byProperty, function (accValue, name) {
+            accValue[byProperty] = name;
+            return accValue;
         }),
     );
 
@@ -127,13 +132,13 @@ export function prepare(items, properties, byProperty) {
 export function countValues(items, key, initialResult = {}) {
     return reduce_(
         items,
-        function (result, item) {
-            if (Object.hasOwnProperty.call(result, item[key])) {
-                result[item[key]]++;
+        function (accResult, item) {
+            if (Object.hasOwnProperty.call(accResult, item[key])) {
+                accResult[item[key]]++;
             } else if (Object.hasOwnProperty.call(item, key)) {
-                result[item[key]] = 1;
+                accResult[item[key]] = 1;
             }
-            return result;
+            return accResult;
         },
         initialResult,
     );

--- a/packages/ui/src/ui/common/hammer/aggregation.js
+++ b/packages/ui/src/ui/common/hammer/aggregation.js
@@ -2,46 +2,46 @@ import each_ from 'lodash/each';
 import map_ from 'lodash/map';
 import reduce_ from 'lodash/reduce';
 
-function aggregateSimple(accAggregation, item, name, type) {
+function aggregateSimple(draftAggregation, item, name, type) {
     switch (type) {
         case 'sum':
-            accAggregation[name] = accAggregation[name] || 0;
+            draftAggregation[name] = draftAggregation[name] || 0;
             if (typeof item[name] === 'number') {
-                accAggregation[name] += item[name];
+                draftAggregation[name] += item[name];
             }
             break;
 
         case 'max':
-            accAggregation[name] = accAggregation[name] || -Infinity;
+            draftAggregation[name] = draftAggregation[name] || -Infinity;
             if (typeof item[name] === 'number') {
-                accAggregation[name] = Math.max(accAggregation[name], item[name]);
+                draftAggregation[name] = Math.max(draftAggregation[name], item[name]);
             }
             break;
 
         case 'min':
-            accAggregation[name] = accAggregation[name] || Infinity;
+            draftAggregation[name] = draftAggregation[name] || Infinity;
             if (typeof item[name] === 'number') {
-                accAggregation[name] = Math.min(accAggregation[name], item[name]);
+                draftAggregation[name] = Math.min(draftAggregation[name], item[name]);
             }
             break;
 
         case 'concat-array':
-            accAggregation[name] = accAggregation[name] || [];
+            draftAggregation[name] = draftAggregation[name] || [];
             if (Array.isArray(item[name])) {
-                accAggregation[name] = accAggregation[name].concat(item[name]);
+                draftAggregation[name] = draftAggregation[name].concat(item[name]);
             }
             break;
 
         case 'concat-string':
-            accAggregation[name] = accAggregation[name] || '';
+            draftAggregation[name] = draftAggregation[name] || '';
             if (typeof item[name] === 'string') {
-                accAggregation[name] += item[name];
+                draftAggregation[name] += item[name];
             }
             break;
 
         case 'count':
-            accAggregation[name] = accAggregation[name] || 0;
-            accAggregation[name]++;
+            draftAggregation[name] = draftAggregation[name] || 0;
+            draftAggregation[name]++;
             break;
 
         default:
@@ -49,28 +49,28 @@ function aggregateSimple(accAggregation, item, name, type) {
     }
 }
 
-function aggregateNested(accAggregation, item, parts, type) {
+function aggregateNested(draftAggregation, item, parts, type) {
     let name;
     if (parts.length > 1) {
         name = parts.shift();
-        accAggregation[name] = accAggregation[name] || {};
-        aggregateNested(accAggregation[name], item[name], parts.slice(), type);
+        draftAggregation[name] = draftAggregation[name] || {};
+        aggregateNested(draftAggregation[name], item[name], parts.slice(), type);
     } else {
         name = parts[0];
-        aggregateSimple(accAggregation, item, name, type);
+        aggregateSimple(draftAggregation, item, name, type);
     }
 }
 
-function aggregate(accAggregation, item, property, lastItem) {
+function aggregate(draftAggregation, item, property, lastItem) {
     const name = property.name;
     const type = property.type;
 
     if (typeof type === 'function') {
-        type(accAggregation, item, name, lastItem);
+        type(draftAggregation, item, name, lastItem);
     } else if (type.startsWith('nested/')) {
-        aggregateNested(accAggregation, item, name.split('.'), type.slice('nested/'.length));
+        aggregateNested(draftAggregation, item, name.split('.'), type.slice('nested/'.length));
     } else {
-        aggregateSimple(accAggregation, item, name, type);
+        aggregateSimple(draftAggregation, item, name, type);
     }
 }
 
@@ -114,9 +114,9 @@ export function prepare(items, properties, byProperty) {
     );
 
     prepared = [prepared.total].concat(
-        map_(prepared.byProperty, function (accValue, name) {
-            accValue[byProperty] = name;
-            return accValue;
+        map_(prepared.byProperty, function (draftValue, name) {
+            draftValue[byProperty] = name;
+            return draftValue;
         }),
     );
 

--- a/packages/ui/src/ui/common/hammer/aggregation.spec.js
+++ b/packages/ui/src/ui/common/hammer/aggregation.spec.js
@@ -103,11 +103,11 @@ describe('hammer.aggregation', () => {
                 const properties = [
                     {
                         name: 'foo',
-                        type(aggregation, item, name) {
-                            aggregation[name] = aggregation[name] || '';
+                        type(accAggregation, item, name) {
+                            accAggregation[name] = accAggregation[name] || '';
 
                             if (typeof item[name] === 'string') {
-                                aggregation[name] += item[name];
+                                accAggregation[name] += item[name];
                             }
                         },
                     },
@@ -214,7 +214,7 @@ describe('hammer.aggregation', () => {
                 const properties = [
                     {
                         name: 'foo',
-                        type(aggregation, item, name, lastItem) {
+                        type(accAggregation, item, name, lastItem) {
                             if (item.name === 'abc') {
                                 expect(lastItem).toBe(false);
                             }

--- a/packages/ui/src/ui/common/hammer/aggregation.spec.js
+++ b/packages/ui/src/ui/common/hammer/aggregation.spec.js
@@ -103,11 +103,11 @@ describe('hammer.aggregation', () => {
                 const properties = [
                     {
                         name: 'foo',
-                        type(accAggregation, item, name) {
-                            accAggregation[name] = accAggregation[name] || '';
+                        type(draftAggregation, item, name) {
+                            draftAggregation[name] = draftAggregation[name] || '';
 
                             if (typeof item[name] === 'string') {
-                                accAggregation[name] += item[name];
+                                draftAggregation[name] += item[name];
                             }
                         },
                     },
@@ -214,7 +214,7 @@ describe('hammer.aggregation', () => {
                 const properties = [
                     {
                         name: 'foo',
-                        type(accAggregation, item, name, lastItem) {
+                        type(draftAggregation, item, name, lastItem) {
                             if (item.name === 'abc') {
                                 expect(lastItem).toBe(false);
                             }

--- a/packages/ui/src/ui/common/hammer/format.js
+++ b/packages/ui/src/ui/common/hammer/format.js
@@ -24,11 +24,12 @@ function preformat(value) {
         [/_data_size$/, '_size'],
     ];
 
+    let result = value;
     forEach_(replacements, (replacementSettings) => {
-        value = value.replace.apply(value, replacementSettings);
+        result = result.replace.apply(result, replacementSettings);
     });
 
-    return value;
+    return result;
 }
 
 function postformat(value) {
@@ -54,13 +55,14 @@ function postformat(value) {
         ['lastVisited', 'Visited'],
     ];
 
+    let result = value;
     forEach_(replacements, (replacementSettings) => {
         const regex = new RegExp('(^|\\s)(' + replacementSettings[0] + ')($|\\s)', 'i');
         const replacement = '$1' + replacementSettings[1] + '$3';
-        value = value.replace(regex, replacement);
+        result = result.replace(regex, replacement);
     });
 
-    return value;
+    return result;
 }
 
 /**
@@ -69,8 +71,8 @@ function postformat(value) {
  * @param {Object} settings
  * @returns {String}
  */
-format['ReadableField'] = function (value, settings) {
-    settings = settings || {};
+format['ReadableField'] = function (value, _settings) {
+    const settings = _settings || {};
 
     let formatted = value;
 
@@ -194,10 +196,11 @@ format['RackToVector'] = function (value) {
     const rackPartRegex = /([a-z]+)|(\d+)|([-.])/i;
     const vector = [];
     let currentMatch;
+    let remaining = value;
 
-    if (typeof value !== 'undefined') {
+    if (typeof remaining !== 'undefined') {
         do {
-            currentMatch = rackPartRegex.exec(value);
+            currentMatch = rackPartRegex.exec(remaining);
 
             if (currentMatch !== null) {
                 if (currentMatch[2]) {
@@ -208,11 +211,11 @@ format['RackToVector'] = function (value) {
                     vector.push(currentMatch[3]);
                 }
 
-                value = value.substring(currentMatch.index + currentMatch[0].length);
+                remaining = remaining.substring(currentMatch.index + currentMatch[0].length);
             }
         } while (currentMatch !== null);
     } else {
-        vector.push(value);
+        vector.push(remaining);
     }
 
     return vector;

--- a/packages/ui/src/ui/common/hammer/stat.js
+++ b/packages/ui/src/ui/common/hammer/stat.js
@@ -60,8 +60,7 @@ function findHistogramMedian(histogram) {
         const fullBucketSum = reduce_(
             buckets,
             (memo, bucket) => {
-                memo += bucket;
-                return memo;
+                return memo + bucket;
             },
             0,
         );
@@ -94,8 +93,7 @@ function computeHistogramQuartiles(histogram) {
         const fullBucketSum = reduce_(
             buckets,
             (memo, bucket) => {
-                memo += bucket;
-                return memo;
+                return memo + bucket;
             },
             0,
         );
@@ -133,13 +131,13 @@ function computeHistogramQuartiles(histogram) {
 
 function computeQuartiles(data, method) {
     // Sort and copy data
-    data = data.slice().sort(sortNumbers);
+    const sortedData = data.slice().sort(sortNumbers);
 
     // Calculate min and max
-    const n = data.length;
-    const dataMin = data[0];
-    const dataMax = data[n - 1];
-    const median = findMedian(data);
+    const n = sortedData.length;
+    const dataMin = sortedData[0];
+    const dataMax = sortedData[n - 1];
+    const median = findMedian(sortedData);
     let firstQuartile;
     let thirdQuartile;
     let splittedData;
@@ -155,20 +153,20 @@ function computeQuartiles(data, method) {
     }
 
     if (method === 'standard') {
-        splittedData = splitByMedian(data);
+        splittedData = splitByMedian(sortedData);
         firstQuartile = findMedian(splittedData.firstHalf);
         thirdQuartile = findMedian(splittedData.secondHalf);
     } else if (method === 'tuckey') {
-        splittedData = splitByMedian(data, 'tuckey');
+        splittedData = splitByMedian(sortedData, 'tuckey');
         firstQuartile = findMedian(splittedData.firstHalf);
         thirdQuartile = findMedian(splittedData.secondHalf);
     } else if (method === 'combined') {
         // In combined method quartiles are always the mean of previous two methods;
-        splittedData = splitByMedian(data);
+        splittedData = splitByMedian(sortedData);
         firstQuartile = findMedian(splittedData.firstHalf);
         thirdQuartile = findMedian(splittedData.secondHalf);
 
-        splittedData = splitByMedian(data, 'tuckey');
+        splittedData = splitByMedian(sortedData, 'tuckey');
         firstQuartile = (firstQuartile + findMedian(splittedData.firstHalf)) / 2;
         thirdQuartile = (thirdQuartile + findMedian(splittedData.secondHalf)) / 2;
     }
@@ -187,18 +185,18 @@ function sortNumbers(a, b) {
 }
 
 // PDF - probability density function
-stat.pdf = function (data, settings) {
-    settings = settings || {};
+stat.pdf = function (data, _settings) {
+    const settings = _settings || {};
     // Sort and copy data
-    data = data.slice().sort(sortNumbers);
+    const sortedData = data.slice().sort(sortNumbers);
 
     // Calculate min and max
-    const n = data.length;
-    const dataMin = data[0];
-    const dataMax = data[n - 1];
+    const n = sortedData.length;
+    const dataMin = sortedData[0];
+    const dataMax = sortedData[n - 1];
 
     // Compute bucket size and buckets number
-    const quartiles = computeQuartiles(data, 'combined');
+    const quartiles = computeQuartiles(sortedData, 'combined');
 
     const IQR = quartiles.q75 - quartiles.q25;
     let bucketSize = settings.forcedBucketSize
@@ -224,7 +222,7 @@ stat.pdf = function (data, settings) {
             count: 0,
         };
 
-        while (data[j] < bucket.end && data[j] >= bucket.start) {
+        while (sortedData[j] < bucket.end && sortedData[j] >= bucket.start) {
             bucket.count = bucket.count + 1;
             j++;
         }
@@ -250,11 +248,11 @@ stat.pdf = function (data, settings) {
 // ECDF - empirical cumulative distribution function
 stat.ecdf = function (data) {
     // Sort and copy data
-    data = data.slice();
+    const dataCopy = data.slice();
 
-    const condencedData = uniq_(data).sort(sortNumbers);
-    const dataCounts = countBy_(data);
-    const n = data.length;
+    const condencedData = uniq_(dataCopy).sort(sortNumbers);
+    const dataCounts = countBy_(dataCopy);
+    const n = dataCopy.length;
 
     // Calculate min and max
     const nCondenced = condencedData.length;
@@ -282,8 +280,8 @@ stat.ecdf = function (data) {
     };
 };
 
-stat.quartiles = function (data, method) {
-    method = method || 'combined';
+stat.quartiles = function (data, _method) {
+    const method = _method || 'combined';
     return computeQuartiles(data, method);
 };
 

--- a/packages/ui/src/ui/common/hammer/tables.js
+++ b/packages/ui/src/ui/common/hammer/tables.js
@@ -118,11 +118,11 @@ class InverseIndex extends BoundedArray {
 
     static TABLE_SIMILARITY_THRESHOLD = 0.9;
 
-    static addToFrequences(container, word) {
-        if (isNaN(container[word])) {
-            container[word] = 0;
+    static addToFrequences(accContainer, word) {
+        if (isNaN(accContainer[word])) {
+            accContainer[word] = 0;
         }
-        ++container[word];
+        ++accContainer[word];
     }
 
     _init(data = []) {

--- a/packages/ui/src/ui/common/hammer/tables.js
+++ b/packages/ui/src/ui/common/hammer/tables.js
@@ -118,11 +118,11 @@ class InverseIndex extends BoundedArray {
 
     static TABLE_SIMILARITY_THRESHOLD = 0.9;
 
-    static addToFrequences(accContainer, word) {
-        if (isNaN(accContainer[word])) {
-            accContainer[word] = 0;
+    static addToFrequences(draftContainer, word) {
+        if (isNaN(draftContainer[word])) {
+            draftContainer[word] = 0;
         }
-        ++accContainer[word];
+        ++draftContainer[word];
     }
 
     _init(data = []) {

--- a/packages/ui/src/ui/common/hammer/tree-list.ts
+++ b/packages/ui/src/ui/common/hammer/tree-list.ts
@@ -287,21 +287,21 @@ export function flattenTree<T extends TreeNode<unknown, unknown>>(
     level = 0,
     basePath = '',
 ) {
-    basePath += treeNode.name + '/';
+    const currentPath = basePath + treeNode.name + '/';
 
     let tree: Array<TreeNodeOrLeaf<T> & FlatItemDetails> = [];
 
     tree = tree.concat(
         map_(treeNode.leaves, (leaf) => {
-            return augmentTreeNode(leaf, level, basePath);
+            return augmentTreeNode(leaf, level, currentPath);
         }),
     );
 
     each_(treeNode.children, (childNode) => {
-        childNode = augmentTreeNode(childNode, level, basePath);
+        const augmented = augmentTreeNode(childNode, level, currentPath);
 
-        tree.push(childNode);
-        tree = tree.concat(flattenTree(childNode, level + 1, basePath));
+        tree.push(augmented);
+        tree = tree.concat(flattenTree(augmented, level + 1, currentPath));
     });
 
     return tree;

--- a/packages/ui/src/ui/common/hammer/tree-list.ts
+++ b/packages/ui/src/ui/common/hammer/tree-list.ts
@@ -38,11 +38,11 @@ export type TreeNodeOrLeaf<T extends TreeNode<unknown, unknown>> = T | TreeLeaf<
  * @param initedBy - name of a treeNode that created this tree node initially
  */
 function getTreeNode<T, L>(
-    accTreeNodes: Record<string, TreeNode<T, L>>,
+    draftTreeNodes: Record<string, TreeNode<T, L>>,
     name: string,
     initedBy: string,
 ): TreeNode<T, L> {
-    accTreeNodes[name] = accTreeNodes[name] || {
+    draftTreeNodes[name] = draftTreeNodes[name] || {
         name,
         attributes: {},
         children: [],
@@ -50,7 +50,7 @@ function getTreeNode<T, L>(
         _initedBy: initedBy, // needed for debug purposes in case of inconsistent data
     };
 
-    return accTreeNodes[name];
+    return draftTreeNodes[name];
 }
 
 function getTreeLeafNode<L>(leafNode: L, name: string): LeafNode<L> {
@@ -243,19 +243,19 @@ export interface FieldDescr<T extends TreeNode<unknown, unknown>> {
  * @param fields - description for all possible sort fields in column-like format.
  */
 export function sortTree<T extends TreeNode<unknown, unknown>, FieldT extends string>(
-    accTreeNode: T,
+    draftTreeNode: T,
     sortInfo: OldSortState,
     fields: Record<FieldT, FieldDescr<T>>,
 ) {
-    accTreeNode.children = utils.sort(accTreeNode.children, sortInfo, fields);
-    accTreeNode.leaves = utils.sort(accTreeNode.leaves, sortInfo, fields);
+    draftTreeNode.children = utils.sort(draftTreeNode.children, sortInfo, fields);
+    draftTreeNode.leaves = utils.sort(draftTreeNode.leaves, sortInfo, fields);
 
-    accTreeNode.children = map_(accTreeNode.children, (c) => {
-        const childEntry = c as typeof accTreeNode;
+    draftTreeNode.children = map_(draftTreeNode.children, (c) => {
+        const childEntry = c as typeof draftTreeNode;
         return sortTree(childEntry, sortInfo, fields);
     });
 
-    return accTreeNode;
+    return draftTreeNode;
 }
 
 function augmentTreeNode<T extends {name: string}>(entry: T, level: number, basePath: string) {

--- a/packages/ui/src/ui/common/hammer/tree-list.ts
+++ b/packages/ui/src/ui/common/hammer/tree-list.ts
@@ -38,11 +38,11 @@ export type TreeNodeOrLeaf<T extends TreeNode<unknown, unknown>> = T | TreeLeaf<
  * @param initedBy - name of a treeNode that created this tree node initially
  */
 function getTreeNode<T, L>(
-    treeNodes: Record<string, TreeNode<T, L>>,
+    accTreeNodes: Record<string, TreeNode<T, L>>,
     name: string,
     initedBy: string,
 ): TreeNode<T, L> {
-    treeNodes[name] = treeNodes[name] || {
+    accTreeNodes[name] = accTreeNodes[name] || {
         name,
         attributes: {},
         children: [],
@@ -50,7 +50,7 @@ function getTreeNode<T, L>(
         _initedBy: initedBy, // needed for debug purposes in case of inconsistent data
     };
 
-    return treeNodes[name];
+    return accTreeNodes[name];
 }
 
 function getTreeLeafNode<L>(leafNode: L, name: string): LeafNode<L> {
@@ -243,19 +243,19 @@ export interface FieldDescr<T extends TreeNode<unknown, unknown>> {
  * @param fields - description for all possible sort fields in column-like format.
  */
 export function sortTree<T extends TreeNode<unknown, unknown>, FieldT extends string>(
-    treeNode: T,
+    accTreeNode: T,
     sortInfo: OldSortState,
     fields: Record<FieldT, FieldDescr<T>>,
 ) {
-    treeNode.children = utils.sort(treeNode.children, sortInfo, fields);
-    treeNode.leaves = utils.sort(treeNode.leaves, sortInfo, fields);
+    accTreeNode.children = utils.sort(accTreeNode.children, sortInfo, fields);
+    accTreeNode.leaves = utils.sort(accTreeNode.leaves, sortInfo, fields);
 
-    treeNode.children = map_(treeNode.children, (c) => {
-        const childEntry = c as typeof treeNode;
+    accTreeNode.children = map_(accTreeNode.children, (c) => {
+        const childEntry = c as typeof accTreeNode;
         return sortTree(childEntry, sortInfo, fields);
     });
 
-    return treeNode;
+    return accTreeNode;
 }
 
 function augmentTreeNode<T extends {name: string}>(entry: T, level: number, basePath: string) {

--- a/packages/ui/src/ui/common/hammer/utils.js
+++ b/packages/ui/src/ui/common/hammer/utils.js
@@ -100,8 +100,8 @@ function wrapCompareFnByAsc(compareFn, asc, undefinedAsk = true) {
     return (l, r) => compareFn(l, r, orderK, undefinedOrderK);
 }
 
-utils.sort = function (data, sortInfo, fields, options) {
-    options = options || {};
+utils.sort = function (data, sortInfo, fields, _options) {
+    const options = _options || {};
 
     const unwrappedSortInfo = sortInfo;
     const unwrappedData = data;

--- a/packages/ui/src/ui/common/thor/unipika.ts
+++ b/packages/ui/src/ui/common/thor/unipika.ts
@@ -23,8 +23,8 @@ const {utf8} = unipika.utils;
 /**
  * @deprecated Use corresponding selector from `selectors/thor/unipika`
  */
-unipika.prepareSettings = function (settings: UnipikaSettings) {
-    settings = settings || {};
+unipika.prepareSettings = function (_settings: UnipikaSettings) {
+    const settings: UnipikaSettings = _settings || {};
     Object.assign(settings, getUnipikaSettingsFromConfig());
 
     settings.format = parseSetting(settings, 'format', getSettingBySelector(selectFormat));
@@ -53,8 +53,8 @@ unipika.prepareSettings = function (settings: UnipikaSettings) {
 /**
  * @deprecated The function uses store implicitly, use `prettyPrint` from `utils/unipika.ts instead of it.
  */
-unipika.prettyprint = function (value: unknown, settings: UnipikaSettings) {
-    settings = unipika.prepareSettings(settings);
+unipika.prettyprint = function (value: unknown, _settings: UnipikaSettings) {
+    const settings = unipika.prepareSettings(_settings);
     return prettyPrint(value, settings);
 };
 

--- a/packages/ui/src/ui/common/thor/ypath.ts
+++ b/packages/ui/src/ui/common/thor/ypath.ts
@@ -6,8 +6,8 @@ import {appendInnerErrors} from '../../utils/errors';
 const yson = unipika.utils.yson;
 
 /** @deprecated */
-function convertToNumberOld(value: number | string, defaultValue?: number): number | undefined {
-    value = yson.value(value);
+function convertToNumberOld(_value: number | string, defaultValue?: number): number | undefined {
+    const value = yson.value(_value);
 
     const type = unipika.utils.type(value);
 

--- a/packages/ui/src/ui/common/utils/url.ts
+++ b/packages/ui/src/ui/common/utils/url.ts
@@ -3,11 +3,9 @@ export function absolute(relative: string, base?: string) {
         return relative;
     }
 
-    if (base === undefined) {
-        base = window?.location.pathname || '';
-    }
+    const resolvedBase = base !== undefined ? base : window?.location.pathname || '';
 
-    const stack = base.split('/');
+    const stack = resolvedBase.split('/');
     const parts = relative.split('/');
     stack.pop();
     for (let i = 0; i < parts.length; i++) {

--- a/packages/ui/src/ui/components/ColumnSelector/ColumnSelector.js
+++ b/packages/ui/src/ui/components/ColumnSelector/ColumnSelector.js
@@ -192,63 +192,63 @@ export default class ColumnSelector extends Component {
 
     toggleItem = (name) => {
         this.withActualItems(({items}) => {
-            items = [...items];
-            const index = items.findIndex((item) => item.name === name);
-            const changedItem = items[index];
-            items[index] = {...changedItem, checked: !changedItem.checked};
+            const itemsCopy = [...items];
+            const index = itemsCopy.findIndex((item) => item.name === name);
+            const changedItem = itemsCopy[index];
+            itemsCopy[index] = {...changedItem, checked: !changedItem.checked};
 
-            return {items};
+            return {items: itemsCopy};
         });
     };
 
     selectAllItems = () => {
         this.withActualItems(({items}) => {
             const visibleMap = this.getVisibleItemsMap();
-            items = [...items];
-            each_(items, (item, index) => {
+            const itemsCopy = [...items];
+            each_(itemsCopy, (item, index) => {
                 if (!visibleMap[item.name]) {
                     return;
                 }
                 if (!item.checked && !item.disabled) {
-                    items[index] = {...item, checked: true};
+                    itemsCopy[index] = {...item, checked: true};
                 }
             });
 
-            return {items};
+            return {items: itemsCopy};
         });
     };
 
     deselectAllItems = () => {
         this.withActualItems(({items}) => {
             const visibleMap = this.getVisibleItemsMap();
-            items = [...items];
-            each_(items, (item, index) => {
+            const itemsCopy = [...items];
+            each_(itemsCopy, (item, index) => {
                 if (!visibleMap[item.name]) {
                     return;
                 }
                 if (item.checked && !item.disabled && (item.isDeletable ?? true)) {
-                    items[index] = {...item, checked: false};
+                    itemsCopy[index] = {...item, checked: false};
                 }
             });
 
-            return {items};
+            return {items: itemsCopy};
         });
     };
 
     invertItems = () => {
         this.withActualItems(({items}) => {
             const visibleItems = this.getVisibleItemsMap();
-            items = [...items];
-            each_(items, (item, index) => {
+            const itemsCopy = [...items];
+            each_(itemsCopy, (item, index) => {
                 if (!visibleItems[item.name]) {
                     return;
                 }
                 if (!item.disabled) {
-                    items[index] = {...item, checked: !item.checked};
+                    itemsCopy[index] = {...item, checked: !item.checked};
                 }
             });
 
-            return {items};
+            return {items: itemsCopy};
         });
     };
 
@@ -262,16 +262,20 @@ export default class ColumnSelector extends Component {
         }
 
         this.withActualItems(({items}) => {
-            items = [...items];
+            const itemsCopy = [...items];
 
             const {items: visibleItems} = this.getVisibleItems();
-            const fromIndex = items.findIndex((item) => item.name === visibleItems[oldIndex].name);
-            const toIndex = items.findIndex((item) => item.name === visibleItems[newIndex].name);
+            const fromIndex = itemsCopy.findIndex(
+                (item) => item.name === visibleItems[oldIndex].name,
+            );
+            const toIndex = itemsCopy.findIndex(
+                (item) => item.name === visibleItems[newIndex].name,
+            );
 
-            const [removed] = items.splice(fromIndex, 1);
-            items.splice(toIndex, 0, removed);
+            const [removed] = itemsCopy.splice(fromIndex, 1);
+            itemsCopy.splice(toIndex, 0, removed);
 
-            return {items};
+            return {items: itemsCopy};
         });
     };
 
@@ -366,9 +370,9 @@ export default class ColumnSelector extends Component {
 
     filterItems(items) {
         const {showDisabledItems} = this.props;
-        items = showDisabledItems ? items : filter_(items, (item) => !item.disabled);
+        const filteredItems = showDisabledItems ? items : filter_(items, (item) => !item.disabled);
 
-        const visibleItems = this.filterItemsByName(items);
+        const visibleItems = this.filterItemsByName(filteredItems);
         return this.state.showSelectedOnly
             ? filter_(visibleItems, (item) => item.checked)
             : visibleItems;

--- a/packages/ui/src/ui/components/ColumnSelectorModal/ColumnSelectorModal.tsx
+++ b/packages/ui/src/ui/components/ColumnSelectorModal/ColumnSelectorModal.tsx
@@ -217,7 +217,7 @@ export default class ColumnSelectorModal<T = never> extends React.Component<Prop
         const sortableSelectorProps = this._getSortableSelectorProps(selectorProps, items);
         const selectedItemsCount = reduce_(
             sortableSelectorProps.items,
-            (acc, item) => (item.disabled || !item.checked ? acc : ++acc),
+            (acc, item) => (item.disabled || !item.checked ? acc : acc + 1),
             0,
         );
 

--- a/packages/ui/src/ui/components/ElementsTable/ElementsTable.js
+++ b/packages/ui/src/ui/components/ElementsTable/ElementsTable.js
@@ -129,22 +129,22 @@ class ElementsTable extends Component {
         const totalKeys = keys.length;
         let prevKey, prevKeyParts;
 
-        return keys.reduce((states, key, index) => {
+        return keys.reduce((accStates, key, index) => {
             // initially item is not empty
-            states[key] = {empty: false};
+            accStates[key] = {empty: false};
 
             const keyParts = key.split('/');
             // if we haven't traversed deeper right after the previous item, then the previous item
             // doesn't have children, i.e. is empty
             if (prevKeyParts && prevKeyParts.length >= keyParts.length) {
-                states[prevKey] = {empty: true};
+                accStates[prevKey] = {empty: true};
             }
             // last item is always empty
             if (index === totalKeys - 1) {
-                states[key] = {empty: true};
+                accStates[key] = {empty: true};
             }
             [prevKey, prevKeyParts] = [key, keyParts];
-            return states;
+            return accStates;
         }, {});
     }
 

--- a/packages/ui/src/ui/components/MonacoEditor/MonacoEditor.tsx
+++ b/packages/ui/src/ui/components/MonacoEditor/MonacoEditor.tsx
@@ -113,6 +113,7 @@ const MonacoEditor: FC<Props> = ({
 
         key.setScope('monaco-editor');
         if (editorRef) {
+            // eslint-disable-next-line no-param-reassign -- callback initializes the caller-owned React ref
             editorRef.current = editorInstance;
         }
 

--- a/packages/ui/src/ui/components/StatisticTable/StatisticTable.tsx
+++ b/packages/ui/src/ui/components/StatisticTable/StatisticTable.tsx
@@ -191,13 +191,13 @@ type VisibleColumns = Array<ColumnName>;
 
 const prepareTableProps = ({visibleColumns}: {visibleColumns: VisibleColumns}) => {
     const columns = visibleColumns.reduce(
-        (ret, col) => {
-            ret[col] = {
+        (accRet, col) => {
+            accRet[col] = {
                 sort: false,
                 align: 'right',
             };
 
-            return ret;
+            return accRet;
         },
         {
             name: {

--- a/packages/ui/src/ui/components/Yson/StructuredYson/flattenUnipika.ts
+++ b/packages/ui/src/ui/components/Yson/StructuredYson/flattenUnipika.ts
@@ -419,7 +419,7 @@ function handleUnipikaMapImpl(
     items: UnipikaMap['$value'],
     level: number,
     ctx: FlatContext,
-    accInfo: LevelInfo,
+    draftInfo: LevelInfo,
 ) {
     for (let i = 0; i < items.length; ++i) {
         const [key, value] = items[i];
@@ -427,7 +427,7 @@ function handleUnipikaMapImpl(
         ctx.dst.push(keyItem);
         pushPath(key.$value, ctx);
         flattenUnipikaImpl(value, level, ctx);
-        ++accInfo.currentIndex;
+        ++draftInfo.currentIndex;
         popPath(ctx);
     }
 }

--- a/packages/ui/src/ui/components/Yson/StructuredYson/flattenUnipika.ts
+++ b/packages/ui/src/ui/components/Yson/StructuredYson/flattenUnipika.ts
@@ -419,7 +419,7 @@ function handleUnipikaMapImpl(
     items: UnipikaMap['$value'],
     level: number,
     ctx: FlatContext,
-    info: LevelInfo,
+    accInfo: LevelInfo,
 ) {
     for (let i = 0; i < items.length; ++i) {
         const [key, value] = items[i];
@@ -427,7 +427,7 @@ function handleUnipikaMapImpl(
         ctx.dst.push(keyItem);
         pushPath(key.$value, ctx);
         flattenUnipikaImpl(value, level, ctx);
-        ++info.currentIndex;
+        ++accInfo.currentIndex;
         popPath(ctx);
     }
 }

--- a/packages/ui/src/ui/components/common/Datepicker/Month/Month.js
+++ b/packages/ui/src/ui/components/common/Datepicker/Month/Month.js
@@ -95,17 +95,17 @@ export class Month extends React.Component {
     };
 
     // eslint-disable-next-line complexity
-    getMods = ({currentDateTime, mergedIntervals, flags}) => {
+    getMods = ({currentDateTime, mergedIntervals, flags: draftFlags}) => {
         const {min, max, selectedInterval, hovered, isDefaultFrom, onRangeDateClick} = this.props;
 
         let isToday = false;
         let isSelected = false;
 
-        if (this.isMonthIncludeToday && !flags.hasToday) {
+        if (this.isMonthIncludeToday && !draftFlags.hasToday) {
             isToday = isDatesEqual(currentDateTime, this.todayDateTime);
 
             if (isToday) {
-                flags.hasToday = true;
+                draftFlags.hasToday = true;
             }
         }
 

--- a/packages/ui/src/ui/components/templates/utils.js
+++ b/packages/ui/src/ui/components/templates/utils.js
@@ -11,10 +11,10 @@ import i18n from './i18n';
 import './utils.scss';
 
 function wrapRenderMethods(templates) {
-    return Object.keys(templates).reduce((newTemplates, key) => {
-        newTemplates[key] = templates[key];
+    return Object.keys(templates).reduce((accTemplates, key) => {
+        accTemplates[key] = templates[key];
 
-        return newTemplates;
+        return accTemplates;
     }, {});
 }
 

--- a/packages/ui/src/ui/config/yt-config.ts
+++ b/packages/ui/src/ui/config/yt-config.ts
@@ -13,11 +13,11 @@ export function getGroupedClusters(clusters = YT.clusters) {
 
     const groups = reduce_(
         clusters,
-        (groups, cluster) => {
+        (accGroups, cluster) => {
             const currentGroup = cluster.group || DEFAULT_GROUP;
-            groups[currentGroup] = groups[currentGroup] || [];
-            groups[currentGroup].push(cluster);
-            return groups;
+            accGroups[currentGroup] = accGroups[currentGroup] || [];
+            accGroups[currentGroup].push(cluster);
+            return accGroups;
         },
         {} as Record<string, Array<ClusterConfig>>,
     );

--- a/packages/ui/src/ui/containers/Dialog/controls/PoolSuggestControl/PoolSuggestControl.tsx
+++ b/packages/ui/src/ui/containers/Dialog/controls/PoolSuggestControl/PoolSuggestControl.tsx
@@ -125,8 +125,8 @@ PoolSuggestControl.isEmpty = (value: Props['value']) => {
     return !value;
 };
 
-function useLoadedPools(cluster?: string, poolTrees?: string[]): Array<string> | null {
-    poolTrees = poolTrees || [];
+function useLoadedPools(cluster?: string, _poolTrees?: string[]): Array<string> | null {
+    const poolTrees = _poolTrees || [];
 
     const [poolNames, setPoolNames] = React.useState<Array<string> | null>(null);
 

--- a/packages/ui/src/ui/containers/Dialog/df-dialog-utils.ts
+++ b/packages/ui/src/ui/containers/Dialog/df-dialog-utils.ts
@@ -192,15 +192,15 @@ type Converter = ReturnType<typeof converterByType>;
 
 function makeDialogField<FormValues = any>(
     item: OptionDescription,
-    accInitialValues: any,
-    accConvertersByName: Record<string, {type: DialogField['type']; converter: Converter}>,
+    draftInitialValues: any,
+    draftConvertersByName: Record<string, {type: DialogField['type']; converter: Converter}>,
     options: MakeDialogFieldsOptions,
 ) {
     const {initialValue, converter, ...res} = descriptionToDialogField<FormValues>(item, options);
     const {type} = res;
 
-    accInitialValues[item.name] = initialValue ?? converter.toFieldValue(item.current_value);
-    accConvertersByName[item.name] = {type: type!, converter};
+    draftInitialValues[item.name] = initialValue ?? converter.toFieldValue(item.current_value);
+    draftConvertersByName[item.name] = {type: type!, converter};
 
     return res;
 }

--- a/packages/ui/src/ui/containers/Dialog/df-dialog-utils.ts
+++ b/packages/ui/src/ui/containers/Dialog/df-dialog-utils.ts
@@ -192,15 +192,15 @@ type Converter = ReturnType<typeof converterByType>;
 
 function makeDialogField<FormValues = any>(
     item: OptionDescription,
-    dstInitialValues: any,
-    dstConvertersByName: Record<string, {type: DialogField['type']; converter: Converter}>,
+    accInitialValues: any,
+    accConvertersByName: Record<string, {type: DialogField['type']; converter: Converter}>,
     options: MakeDialogFieldsOptions,
 ) {
     const {initialValue, converter, ...res} = descriptionToDialogField<FormValues>(item, options);
     const {type} = res;
 
-    dstInitialValues[item.name] = initialValue ?? converter.toFieldValue(item.current_value);
-    dstConvertersByName[item.name] = {type: type!, converter};
+    accInitialValues[item.name] = initialValue ?? converter.toFieldValue(item.current_value);
+    accConvertersByName[item.name] = {type: type!, converter};
 
     return res;
 }

--- a/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
+++ b/packages/ui/src/ui/containers/SettingsPanel/settings-description.tsx
@@ -663,19 +663,19 @@ export function useSettingsDescription(): Array<SettingsPage> {
 
     const res = React.useMemo(() => {
         const extPages: Record<string, SettingsPage> = mapById(externalSettings);
-        return produce(settings, (pages) => {
-            forEach_(pages, (page) => {
+        return produce(settings, (draftPages) => {
+            forEach_(draftPages, (page) => {
                 const extPage = extPages[page.id];
                 if (extPage) {
                     delete extPages[page.id];
                     const extSections = mapById(extPage.sections);
-                    forEach_(page.sections, (section) => {
-                        const s = extSections[section.id];
+                    forEach_(page.sections, (draftSection) => {
+                        const s = extSections[draftSection.id];
                         if (s) {
-                            delete extSections[section.id];
+                            delete extSections[draftSection.id];
                             const extIdsMap = new Map(s.items.map((i) => [i.id, i]));
-                            const newItems = section.items.filter((i) => !extIdsMap.has(i.id));
-                            section.items = [...newItems, ...s.items];
+                            const newItems = draftSection.items.filter((i) => !extIdsMap.has(i.id));
+                            draftSection.items = [...newItems, ...s.items];
                         }
                     });
                     forEach_(extSections, (section) => {
@@ -684,7 +684,7 @@ export function useSettingsDescription(): Array<SettingsPage> {
                 }
             });
             forEach_(extPages, (page) => {
-                pages.splice(pages.length - 1, 0, page);
+                draftPages.splice(draftPages.length - 1, 0, page);
             });
         });
     }, [settings, externalSettings]);

--- a/packages/ui/src/ui/hooks/use-prevent-unload.ts
+++ b/packages/ui/src/ui/hooks/use-prevent-unload.ts
@@ -5,6 +5,7 @@ export const usePreventUnload = ({shouldListen}: {shouldListen: boolean}) => {
         e.preventDefault();
 
         // Included for legacy support, e.g. Chrome/Edge < 119
+        // eslint-disable-next-line no-param-reassign -- required by the beforeunload API
         e.returnValue = true;
     }, []);
 

--- a/packages/ui/src/ui/pages/components/tabs/node/NodeBundlesTotal/NodeBundlesTotal.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/node/NodeBundlesTotal/NodeBundlesTotal.tsx
@@ -118,13 +118,13 @@ export function TabletDynamicTotal(props: TabletDynamicTotalProps) {
                 <div className={block('progress-tooltip')}>
                     {map_(stack, (item, index) => {
                         const {key} = item;
-                        item.color = COLORS[key] ?? getColor(index);
+                        const color = COLORS[key] ?? getColor(index);
 
                         return (
                             <React.Fragment key={key}>
                                 <div
                                     style={{
-                                        backgroundColor: item.color,
+                                        backgroundColor: color,
                                         borderRadius: '50%',
                                         width: '1em',
                                         height: '1em',

--- a/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManager.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManager.tsx
@@ -373,13 +373,13 @@ class UploadManager extends React.Component<Props, State> {
         this.setState({progress: {inProgress: true, event}});
     };
 
-    onStopUpload(error?: State['error']) {
+    onStopUpload(_error?: State['error']) {
         this.setState({progress: {inProgress: false}});
-        if (!error) {
+        if (!_error) {
             this.props.updateView();
             this.props.handleClose();
-        } else if (!axios.isCancel(error) && (!error || error.code !== 'cancelled')) {
-            error = error.response?.data || error;
+        } else if (!axios.isCancel(_error) && (!_error || _error.code !== 'cancelled')) {
+            const error = _error.response?.data || _error;
             this.setState({error});
         }
     }

--- a/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManagerCreate.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManagerCreate.tsx
@@ -330,13 +330,13 @@ class UploadManagerCreateImpl extends React.Component<Props, State> {
         this.setState({progress: {inProgress: true, event}});
     };
 
-    onStopUpload(error?: State['error']) {
+    onStopUpload(_error?: State['error']) {
         this.setState({progress: {inProgress: false}});
-        if (!error) {
+        if (!_error) {
             this.props.updateView();
             this.props.onClose();
-        } else if (!axios.isCancel(error) && (!error || error.code !== 'cancelled')) {
-            error = error.response?.data || error;
+        } else if (!axios.isCancel(_error) && (!_error || _error.code !== 'cancelled')) {
+            const error = _error.response?.data || _error;
             this.setState({error});
         }
     }

--- a/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
+++ b/packages/ui/src/ui/pages/odin/controls/OdinOverview.tsx
@@ -213,7 +213,9 @@ function OdinOverview(props: OdinOverviewProps) {
         (name: string, d?: MetricData, el?: Element, index?: number) => {
             if (el) {
                 const {width, height} = el.getBoundingClientRect();
+                // eslint-disable-next-line no-param-reassign -- popup positioning expects measured dimensions on its anchor
                 (el as any).offsetWidth = width;
+                // eslint-disable-next-line no-param-reassign -- popup positioning expects measured dimensions on its anchor
                 (el as any).offsetHeight = height;
                 setTooltip({
                     metricName: name,

--- a/packages/ui/src/ui/pages/operations/OperationSuggestFilter/OperationSuggestFilter.js
+++ b/packages/ui/src/ui/pages/operations/OperationSuggestFilter/OperationSuggestFilter.js
@@ -20,15 +20,15 @@ export default class OperationSuggestFilter extends Component {
     };
 
     static simpleSuggestLoader(items, text) {
-        text = text.toLowerCase();
+        const lowerText = text.toLowerCase();
 
-        items = filter_(items, (item) => {
+        const filteredItems = filter_(items, (item) => {
             const itemText = typeof item === 'string' ? item : item.value;
 
-            return text ? itemText.toLowerCase().indexOf(text) !== -1 : true;
+            return lowerText ? itemText.toLowerCase().indexOf(lowerText) !== -1 : true;
         });
 
-        return items;
+        return filteredItems;
     }
 
     render() {

--- a/packages/ui/src/ui/pages/operations/selectors.ts
+++ b/packages/ui/src/ui/pages/operations/selectors.ts
@@ -361,9 +361,9 @@ export function getCounters(name: string, states: FIX_MY_TYPE, rawCounters: FIX_
     return hammer.filter.countCategoriesNG({
         items: map_(counters, (count, value) => ({count, value})),
         categories: hammer.filter.flattenCategoriesNG(states, 'name'),
-        custom: (item: {value: string; count: number}, accCounters: Record<string, number>) => {
-            accCounters[item.value] += item.count;
-            accCounters['all'] += item.count;
+        custom: (item: {value: string; count: number}, draftCounters: Record<string, number>) => {
+            draftCounters[item.value] += item.count;
+            draftCounters['all'] += item.count;
         },
     });
 }

--- a/packages/ui/src/ui/pages/operations/selectors.ts
+++ b/packages/ui/src/ui/pages/operations/selectors.ts
@@ -361,9 +361,9 @@ export function getCounters(name: string, states: FIX_MY_TYPE, rawCounters: FIX_
     return hammer.filter.countCategoriesNG({
         items: map_(counters, (count, value) => ({count, value})),
         categories: hammer.filter.flattenCategoriesNG(states, 'name'),
-        custom: (item: {value: string; count: number}, counters: Record<string, number>) => {
-            counters[item.value] += item.count;
-            counters['all'] += item.count;
+        custom: (item: {value: string; count: number}, accCounters: Record<string, number>) => {
+            accCounters[item.value] += item.count;
+            accCounters['all'] += item.count;
         },
     });
 }

--- a/packages/ui/src/ui/pages/query-tracker/Plan/components/Minimap/Minimap.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/components/Minimap/Minimap.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign -- minimap layout mutates its owned radar geometry */
+
 import * as React from 'react';
 
 import {Card} from '@gravity-ui/uikit';

--- a/packages/ui/src/ui/pages/query-tracker/Plan/models/dataTypes.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/models/dataTypes.ts
@@ -95,18 +95,18 @@ export type DataType = {
       }
 );
 export function getType(typeArray: yqlModel.value.TypeArray): DataType {
-    function setOptional(dataType: DataType) {
-        if (dataType.optional) {
-            dataType.optionalLevel = (dataType.optionalLevel || 1) + 1;
+    function setOptional(accDataType: DataType) {
+        if (accDataType.optional) {
+            accDataType.optionalLevel = (accDataType.optionalLevel || 1) + 1;
         }
-        dataType.optional = true;
-        return dataType;
+        accDataType.optional = true;
+        return accDataType;
     }
 
-    function setTag(dataType: DataType, typeTag: string) {
-        dataType.tagged = true;
-        dataType.tags = (dataType.tags || []).concat(typeTag);
-        return dataType;
+    function setTag(accDataType: DataType, typeTag: string) {
+        accDataType.tagged = true;
+        accDataType.tags = (accDataType.tags || []).concat(typeTag);
+        return accDataType;
     }
 
     function isEnum(variantTypes: {type: {name: string | number}}[]) {

--- a/packages/ui/src/ui/pages/query-tracker/Plan/models/dataTypes.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/models/dataTypes.ts
@@ -95,18 +95,18 @@ export type DataType = {
       }
 );
 export function getType(typeArray: yqlModel.value.TypeArray): DataType {
-    function setOptional(accDataType: DataType) {
-        if (accDataType.optional) {
-            accDataType.optionalLevel = (accDataType.optionalLevel || 1) + 1;
+    function setOptional(draftDataType: DataType) {
+        if (draftDataType.optional) {
+            draftDataType.optionalLevel = (draftDataType.optionalLevel || 1) + 1;
         }
-        accDataType.optional = true;
-        return accDataType;
+        draftDataType.optional = true;
+        return draftDataType;
     }
 
-    function setTag(accDataType: DataType, typeTag: string) {
-        accDataType.tagged = true;
-        accDataType.tags = (accDataType.tags || []).concat(typeTag);
-        return accDataType;
+    function setTag(draftDataType: DataType, typeTag: string) {
+        draftDataType.tagged = true;
+        draftDataType.tags = (draftDataType.tags || []).concat(typeTag);
+        return draftDataType;
     }
 
     function isEnum(variantTypes: {type: {name: string | number}}[]) {

--- a/packages/ui/src/ui/pages/query-tracker/Plan/services/layout.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/services/layout.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign -- layout operates on private mutable graph structures */
+
 type ID = string & {__brand: 'NodeId'};
 
 export type Edge<NodeId> = {

--- a/packages/ui/src/ui/pages/query-tracker/Plan/services/preparePlanNode.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/services/preparePlanNode.ts
@@ -5,33 +5,33 @@ import {buildOperationUrl} from '../../QueryResults/helpers/buildOperationUrl';
 import {getOperationUrl} from '../../QueryResults/helpers/getOperationUrl';
 
 export const preparePlanNode = (
-    node: ProcessedNode,
+    accNode: ProcessedNode,
     operationIdToCluster: Map<string, string>,
 ): ProcessedNode => {
-    if (node.type === 'in' || node.type === 'out') {
-        const table = parseTablePath(node.title ?? '');
+    if (accNode.type === 'in' || accNode.type === 'out') {
+        const table = parseTablePath(accNode.title ?? '');
         if (table) {
-            node.url = genNavigationUrl({cluster: table.cluster, path: table.path});
+            accNode.url = genNavigationUrl({cluster: table.cluster, path: table.path});
         }
-        return node;
+        return accNode;
     }
 
-    if (node.progress?.remoteId) {
-        const id = node.progress.remoteId.split('/').pop();
+    if (accNode.progress?.remoteId) {
+        const id = accNode.progress.remoteId.split('/').pop();
 
         if (!id) {
-            node.url = getOperationUrl(node);
-            return node;
+            accNode.url = getOperationUrl(accNode);
+            return accNode;
         }
 
         const cluster = operationIdToCluster.has(id)
             ? operationIdToCluster.get(id)
-            : node.progress?.remoteData?.cluster_name;
+            : accNode.progress?.remoteData?.cluster_name;
 
         if (cluster) {
-            node.url = buildOperationUrl(cluster, id);
+            accNode.url = buildOperationUrl(cluster, id);
         }
     }
 
-    return node;
+    return accNode;
 };

--- a/packages/ui/src/ui/pages/query-tracker/Plan/services/preparePlanNode.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/services/preparePlanNode.ts
@@ -5,33 +5,33 @@ import {buildOperationUrl} from '../../QueryResults/helpers/buildOperationUrl';
 import {getOperationUrl} from '../../QueryResults/helpers/getOperationUrl';
 
 export const preparePlanNode = (
-    accNode: ProcessedNode,
+    draftNode: ProcessedNode,
     operationIdToCluster: Map<string, string>,
 ): ProcessedNode => {
-    if (accNode.type === 'in' || accNode.type === 'out') {
-        const table = parseTablePath(accNode.title ?? '');
+    if (draftNode.type === 'in' || draftNode.type === 'out') {
+        const table = parseTablePath(draftNode.title ?? '');
         if (table) {
-            accNode.url = genNavigationUrl({cluster: table.cluster, path: table.path});
+            draftNode.url = genNavigationUrl({cluster: table.cluster, path: table.path});
         }
-        return accNode;
+        return draftNode;
     }
 
-    if (accNode.progress?.remoteId) {
-        const id = accNode.progress.remoteId.split('/').pop();
+    if (draftNode.progress?.remoteId) {
+        const id = draftNode.progress.remoteId.split('/').pop();
 
         if (!id) {
-            accNode.url = getOperationUrl(accNode);
-            return accNode;
+            draftNode.url = getOperationUrl(draftNode);
+            return draftNode;
         }
 
         const cluster = operationIdToCluster.has(id)
             ? operationIdToCluster.get(id)
-            : accNode.progress?.remoteData?.cluster_name;
+            : draftNode.progress?.remoteData?.cluster_name;
 
         if (cluster) {
-            accNode.url = buildOperationUrl(cluster, id);
+            draftNode.url = buildOperationUrl(cluster, id);
         }
     }
 
-    return accNode;
+    return draftNode;
 };

--- a/packages/ui/src/ui/pages/query-tracker/Plan/utils.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/utils.ts
@@ -429,23 +429,23 @@ export function updateProgress(
 export function updateColors(nodes: DataSet<ProcessedNode>, colors: GraphColors) {
     const itemsToUpdate: ProcessedNode[] = [];
     nodes.forEach(
-        (accNode) => {
-            if (accNode.type === 'in' || accNode.type === 'out') {
-                accNode.image = drawTable(colors);
+        (draftNode) => {
+            if (draftNode.type === 'in' || draftNode.type === 'out') {
+                draftNode.image = drawTable(colors);
             } else {
-                const detail = accNode.progress;
+                const detail = draftNode.progress;
 
-                accNode.font = {
+                draftNode.font = {
                     color: detail?.remoteId ? colors.text.link : colors.text.label,
                 };
 
                 if (detail) {
-                    accNode.image = drawCircle({type: 'update', node: detail, colors});
+                    draftNode.image = drawCircle({type: 'update', node: detail, colors});
                 } else {
-                    accNode.image = drawCircle({type: 'new', colors});
+                    draftNode.image = drawCircle({type: 'new', colors});
                 }
             }
-            itemsToUpdate.push(accNode);
+            itemsToUpdate.push(draftNode);
         },
         {
             filter(item) {
@@ -652,11 +652,11 @@ export function drawRunningIcon(progress: NodeProgress | undefined, {operation}:
 
 export function handleRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
     return (node: T) => {
-        refs.forEach((accRef) => {
-            if (typeof accRef === 'function') {
-                accRef(node);
-            } else if (accRef) {
-                (accRef.current as T) = node;
+        refs.forEach((draftRef) => {
+            if (typeof draftRef === 'function') {
+                draftRef(node);
+            } else if (draftRef) {
+                (draftRef.current as T) = node;
             }
         });
     };

--- a/packages/ui/src/ui/pages/query-tracker/Plan/utils.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/utils.ts
@@ -429,23 +429,23 @@ export function updateProgress(
 export function updateColors(nodes: DataSet<ProcessedNode>, colors: GraphColors) {
     const itemsToUpdate: ProcessedNode[] = [];
     nodes.forEach(
-        (node) => {
-            if (node.type === 'in' || node.type === 'out') {
-                node.image = drawTable(colors);
+        (accNode) => {
+            if (accNode.type === 'in' || accNode.type === 'out') {
+                accNode.image = drawTable(colors);
             } else {
-                const detail = node.progress;
+                const detail = accNode.progress;
 
-                node.font = {
+                accNode.font = {
                     color: detail?.remoteId ? colors.text.link : colors.text.label,
                 };
 
                 if (detail) {
-                    node.image = drawCircle({type: 'update', node: detail, colors});
+                    accNode.image = drawCircle({type: 'update', node: detail, colors});
                 } else {
-                    node.image = drawCircle({type: 'new', colors});
+                    accNode.image = drawCircle({type: 'new', colors});
                 }
             }
-            itemsToUpdate.push(node);
+            itemsToUpdate.push(accNode);
         },
         {
             filter(item) {
@@ -652,11 +652,11 @@ export function drawRunningIcon(progress: NodeProgress | undefined, {operation}:
 
 export function handleRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
     return (node: T) => {
-        refs.forEach((ref) => {
-            if (typeof ref === 'function') {
-                ref(node);
-            } else if (ref) {
-                (ref.current as T) = node;
+        refs.forEach((accRef) => {
+            if (typeof accRef === 'function') {
+                accRef(node);
+            } else if (accRef) {
+                (accRef.current as T) = node;
             }
         });
     };

--- a/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLTable/YQLTable.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueryResultsView/YQLTable/YQLTable.tsx
@@ -388,9 +388,9 @@ function getSortedData<T>(
     }
     const sortOrderArray = Array.isArray(sortOrder) ? sortOrder : [sortOrder];
     const sortColumns = sortOrderArray.reduce(
-        (obj, {columnId, order}) => {
-            obj[columnId] = order;
-            return obj;
+        (accObj, {columnId, order}) => {
+            accObj[columnId] = order;
+            return accObj;
         },
         {} as Record<string, OrderType>,
     );

--- a/packages/ui/src/ui/services/promisified-worker.ts
+++ b/packages/ui/src/ui/services/promisified-worker.ts
@@ -117,6 +117,7 @@ export async function promisifyWorker<T extends ExposedFunctions>(
         return jobResult;
     }
 
+    // eslint-disable-next-line no-param-reassign
     worker.onmessage = function (message: MessageEvent<Response>) {
         const response = message.data;
 
@@ -138,6 +139,7 @@ export async function promisifyWorker<T extends ExposedFunctions>(
         }
     };
 
+    // eslint-disable-next-line no-param-reassign
     worker.onerror = function (error) {
         // We don't actually know what job the error occured in, so reject them all just to be safe.
         // This event should never fire since we have a try catch within the worker's onmessage

--- a/packages/ui/src/ui/store/actions/components/versions/versions_v2.ts
+++ b/packages/ui/src/ui/store/actions/components/versions/versions_v2.ts
@@ -126,13 +126,8 @@ function prepareSummary({total, error, ...versions}: DiscoverVersionsData['summa
 function prepareDetails(details: DiscoverVersionsData['details']) {
     return map_(details, (item) => {
         const calculatedState = item.offline ? 'offline' : 'online';
-        item.state = item.state ? item.state : calculatedState;
-        if (item.error) {
-            item.state = 'error';
-        }
-
-        item.banned = Boolean(item.banned);
-        return item;
+        const state = item.error ? 'error' : item.state || calculatedState;
+        return {...item, state, banned: Boolean(item.banned)};
     });
 }
 

--- a/packages/ui/src/ui/store/actions/navigation/content/map-node.js
+++ b/packages/ui/src/ui/store/actions/navigation/content/map-node.js
@@ -307,9 +307,9 @@ export function selectAll(isAllSelected) {
 
             selected = reduce_(
                 allNodes,
-                (res, node) => {
-                    res[ypath.getValue(node)] = true;
-                    return res;
+                (accRes, node) => {
+                    accRes[ypath.getValue(node)] = true;
+                    return accRes;
                 },
                 {},
             );

--- a/packages/ui/src/ui/store/actions/navigation/content/table/table.js
+++ b/packages/ui/src/ui/store/actions/navigation/content/table/table.js
@@ -501,8 +501,8 @@ export function getTableData() {
                 // if we have columns preset -> update checked according to preset
                 const preset = selectColumnsPreset(state);
                 if (preset?.columns) {
-                    preparedColumns.forEach((column) => {
-                        column.checked = preset?.columns?.includes(column.name);
+                    preparedColumns.forEach((draftColumn) => {
+                        draftColumn.checked = preset?.columns?.includes(draftColumn.name);
                     });
                 }
                 dispatch(setColumns(preparedColumns, preparedOmittedColumns, deniedKeyColumns));

--- a/packages/ui/src/ui/store/actions/navigation/content/table/table.js
+++ b/packages/ui/src/ui/store/actions/navigation/content/table/table.js
@@ -424,6 +424,8 @@ export function updateTableData() {
                     dispatch(setColumns(preparedColumns, preparedOmittedColumns, []));
                 }
 
+                let displayRows = rows;
+
                 if (moveBackward) {
                     let newOffsetValue;
                     if (!isEmpty_(offsetValue) && rows.length < requestedPageSize) {
@@ -436,7 +438,7 @@ export function updateTableData() {
                             requestedPageSize - rows.length + 1,
                             previousRows.length,
                         );
-                        rows = rows.concat(previousRows.slice(1, addRowCount));
+                        displayRows = rows.concat(previousRows.slice(1, addRowCount));
                     } else {
                         const keyColumns = selectKeyColumns(state);
                         newOffsetValue = Query.prepareKey(getColumnsValues(rows[0], keyColumns));
@@ -452,7 +454,7 @@ export function updateTableData() {
 
                 dispatch({
                     type: GET_TABLE_DATA.SUCCESS,
-                    data: {rows, yqlTypes},
+                    data: {rows: displayRows, yqlTypes},
                 });
             })
             .catch((error) => {

--- a/packages/ui/src/ui/store/actions/navigation/tabs/tablet-errors/tablet-errors-by-path.ts
+++ b/packages/ui/src/ui/store/actions/navigation/tabs/tablet-errors/tablet-errors-by-path.ts
@@ -54,8 +54,7 @@ export function loadTabletErrorsByTablePath(
                 omit_(params, ['fixed_end_timestamp']),
             )
         ) {
-            page = 0;
-            dispatch(tabletErrorsByPathActions.updateFilter({pageFilter: page}));
+            dispatch(tabletErrorsByPathActions.updateFilter({pageFilter: 0}));
             return Promise.resolve();
         }
 

--- a/packages/ui/src/ui/store/actions/navigation/tabs/tablet-errors/tablet-errors-by-path.ts
+++ b/packages/ui/src/ui/store/actions/navigation/tabs/tablet-errors/tablet-errors-by-path.ts
@@ -59,14 +59,15 @@ export function loadTabletErrorsByTablePath(
         }
 
         const prevData = selectTabletErrorsByPathData(state);
-        if (page != 0 && prevData) {
-            params.fixed_end_timestamp = prevData.fixed_end_timestamp;
-        }
+        const requestParams =
+            page != 0 && prevData
+                ? {...params, fixed_end_timestamp: prevData.fixed_end_timestamp}
+                : params;
 
         return fetchFromTabletErrorsApi(
             'tablet_errors_by_table',
             cluster,
-            {...params, offset: page * ROWS_PER_PAGE, count_limit: 100},
+            {...requestParams, offset: page * ROWS_PER_PAGE, count_limit: 100},
             cancelHelper.removeAllAndGenerateNextToken(),
         )
             .then(({data}) => {
@@ -74,7 +75,7 @@ export function loadTabletErrorsByTablePath(
                     page === 0
                         ? {
                               data,
-                              dataParams: params,
+                              dataParams: requestParams,
                               total_row_count: data.total_row_count,
                               error_count_limit_exceeded: data?.error_count_limit_exceeded,
                           }

--- a/packages/ui/src/ui/store/actions/operations/index.js
+++ b/packages/ui/src/ui/store/actions/operations/index.js
@@ -84,7 +84,7 @@ export function setPoolsAndWeights(
 
         const params = reduce_(
             pools,
-            (res, pool, tree) => {
+            (accRes, pool, tree) => {
                 const old = poolTrees[tree] || {};
                 const treeParams = {};
 
@@ -128,9 +128,9 @@ export function setPoolsAndWeights(
                 }
 
                 if (Object.keys(treeParams).length > 0) {
-                    res[tree] = treeParams;
+                    accRes[tree] = treeParams;
                 }
-                return res;
+                return accRes;
             },
             {},
         );

--- a/packages/ui/src/ui/store/actions/system/chunks.js
+++ b/packages/ui/src/ui/store/actions/system/chunks.js
@@ -118,8 +118,8 @@ function prepareChunkCells(chunks) {
         };
     });
 
-    forEach_(chunkTypes, (type) => {
-        type = type.name;
+    forEach_(chunkTypes, (chunkType) => {
+        const type = chunkType.name;
 
         if (chunks[type]) {
             // Some chunks types may not exist on cluster, e.g. foreign chunks

--- a/packages/ui/src/ui/store/actions/system/nodes.ts
+++ b/packages/ui/src/ui/store/actions/system/nodes.ts
@@ -177,11 +177,11 @@ type ExtendedCalculatedInfo = 'alerts_online' | 'alerts_offline';
 
 function increaseFlagCounter<
     K extends keyof RackInfo['nodes'][number]['$attributes'] | ExtendedCalculatedInfo,
->(accDst: Partial<Record<K, number>>, name: K, attrs: Record<K, boolean>) {
-    if (accDst[name] === undefined) {
-        accDst[name] = attrs[name] ? 1 : 0;
+>(draftDst: Partial<Record<K, number>>, name: K, attrs: Record<K, boolean>) {
+    if (draftDst[name] === undefined) {
+        draftDst[name] = attrs[name] ? 1 : 0;
     } else {
-        accDst[name]! += attrs[name] ? 1 : 0;
+        draftDst[name]! += attrs[name] ? 1 : 0;
     }
 }
 

--- a/packages/ui/src/ui/store/actions/system/nodes.ts
+++ b/packages/ui/src/ui/store/actions/system/nodes.ts
@@ -177,11 +177,11 @@ type ExtendedCalculatedInfo = 'alerts_online' | 'alerts_offline';
 
 function increaseFlagCounter<
     K extends keyof RackInfo['nodes'][number]['$attributes'] | ExtendedCalculatedInfo,
->(dst: Partial<Record<K, number>>, name: K, attrs: Record<K, boolean>) {
-    if (dst[name] === undefined) {
-        dst[name] = attrs[name] ? 1 : 0;
+>(accDst: Partial<Record<K, number>>, name: K, attrs: Record<K, boolean>) {
+    if (accDst[name] === undefined) {
+        accDst[name] = attrs[name] ? 1 : 0;
     } else {
-        dst[name]! += attrs[name] ? 1 : 0;
+        accDst[name]! += attrs[name] ? 1 : 0;
     }
 }
 

--- a/packages/ui/src/ui/store/actions/system/schedulers.js
+++ b/packages/ui/src/ui/store/actions/system/schedulers.js
@@ -119,8 +119,8 @@ export function getAgents() {
             attributes: ['annotations', 'maintenance', 'maintenance_message'],
             ...USE_SUPRESS_SYNC,
         })
-        .then((hosts) => {
-            hosts = hosts || [];
+        .then((_hosts) => {
+            const hosts = _hosts || [];
             const res = sortBy_(hosts, (host) => {
                 return ypath.getValue(host, '');
             });

--- a/packages/ui/src/ui/store/actions/users/index.js
+++ b/packages/ui/src/ui/store/actions/users/index.js
@@ -44,10 +44,12 @@ export function prepareUserData(item) {
     allGroups.sort();
     const hasIdm = flags.get(idm || false);
 
-    item.$attributes.idm = hasIdm;
-    item.$attributes.externalSystem = getExternalSystem(ldap, hasIdm);
-    item.$attributes['transitiveGroups'] = difference_(allGroups, groups);
-    return item.$attributes;
+    return {
+        ...item.$attributes,
+        idm: hasIdm,
+        externalSystem: getExternalSystem(ldap, hasIdm),
+        transitiveGroups: difference_(allGroups, groups),
+    };
 }
 
 export function fetchUsers() {

--- a/packages/ui/src/ui/store/reducers/components/nodes/nodes/node.tsx
+++ b/packages/ui/src/ui/store/reducers/components/nodes/nodes/node.tsx
@@ -231,10 +231,10 @@ export class Node {
 
         this.IOWeight = reduce_(
             media,
-            (result, medium, mediumName) => {
-                result[mediumName] = medium.io_weight;
+            (accResult, medium, mediumName) => {
+                accResult[mediumName] = medium.io_weight;
 
-                return result;
+                return accResult;
             },
             {} as Node['IOWeight'],
         );
@@ -354,16 +354,16 @@ export class Node {
         let usedDataInd = 0;
         let generatedColorInd = SERIE_COLORS.length;
 
-        memory = map_(memory, (categoryData) => {
-            memoryUsage += categoryData.rawData.used || 0;
+        memory = map_(memory, (accCategoryData) => {
+            memoryUsage += accCategoryData.rawData.used || 0;
             // the first 10 objects with a non-zero value are guaranteed to receive a predefined color value
-            if (categoryData.rawData.used && usedDataInd < 10) {
-                categoryData.color = Node.getColor(usedDataInd++);
+            if (accCategoryData.rawData.used && usedDataInd < 10) {
+                accCategoryData.color = Node.getColor(usedDataInd++);
             } else {
                 // the rest are generated
-                categoryData.color = Node.getColor(generatedColorInd++);
+                accCategoryData.color = Node.getColor(generatedColorInd++);
             }
-            return categoryData;
+            return accCategoryData;
         });
 
         this.memoryData = memory;
@@ -389,9 +389,9 @@ export class Node {
             const normalizeBy = 100 / this.memoryProgress;
 
             this.memoryProgress *= normalizeBy;
-            this.memoryData = map_(memory, (categoryData) => {
-                categoryData.value *= normalizeBy;
-                return categoryData;
+            this.memoryData = map_(memory, (accCategoryData) => {
+                accCategoryData.value *= normalizeBy;
+                return accCategoryData;
             });
         }
     }

--- a/packages/ui/src/ui/store/reducers/components/nodes/nodes/node.tsx
+++ b/packages/ui/src/ui/store/reducers/components/nodes/nodes/node.tsx
@@ -354,16 +354,16 @@ export class Node {
         let usedDataInd = 0;
         let generatedColorInd = SERIE_COLORS.length;
 
-        memory = map_(memory, (accCategoryData) => {
-            memoryUsage += accCategoryData.rawData.used || 0;
+        memory = map_(memory, (draftCategoryData) => {
+            memoryUsage += draftCategoryData.rawData.used || 0;
             // the first 10 objects with a non-zero value are guaranteed to receive a predefined color value
-            if (accCategoryData.rawData.used && usedDataInd < 10) {
-                accCategoryData.color = Node.getColor(usedDataInd++);
+            if (draftCategoryData.rawData.used && usedDataInd < 10) {
+                draftCategoryData.color = Node.getColor(usedDataInd++);
             } else {
                 // the rest are generated
-                accCategoryData.color = Node.getColor(generatedColorInd++);
+                draftCategoryData.color = Node.getColor(generatedColorInd++);
             }
-            return accCategoryData;
+            return draftCategoryData;
         });
 
         this.memoryData = memory;
@@ -389,9 +389,9 @@ export class Node {
             const normalizeBy = 100 / this.memoryProgress;
 
             this.memoryProgress *= normalizeBy;
-            this.memoryData = map_(memory, (accCategoryData) => {
-                accCategoryData.value *= normalizeBy;
-                return accCategoryData;
+            this.memoryData = map_(memory, (draftCategoryData) => {
+                draftCategoryData.value *= normalizeBy;
+                return draftCategoryData;
             });
         }
     }

--- a/packages/ui/src/ui/store/reducers/components/nodes/url-mapping.ts
+++ b/packages/ui/src/ui/store/reducers/components/nodes/url-mapping.ts
@@ -43,11 +43,11 @@ const createParam = (group: string, value: string, direction: string) => ({
 const createParams = (group: string, values: Array<string>) =>
     reduce_(
         values,
-        (res, value) => {
-            res[`${value}From`] = createParam(group, value, 'from');
-            res[`${value}To`] = createParam(group, value, 'to');
+        (accRes, value) => {
+            accRes[`${value}From`] = createParam(group, value, 'from');
+            accRes[`${value}To`] = createParam(group, value, 'to');
 
-            return res;
+            return accRes;
         },
         {} as Record<string, ReturnType<typeof createParam>>,
     );

--- a/packages/ui/src/ui/store/reducers/dashboard/url-mapping.js
+++ b/packages/ui/src/ui/store/reducers/dashboard/url-mapping.js
@@ -10,18 +10,18 @@ import {Page} from '../../../constants/index';
 
 const preparedListParams = reduce_(
     listParams,
-    (result, value, key) => {
-        result[Page.OPERATIONS + '_' + key] = {...value};
-        return result;
+    (accResult, value, key) => {
+        accResult[Page.OPERATIONS + '_' + key] = {...value};
+        return accResult;
     },
     {},
 );
 
 const preparedAccountsParams = reduce_(
     accountsParams,
-    (result, value, key) => {
-        result[Page.ACCOUNTS + '_' + key] = {...value};
-        return result;
+    (accResult, value, key) => {
+        accResult[Page.ACCOUNTS + '_' + key] = {...value};
+        return accResult;
     },
     {},
 );

--- a/packages/ui/src/ui/store/reducers/dashboard/url-mapping.js
+++ b/packages/ui/src/ui/store/reducers/dashboard/url-mapping.js
@@ -40,8 +40,8 @@ export const dashboardParams = {
 };
 
 export function getDashboardPreparedState(state, location) {
-    state = getListPreparedState(state, location);
-    state = getAccountsPreparedState(state, location);
+    const listState = getListPreparedState(state, location);
+    const dashboardState = getAccountsPreparedState(listState, location);
 
-    return state;
+    return dashboardState;
 }

--- a/packages/ui/src/ui/store/reducers/global/index.ts
+++ b/packages/ui/src/ui/store/reducers/global/index.ts
@@ -171,15 +171,15 @@ const initialState: GlobalState = {
 function updatedTitle(
     state: GlobalState,
     {
-        cluster,
-        page,
-        path,
+        cluster: _cluster,
+        page: _page,
+        path: _path,
         clusters,
     }: Pick<GlobalState, 'cluster' | 'page' | 'path'> & {clusters: Record<string, ClusterConfig>},
 ) {
-    cluster = typeof cluster !== 'undefined' ? cluster : state.cluster;
-    page = typeof page !== 'undefined' ? page : state.page;
-    path = typeof path !== 'undefined' ? path : state.path;
+    const cluster = typeof _cluster !== 'undefined' ? _cluster : state.cluster;
+    const page = typeof _page !== 'undefined' ? _page : state.page;
+    const path = typeof _path !== 'undefined' ? _path : state.path;
 
     const clusterConfig = getClusterConfig(clusters, cluster ?? '');
     const clusterName = clusterConfig.name || cluster;

--- a/packages/ui/src/ui/store/reducers/operations/jobs/jobs.ts
+++ b/packages/ui/src/ui/store/reducers/operations/jobs/jobs.ts
@@ -189,8 +189,9 @@ function prepareJobs({
     // Backward compatibility for fail_context
     // TODO: find out, do we still need it?
     return map_(prepared, (job) => {
-        job.fail_context_size = job.fail_context_size || 0;
-        return new Job({clusterConfig, job, operationId});
+        const preparedJob = Object.assign({}, job);
+        preparedJob.fail_context_size = job.fail_context_size || 0;
+        return new Job({clusterConfig, job: preparedJob, operationId});
     });
 }
 

--- a/packages/ui/src/ui/store/reducers/operations/list/list.ts
+++ b/packages/ui/src/ui/store/reducers/operations/list/list.ts
@@ -258,26 +258,26 @@ function reducer(state = initialState, action: OperationsListStateAction): Opera
             const counters: any = action.data;
             const filters = reduce_(
                 state.filters,
-                (filters, value, name) => {
+                (accFilters, value, name) => {
                     switch (value.type) {
                         case STATE_FILTER:
-                            filters[name as keyof typeof filters] = {
+                            accFilters[name as keyof typeof accFilters] = {
                                 ...value,
                                 counters,
                             };
                             break;
                         case PARAM_FILTER:
-                            filters[name as keyof typeof filters] = {
+                            accFilters[name as keyof typeof accFilters] = {
                                 ...value,
                                 counter: counters.failed_jobs_count,
                             };
                             break;
                         default:
-                            filters[name as keyof typeof filters] = value;
+                            accFilters[name as keyof typeof accFilters] = value;
                             break;
                     }
 
-                    return filters;
+                    return accFilters;
                 },
                 {} as OperationsListState['filters'],
             );

--- a/packages/ui/src/ui/store/reducers/system/masters.ts
+++ b/packages/ui/src/ui/store/reducers/system/masters.ts
@@ -36,27 +36,27 @@ function calculateStatusCounts(masters: Array<MasterDataItem | undefined>) {
 
     return reduce_(
         masters,
-        (result, master) => {
+        (accResult, master) => {
             if (!master || !master.state) {
-                return result;
+                return accResult;
             }
 
             switch (master.state) {
                 case 'stopped':
                 case 'unknown':
-                    result.unavailable += 1;
+                    accResult.unavailable += 1;
                     break;
                 case 'elections':
                 case 'follower_recovery':
                 case 'leader_recovery':
-                    result.recovery += 1;
+                    accResult.recovery += 1;
                     break;
                 case 'following':
                 case 'leading':
-                    result.success += 1;
+                    accResult.success += 1;
             }
 
-            return result;
+            return accResult;
         },
         initialStatusCount,
     );

--- a/packages/ui/src/ui/store/selectors/components/node/memory.ts
+++ b/packages/ui/src/ui/store/selectors/components/node/memory.ts
@@ -134,9 +134,9 @@ const selectNodeMemoryUsageBundlesByName = createSelector(
             maxRowCache = max_([maxRowCache, tmp.rowCache])!;
         });
 
-        forEach_(itemsByName, (accItem) => {
-            accItem.tabletStaticLimit = maxTabletStatic;
-            accItem.rowCacheLimit = maxRowCache;
+        forEach_(itemsByName, (draftItem) => {
+            draftItem.tabletStaticLimit = maxTabletStatic;
+            draftItem.rowCacheLimit = maxRowCache;
         });
 
         return itemsByName;
@@ -306,14 +306,14 @@ const selectNodeMemoryUsageTablesAndBundlesByName = createSelector(
         });
 
         if (!allowBundles) {
-            forEach_(tablesByName, (accItem) => {
-                if (accItem.isBundle) {
+            forEach_(tablesByName, (draftItem) => {
+                if (draftItem.isBundle) {
                     return;
                 }
 
-                accItem.tabletDynamic.limit = maxDynamic;
-                accItem.tabletStaticLimit = maxStatic;
-                accItem.rowCacheLimit = maxRowCache;
+                draftItem.tabletDynamic.limit = maxDynamic;
+                draftItem.tabletStaticLimit = maxStatic;
+                draftItem.rowCacheLimit = maxRowCache;
             });
         }
 

--- a/packages/ui/src/ui/store/selectors/components/node/memory.ts
+++ b/packages/ui/src/ui/store/selectors/components/node/memory.ts
@@ -134,9 +134,9 @@ const selectNodeMemoryUsageBundlesByName = createSelector(
             maxRowCache = max_([maxRowCache, tmp.rowCache])!;
         });
 
-        forEach_(itemsByName, (item) => {
-            item.tabletStaticLimit = maxTabletStatic;
-            item.rowCacheLimit = maxRowCache;
+        forEach_(itemsByName, (accItem) => {
+            accItem.tabletStaticLimit = maxTabletStatic;
+            accItem.rowCacheLimit = maxRowCache;
         });
 
         return itemsByName;
@@ -306,14 +306,14 @@ const selectNodeMemoryUsageTablesAndBundlesByName = createSelector(
         });
 
         if (!allowBundles) {
-            forEach_(tablesByName, (item) => {
-                if (item.isBundle) {
+            forEach_(tablesByName, (accItem) => {
+                if (accItem.isBundle) {
                     return;
                 }
 
-                item.tabletDynamic.limit = maxDynamic;
-                item.tabletStaticLimit = maxStatic;
-                item.rowCacheLimit = maxRowCache;
+                accItem.tabletDynamic.limit = maxDynamic;
+                accItem.tabletStaticLimit = maxStatic;
+                accItem.rowCacheLimit = maxRowCache;
             });
         }
 

--- a/packages/ui/src/ui/store/selectors/groups.ts
+++ b/packages/ui/src/ui/store/selectors/groups.ts
@@ -44,11 +44,11 @@ export const selectGroupsTree = createSelector([selectGroups], (groups) => {
     res[ROOT_GROUP_NAME] = root;
 
     const hasChildren: Record<string, boolean> = {};
-    forEach_(res, (item: GroupsTreeNode) => {
-        if (item === root) {
+    forEach_(res, (accItem: GroupsTreeNode) => {
+        if (accItem === root) {
             return;
         }
-        let {memberOf = []} = item;
+        let {memberOf = []} = accItem;
         if (memberOf.length === 0) {
             memberOf = [ROOT_GROUP_NAME];
         }
@@ -59,14 +59,14 @@ export const selectGroupsTree = createSelector([selectGroups], (groups) => {
              * a group might be a member of many other groups
              * i.e. different copies will have different parent field
              */
-            const itemCopy = {...item, parent};
+            const itemCopy = {...accItem, parent};
             res[parent].children.push(itemCopy);
-            item.parent = parent;
+            accItem.parent = parent;
         });
     });
-    hammer.treeList.treeForEach(res[ROOT_GROUP_NAME], (item: GroupsTreeNode, depth: number) => {
-        item.shift = depth - 1; // -1 cause <Root> is not visible
-        item.hasChildren = hasChildren[item.name!];
+    hammer.treeList.treeForEach(res[ROOT_GROUP_NAME], (accItem: GroupsTreeNode, depth: number) => {
+        accItem.shift = depth - 1; // -1 cause <Root> is not visible
+        accItem.hasChildren = hasChildren[accItem.name!];
     });
     return res;
 });
@@ -107,16 +107,16 @@ const selectGroupsTreeFilteredAndExpanded = createSelector(
             }
         });
 
-        hammer.treeList.treeForEach(res.children, (node: GroupsTreeNode) => {
-            const userInteractedWithNode = typeof expandedByUser[node.name] !== 'undefined';
+        hammer.treeList.treeForEach(res.children, (accNode: GroupsTreeNode) => {
+            const userInteractedWithNode = typeof expandedByUser[accNode.name] !== 'undefined';
 
             const expanded = userInteractedWithNode ? expandedByUser : expandedBySearch;
 
-            if (!expanded[node.name]) {
-                node.expanded = false;
-                node.children = [];
+            if (!expanded[accNode.name]) {
+                accNode.expanded = false;
+                accNode.children = [];
             } else {
-                node.expanded = true;
+                accNode.expanded = true;
             }
         });
 

--- a/packages/ui/src/ui/store/selectors/groups.ts
+++ b/packages/ui/src/ui/store/selectors/groups.ts
@@ -44,11 +44,11 @@ export const selectGroupsTree = createSelector([selectGroups], (groups) => {
     res[ROOT_GROUP_NAME] = root;
 
     const hasChildren: Record<string, boolean> = {};
-    forEach_(res, (accItem: GroupsTreeNode) => {
-        if (accItem === root) {
+    forEach_(res, (draftItem: GroupsTreeNode) => {
+        if (draftItem === root) {
             return;
         }
-        let {memberOf = []} = accItem;
+        let {memberOf = []} = draftItem;
         if (memberOf.length === 0) {
             memberOf = [ROOT_GROUP_NAME];
         }
@@ -59,15 +59,18 @@ export const selectGroupsTree = createSelector([selectGroups], (groups) => {
              * a group might be a member of many other groups
              * i.e. different copies will have different parent field
              */
-            const itemCopy = {...accItem, parent};
+            const itemCopy = {...draftItem, parent};
             res[parent].children.push(itemCopy);
-            accItem.parent = parent;
+            draftItem.parent = parent;
         });
     });
-    hammer.treeList.treeForEach(res[ROOT_GROUP_NAME], (accItem: GroupsTreeNode, depth: number) => {
-        accItem.shift = depth - 1; // -1 cause <Root> is not visible
-        accItem.hasChildren = hasChildren[accItem.name!];
-    });
+    hammer.treeList.treeForEach(
+        res[ROOT_GROUP_NAME],
+        (draftItem: GroupsTreeNode, depth: number) => {
+            draftItem.shift = depth - 1; // -1 cause <Root> is not visible
+            draftItem.hasChildren = hasChildren[draftItem.name!];
+        },
+    );
     return res;
 });
 
@@ -107,16 +110,16 @@ const selectGroupsTreeFilteredAndExpanded = createSelector(
             }
         });
 
-        hammer.treeList.treeForEach(res.children, (accNode: GroupsTreeNode) => {
-            const userInteractedWithNode = typeof expandedByUser[accNode.name] !== 'undefined';
+        hammer.treeList.treeForEach(res.children, (draftNode: GroupsTreeNode) => {
+            const userInteractedWithNode = typeof expandedByUser[draftNode.name] !== 'undefined';
 
             const expanded = userInteractedWithNode ? expandedByUser : expandedBySearch;
 
-            if (!expanded[accNode.name]) {
-                accNode.expanded = false;
-                accNode.children = [];
+            if (!expanded[draftNode.name]) {
+                draftNode.expanded = false;
+                draftNode.children = [];
             } else {
-                accNode.expanded = true;
+                draftNode.expanded = true;
             }
         });
 

--- a/packages/ui/src/ui/store/selectors/navigation/content/map-node.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/map-node.js
@@ -164,8 +164,8 @@ const selectTableColumns = createSelector(
 export const selectPreparedTableColumns = createSelector(selectTableColumns, (columns) =>
     transform_(
         columns,
-        (preparedColumns, column, name) => {
-            preparedColumns[name] = {
+        (accPreparedColumns, column, name) => {
+            accPreparedColumns[name] = {
                 ...column,
                 name,
             };
@@ -284,9 +284,9 @@ export const TYPE_WEIGHTS = map_(
         'boolean_node',
     ],
     (type, index, types) => ({type, weight: types.length - index}),
-).reduce((res, item) => {
-    res[item.type] = item.weight;
-    return res;
+).reduce((accRes, item) => {
+    accRes[item.type] = item.weight;
+    return accRes;
 }, {});
 
 export const selectSortedNodes = createSelector(

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/schema/index.js
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/schema/index.js
@@ -51,15 +51,15 @@ export const selectFilteredSchema = createSelector([selectSchema, selectColumn],
 export const selectComputedColumns = createSelector([selectSchema], (schema) => {
     const items = reduce_(
         schema,
-        (res, schemaEntry) => {
+        (accRes, schemaEntry) => {
             forEach_(schemaEntry, (columnValue, columnName) => {
-                res[columnName] = res[columnName] || {
+                accRes[columnName] = accRes[columnName] || {
                     caption: columnName === 'index' ? '#' : getSchemaColumnName(columnName),
                     sort: false,
                     align: 'left',
                 };
             });
-            return res;
+            return accRes;
         },
         {},
     );

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablet-errors-background.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablet-errors-background.ts
@@ -83,13 +83,13 @@ export const selectTabletErrorsReplicationErrors = createSelector([selectTabletE
         (acc, errors, replicaId) => {
             const errorsByTablet = reduce_(
                 errors,
-                (errAcc, error) => {
+                (accErrors, error) => {
                     const tablet_id = ypath.getValue(error.attributes, '/tablet_id');
-                    if (!errAcc[tablet_id]) {
-                        errAcc[tablet_id] = [];
+                    if (!accErrors[tablet_id]) {
+                        accErrors[tablet_id] = [];
                     }
-                    errAcc[tablet_id].push(error);
-                    return errAcc;
+                    accErrors[tablet_id].push(error);
+                    return accErrors;
                 },
                 {} as ValueOf<typeof acc>,
             );

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablets-ts.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablets-ts.ts
@@ -40,13 +40,13 @@ const SUM_FIELDS: Array<TypedKeys<TabletInfo, number>> = [
 ];
 
 function addHostItem(
-    dst: TreeNode<TabletInfo, TabletInfo>,
+    accDst: TreeNode<TabletInfo, TabletInfo>,
     item: TabletInfo,
-    maxDst: Pick<TabletInfo, TypedKeys<TabletInfo, number>>,
+    accMaxDst: Pick<TabletInfo, TypedKeys<TabletInfo, number>>,
 ) {
-    dst.children.push({
+    accDst.children.push({
         name: item.tablet_id,
-        parent: dst.name,
+        parent: accDst.name,
         attributes: {
             ...item,
             name: item.tablet_id,
@@ -57,9 +57,9 @@ function addHostItem(
     });
 
     forEach_(SUM_FIELDS, (k) => {
-        dst.attributes[k] += item[k];
+        accDst.attributes[k] += item[k];
 
-        maxDst[k] = max_([maxDst[k], item[k]])!;
+        accMaxDst[k] = max_([accMaxDst[k], item[k]])!;
     });
 }
 
@@ -119,10 +119,10 @@ const selectTabletsByNameRoot = createSelector(
             attributes: {} as any,
         };
 
-        forEach_(root.children, (item) => {
-            item.attributes.childrenCount = item.children.length;
+        forEach_(root.children, (accItem) => {
+            accItem.attributes.childrenCount = accItem.children.length;
             forEach_(SUM_FIELDS, (k) => {
-                maxHost[k] = max_([maxHost[k], item.attributes[k]])!;
+                maxHost[k] = max_([maxHost[k], accItem.attributes[k]])!;
             });
         });
 

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/tablets-ts.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/tablets-ts.ts
@@ -40,13 +40,13 @@ const SUM_FIELDS: Array<TypedKeys<TabletInfo, number>> = [
 ];
 
 function addHostItem(
-    accDst: TreeNode<TabletInfo, TabletInfo>,
+    draftDst: TreeNode<TabletInfo, TabletInfo>,
     item: TabletInfo,
-    accMaxDst: Pick<TabletInfo, TypedKeys<TabletInfo, number>>,
+    draftMaxDst: Pick<TabletInfo, TypedKeys<TabletInfo, number>>,
 ) {
-    accDst.children.push({
+    draftDst.children.push({
         name: item.tablet_id,
-        parent: accDst.name,
+        parent: draftDst.name,
         attributes: {
             ...item,
             name: item.tablet_id,
@@ -57,9 +57,9 @@ function addHostItem(
     });
 
     forEach_(SUM_FIELDS, (k) => {
-        accDst.attributes[k] += item[k];
+        draftDst.attributes[k] += item[k];
 
-        accMaxDst[k] = max_([accMaxDst[k], item[k]])!;
+        draftMaxDst[k] = max_([draftMaxDst[k], item[k]])!;
     });
 }
 
@@ -119,10 +119,10 @@ const selectTabletsByNameRoot = createSelector(
             attributes: {} as any,
         };
 
-        forEach_(root.children, (accItem) => {
-            accItem.attributes.childrenCount = accItem.children.length;
+        forEach_(root.children, (draftItem) => {
+            draftItem.attributes.childrenCount = draftItem.children.length;
             forEach_(SUM_FIELDS, (k) => {
-                maxHost[k] = max_([maxHost[k], accItem.attributes[k]])!;
+                maxHost[k] = max_([maxHost[k], draftItem.attributes[k]])!;
             });
         });
 

--- a/packages/ui/src/ui/store/selectors/operations/operations-list.ts
+++ b/packages/ui/src/ui/store/selectors/operations/operations-list.ts
@@ -79,12 +79,12 @@ export const selectOperationsListFilterPresets = createSelector(
             ...createPreconfiguredPresets(login),
             ...reduce_(
                 collectionKeys,
-                (collection, path) => {
+                (accCollection, path) => {
                     const settingName = path.slice(
                         (NAMESPACES.OPERATION_PRESETS.value + NS_SEPARATOR).length,
                     );
-                    collection[settingName] = {...data[path]};
-                    return collection;
+                    accCollection[settingName] = {...data[path]};
+                    return accCollection;
                 },
                 {} as Record<string, OperationPresetsSettings>,
             ),

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
@@ -116,11 +116,11 @@ function calcChildrenIntegrals(
         childrenFlowCPU?: number;
         childrenBurstCPU?: number;
     },
-    accDst: Record<PoolName, PoolExtraInfo>,
+    draftDst: Record<PoolName, PoolExtraInfo>,
 ) {
     const {children, name} = pool;
     if (!children?.length) {
-        const res = (accDst[name] = {
+        const res = (draftDst[name] = {
             childrenBurstCPU: 0,
             childrenFlowCPU: 0,
         });
@@ -133,15 +133,15 @@ function calcChildrenIntegrals(
     };
     for (let i = 0; i < children.length; ++i) {
         const item = children[i];
-        const itemExtraInfo = calcChildrenIntegrals(item, accDst);
+        const itemExtraInfo = calcChildrenIntegrals(item, draftDst);
 
-        accDst[item.name] = itemExtraInfo;
+        draftDst[item.name] = itemExtraInfo;
 
         res.childrenFlowCPU += item.flowCPU || 0 + itemExtraInfo.childrenFlowCPU;
         res.childrenBurstCPU += item.burstCPU || 0 + itemExtraInfo.childrenBurstCPU;
     }
 
-    accDst[name] = res;
+    draftDst[name] = res;
     return res;
 }
 

--- a/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
+++ b/packages/ui/src/ui/store/selectors/scheduling/scheduling-pools.ts
@@ -116,11 +116,11 @@ function calcChildrenIntegrals(
         childrenFlowCPU?: number;
         childrenBurstCPU?: number;
     },
-    dst: Record<PoolName, PoolExtraInfo>,
+    accDst: Record<PoolName, PoolExtraInfo>,
 ) {
     const {children, name} = pool;
     if (!children?.length) {
-        const res = (dst[name] = {
+        const res = (accDst[name] = {
             childrenBurstCPU: 0,
             childrenFlowCPU: 0,
         });
@@ -133,15 +133,15 @@ function calcChildrenIntegrals(
     };
     for (let i = 0; i < children.length; ++i) {
         const item = children[i];
-        const itemExtraInfo = calcChildrenIntegrals(item, dst);
+        const itemExtraInfo = calcChildrenIntegrals(item, accDst);
 
-        dst[item.name] = itemExtraInfo;
+        accDst[item.name] = itemExtraInfo;
 
         res.childrenFlowCPU += item.flowCPU || 0 + itemExtraInfo.childrenFlowCPU;
         res.childrenBurstCPU += item.burstCPU || 0 + itemExtraInfo.childrenBurstCPU;
     }
 
-    dst[name] = res;
+    accDst[name] = res;
     return res;
 }
 

--- a/packages/ui/src/ui/types/query-tracker/query.ts
+++ b/packages/ui/src/ui/types/query-tracker/query.ts
@@ -8,35 +8,35 @@ export const cleanupQueryForDraft = (query: QueryItem): QueryItem => {
     };
 };
 
-export const prepareQueryPlanIds = (accQuery: QueryItem, defaultQueryACO: string): QueryItem => {
-    if (isSingleProgress(accQuery.progress)) {
-        const nodes = accQuery.progress?.yql_plan?.Basic.nodes;
-        const links = accQuery.progress?.yql_plan?.Basic.links;
-        const operations = accQuery.progress?.yql_plan?.Detailed?.Operations;
+export const prepareQueryPlanIds = (draftQuery: QueryItem, defaultQueryACO: string): QueryItem => {
+    if (isSingleProgress(draftQuery.progress)) {
+        const nodes = draftQuery.progress?.yql_plan?.Basic.nodes;
+        const links = draftQuery.progress?.yql_plan?.Basic.links;
+        const operations = draftQuery.progress?.yql_plan?.Detailed?.Operations;
         if (nodes) {
-            nodes.forEach((accNode) => {
-                accNode.id = String(accNode.id);
+            nodes.forEach((draftNode) => {
+                draftNode.id = String(draftNode.id);
             });
         }
         if (links) {
-            links.forEach((accLink) => {
-                accLink.source = String(accLink.source);
-                accLink.target = String(accLink.target);
+            links.forEach((draftLink) => {
+                draftLink.source = String(draftLink.source);
+                draftLink.target = String(draftLink.target);
             });
         }
         if (operations) {
-            operations.forEach((accOperation) => {
-                accOperation.Id = String(accOperation.Id);
-                if (accOperation.DependsOn) {
-                    accOperation.DependsOn = accOperation.DependsOn.map(String);
+            operations.forEach((draftOperation) => {
+                draftOperation.Id = String(draftOperation.Id);
+                if (draftOperation.DependsOn) {
+                    draftOperation.DependsOn = draftOperation.DependsOn.map(String);
                 }
             });
         }
     }
 
-    if (!accQuery.access_control_objects) {
-        accQuery.access_control_objects = [defaultQueryACO];
+    if (!draftQuery.access_control_objects) {
+        draftQuery.access_control_objects = [defaultQueryACO];
     }
 
-    return accQuery;
+    return draftQuery;
 };

--- a/packages/ui/src/ui/types/query-tracker/query.ts
+++ b/packages/ui/src/ui/types/query-tracker/query.ts
@@ -8,35 +8,35 @@ export const cleanupQueryForDraft = (query: QueryItem): QueryItem => {
     };
 };
 
-export const prepareQueryPlanIds = (query: QueryItem, defaultQueryACO: string): QueryItem => {
-    if (isSingleProgress(query.progress)) {
-        const nodes = query.progress?.yql_plan?.Basic.nodes;
-        const links = query.progress?.yql_plan?.Basic.links;
-        const operations = query.progress?.yql_plan?.Detailed?.Operations;
+export const prepareQueryPlanIds = (accQuery: QueryItem, defaultQueryACO: string): QueryItem => {
+    if (isSingleProgress(accQuery.progress)) {
+        const nodes = accQuery.progress?.yql_plan?.Basic.nodes;
+        const links = accQuery.progress?.yql_plan?.Basic.links;
+        const operations = accQuery.progress?.yql_plan?.Detailed?.Operations;
         if (nodes) {
-            nodes.forEach((node) => {
-                node.id = String(node.id);
+            nodes.forEach((accNode) => {
+                accNode.id = String(accNode.id);
             });
         }
         if (links) {
-            links.forEach((link) => {
-                link.source = String(link.source);
-                link.target = String(link.target);
+            links.forEach((accLink) => {
+                accLink.source = String(accLink.source);
+                accLink.target = String(accLink.target);
             });
         }
         if (operations) {
-            operations.forEach((operation) => {
-                operation.Id = String(operation.Id);
-                if (operation.DependsOn) {
-                    operation.DependsOn = operation.DependsOn.map(String);
+            operations.forEach((accOperation) => {
+                accOperation.Id = String(accOperation.Id);
+                if (accOperation.DependsOn) {
+                    accOperation.DependsOn = accOperation.DependsOn.map(String);
                 }
             });
         }
     }
 
-    if (!query.access_control_objects) {
-        query.access_control_objects = [defaultQueryACO];
+    if (!accQuery.access_control_objects) {
+        accQuery.access_control_objects = [defaultQueryACO];
     }
 
-    return query;
+    return accQuery;
 };

--- a/packages/ui/src/ui/utils/accounts/accounts-selector.ts
+++ b/packages/ui/src/ui/utils/accounts/accounts-selector.ts
@@ -83,23 +83,23 @@ export function parseAccountData(data: any) {
     return dst;
 }
 
-function updateMasterMemory(dst: AccountParsedData, attributes: any) {
-    prepareResource(dst, attributes, 'master_memory/total', 'Bytes');
-    prepareResource(dst, attributes, 'master_memory/chunk_host', 'Bytes');
+function updateMasterMemory(accDst: AccountParsedData, attributes: any) {
+    prepareResource(accDst, attributes, 'master_memory/total', 'Bytes');
+    prepareResource(accDst, attributes, 'master_memory/chunk_host', 'Bytes');
 
     const perCell = ypath.getValue(attributes, '/resource_usage/master_memory/per_cell');
     forEach_(perCell, (_value, key) => {
-        prepareResource(dst, attributes, `master_memory/per_cell/${key}`, 'Bytes');
+        prepareResource(accDst, attributes, `master_memory/per_cell/${key}`, 'Bytes');
     });
 
-    dst.master_memory_detailed = ypath.getValue(
+    accDst.master_memory_detailed = ypath.getValue(
         attributes,
         '/resource_usage/detailed_master_memory',
     );
 }
 
 function prepareResource(
-    dst: AccountParsedData,
+    accDst: AccountParsedData,
     resourceAttributes: any,
     path: string,
     format: 'Bytes' | 'Number',
@@ -107,7 +107,7 @@ function prepareResource(
     const name = accountMemoryMediumToFieldName(path);
     const committed = ypath.getValue(resourceAttributes, '/committed_resource_usage/' + path);
     const limit = ypath.getValue(resourceAttributes, '/resource_limits/' + path);
-    (dst as FIX_MY_TYPE)[name] = prepareResourceInfo(
+    (accDst as FIX_MY_TYPE)[name] = prepareResourceInfo(
         {
             total: ypath.getValue(resourceAttributes, '/resource_usage/' + path),
             committed,
@@ -116,7 +116,7 @@ function prepareResource(
         format,
     );
 
-    if (dst.hasRecursiveResources) {
+    if (accDst.hasRecursiveResources) {
         const recursiveUsage = ypath.getValue(
             resourceAttributes,
             '/recursive_resource_usage/' + path,
@@ -125,7 +125,7 @@ function prepareResource(
             resourceAttributes,
             '/recursive_committed_resource_usage/' + path,
         );
-        dst.recursiveResources[name] = prepareResourceInfo(
+        accDst.recursiveResources[name] = prepareResourceInfo(
             {
                 total: recursiveUsage,
                 committed: recursiveCommitted,
@@ -180,7 +180,7 @@ function updateResource(
 }
 
 function updateResourcePerMedium(
-    dst: AccountParsedData,
+    accDst: AccountParsedData,
     attributes: any,
     name: string,
     format: 'Bytes' | 'Number',
@@ -195,9 +195,9 @@ function updateResourcePerMedium(
     const committedPerMedium = ypath.getValue(attributes, '/committed_resource_usage/' + path);
     const limitPerMedium = ypath.getValue(attributes, '/resource_limits/' + path);
 
-    dst.perMedium = {};
+    accDst.perMedium = {};
     forEach_(totalPerMedium, (mediumData, mediumName) => {
-        dst.perMedium[mediumName] = updateResourceFields(
+        accDst.perMedium[mediumName] = updateResourceFields(
             {
                 total: mediumData,
                 committed: committedPerMedium[mediumName],
@@ -210,11 +210,11 @@ function updateResourcePerMedium(
 
     let lastMedium;
     try {
-        if (dst.hasRecursiveResources) {
-            dst.recursiveResources.perMedium = {};
+        if (accDst.hasRecursiveResources) {
+            accDst.recursiveResources.perMedium = {};
             forEach_(recursiveTotalPerMedium, (mediumData, mediumName) => {
                 lastMedium = mediumName;
-                (dst.recursiveResources as FIX_MY_TYPE).perMedium[mediumName] =
+                (accDst.recursiveResources as FIX_MY_TYPE).perMedium[mediumName] =
                     updateResourceFields(
                         {
                             total: mediumData,

--- a/packages/ui/src/ui/utils/accounts/accounts-selector.ts
+++ b/packages/ui/src/ui/utils/accounts/accounts-selector.ts
@@ -83,23 +83,23 @@ export function parseAccountData(data: any) {
     return dst;
 }
 
-function updateMasterMemory(accDst: AccountParsedData, attributes: any) {
-    prepareResource(accDst, attributes, 'master_memory/total', 'Bytes');
-    prepareResource(accDst, attributes, 'master_memory/chunk_host', 'Bytes');
+function updateMasterMemory(draftDst: AccountParsedData, attributes: any) {
+    prepareResource(draftDst, attributes, 'master_memory/total', 'Bytes');
+    prepareResource(draftDst, attributes, 'master_memory/chunk_host', 'Bytes');
 
     const perCell = ypath.getValue(attributes, '/resource_usage/master_memory/per_cell');
     forEach_(perCell, (_value, key) => {
-        prepareResource(accDst, attributes, `master_memory/per_cell/${key}`, 'Bytes');
+        prepareResource(draftDst, attributes, `master_memory/per_cell/${key}`, 'Bytes');
     });
 
-    accDst.master_memory_detailed = ypath.getValue(
+    draftDst.master_memory_detailed = ypath.getValue(
         attributes,
         '/resource_usage/detailed_master_memory',
     );
 }
 
 function prepareResource(
-    accDst: AccountParsedData,
+    draftDst: AccountParsedData,
     resourceAttributes: any,
     path: string,
     format: 'Bytes' | 'Number',
@@ -107,7 +107,7 @@ function prepareResource(
     const name = accountMemoryMediumToFieldName(path);
     const committed = ypath.getValue(resourceAttributes, '/committed_resource_usage/' + path);
     const limit = ypath.getValue(resourceAttributes, '/resource_limits/' + path);
-    (accDst as FIX_MY_TYPE)[name] = prepareResourceInfo(
+    (draftDst as FIX_MY_TYPE)[name] = prepareResourceInfo(
         {
             total: ypath.getValue(resourceAttributes, '/resource_usage/' + path),
             committed,
@@ -116,7 +116,7 @@ function prepareResource(
         format,
     );
 
-    if (accDst.hasRecursiveResources) {
+    if (draftDst.hasRecursiveResources) {
         const recursiveUsage = ypath.getValue(
             resourceAttributes,
             '/recursive_resource_usage/' + path,
@@ -125,7 +125,7 @@ function prepareResource(
             resourceAttributes,
             '/recursive_committed_resource_usage/' + path,
         );
-        accDst.recursiveResources[name] = prepareResourceInfo(
+        draftDst.recursiveResources[name] = prepareResourceInfo(
             {
                 total: recursiveUsage,
                 committed: recursiveCommitted,
@@ -180,7 +180,7 @@ function updateResource(
 }
 
 function updateResourcePerMedium(
-    accDst: AccountParsedData,
+    draftDst: AccountParsedData,
     attributes: any,
     name: string,
     format: 'Bytes' | 'Number',
@@ -195,9 +195,9 @@ function updateResourcePerMedium(
     const committedPerMedium = ypath.getValue(attributes, '/committed_resource_usage/' + path);
     const limitPerMedium = ypath.getValue(attributes, '/resource_limits/' + path);
 
-    accDst.perMedium = {};
+    draftDst.perMedium = {};
     forEach_(totalPerMedium, (mediumData, mediumName) => {
-        accDst.perMedium[mediumName] = updateResourceFields(
+        draftDst.perMedium[mediumName] = updateResourceFields(
             {
                 total: mediumData,
                 committed: committedPerMedium[mediumName],
@@ -210,11 +210,11 @@ function updateResourcePerMedium(
 
     let lastMedium;
     try {
-        if (accDst.hasRecursiveResources) {
-            accDst.recursiveResources.perMedium = {};
+        if (draftDst.hasRecursiveResources) {
+            draftDst.recursiveResources.perMedium = {};
             forEach_(recursiveTotalPerMedium, (mediumData, mediumName) => {
                 lastMedium = mediumName;
-                (accDst.recursiveResources as FIX_MY_TYPE).perMedium[mediumName] =
+                (draftDst.recursiveResources as FIX_MY_TYPE).perMedium[mediumName] =
                     updateResourceFields(
                         {
                             total: mediumData,

--- a/packages/ui/src/ui/utils/accounts/accountsTotal.ts
+++ b/packages/ui/src/ui/utils/accounts/accountsTotal.ts
@@ -71,11 +71,11 @@ function prepareMediumStats<T extends Record<string, MediumStat>>(
     availableSpace: Record<keyof T, number>,
     settings: T,
 ) {
-    return forEach_(settings, (accStats, type) => {
+    return forEach_(settings, (draftStats, type) => {
         const used = usedSpace[type] || 0;
         const available = availableSpace[type] || 0;
-        accStats.usage = used;
-        accStats.limit = available;
+        draftStats.usage = used;
+        draftStats.limit = available;
     });
 }
 

--- a/packages/ui/src/ui/utils/accounts/accountsTotal.ts
+++ b/packages/ui/src/ui/utils/accounts/accountsTotal.ts
@@ -71,24 +71,24 @@ function prepareMediumStats<T extends Record<string, MediumStat>>(
     availableSpace: Record<keyof T, number>,
     settings: T,
 ) {
-    return forEach_(settings, (stats, type) => {
+    return forEach_(settings, (accStats, type) => {
         const used = usedSpace[type] || 0;
         const available = availableSpace[type] || 0;
-        stats.usage = used;
-        stats.limit = available;
+        accStats.usage = used;
+        accStats.limit = available;
     });
 }
 
 function initMediumStats<T extends readonly string[]>(list: T) {
     return reduce_(
         list,
-        (list, type: T[number]) => {
-            list[type] = {
+        (accList, type: T[number]) => {
+            accList[type] = {
                 usage: 0,
                 limit: 0,
             };
 
-            return list;
+            return accList;
         },
         {} as Record<T[number], MediumStat>,
     );

--- a/packages/ui/src/ui/utils/components/tablet-cells/index.js
+++ b/packages/ui/src/ui/utils/components/tablet-cells/index.js
@@ -130,16 +130,16 @@ export function prepareBundles(tabletCells, bundles) {
 
     aggregation = reduce_(
         aggregation,
-        (res, bundle) => {
+        (accRes, bundle) => {
             const $attributes = bundles[bundle.bundle].$attributes;
             const bundleNodes = ypath.getValue($attributes, '/nodes');
-            res[bundle.bundle] = {
+            accRes[bundle.bundle] = {
                 $attributes,
                 ...collectBundlesAttrs({}, $attributes),
                 ...bundle,
                 nodes: bundleNodes,
             };
-            return res;
+            return accRes;
         },
         {},
     );
@@ -165,12 +165,12 @@ export function prepareBundles(tabletCells, bundles) {
 
     const nodeTags = reduce_(
         bundleList,
-        (res, bundle) => {
+        (accRes, bundle) => {
             const tag = bundle?.node_tag_filter;
             if (tag) {
-                res[tag] = res[tag] ? res[tag] + 1 : 1;
+                accRes[tag] = accRes[tag] ? accRes[tag] + 1 : 1;
             }
-            return res;
+            return accRes;
         },
         {},
     );

--- a/packages/ui/src/ui/utils/empty.ts
+++ b/packages/ui/src/ui/utils/empty.ts
@@ -2,19 +2,22 @@ import isEqual_ from 'lodash/isEqual';
 
 import {EMPTY_ARRAY, EMPTY_MAP, EMPTY_OBJECT, EMPTY_SET} from '../constants/empty';
 
-export function replaceEmpty<T extends {}>(data: T) {
-    Object.keys(data).forEach((k) => {
-        const key = k as keyof typeof data;
-        const d = data[key];
-        if (d !== EMPTY_OBJECT && isEqual_(d, EMPTY_OBJECT)) {
-            data[key] = EMPTY_OBJECT as any;
-        } else if (d !== EMPTY_ARRAY && isEqual_(d, EMPTY_ARRAY)) {
-            data[key] = EMPTY_ARRAY as any;
-        } else if (d !== EMPTY_SET && isEqual_(d, EMPTY_SET)) {
-            data[key] = EMPTY_SET as any;
-        } else if (d !== EMPTY_MAP && isEqual_(d, EMPTY_MAP)) {
-            data[key] = EMPTY_MAP as any;
-        }
-    });
-    return data;
+export function replaceEmpty<T extends {}>(data: T): T {
+    return Object.keys(data).reduce(
+        (acc, k) => {
+            const key = k as keyof typeof data;
+            const d = data[key];
+            if (d !== EMPTY_OBJECT && isEqual_(d, EMPTY_OBJECT)) {
+                acc[key] = EMPTY_OBJECT as any;
+            } else if (d !== EMPTY_ARRAY && isEqual_(d, EMPTY_ARRAY)) {
+                acc[key] = EMPTY_ARRAY as any;
+            } else if (d !== EMPTY_SET && isEqual_(d, EMPTY_SET)) {
+                acc[key] = EMPTY_SET as any;
+            } else if (d !== EMPTY_MAP && isEqual_(d, EMPTY_MAP)) {
+                acc[key] = EMPTY_MAP as any;
+            }
+            return acc;
+        },
+        {...data},
+    );
 }

--- a/packages/ui/src/ui/utils/errors/index.ts
+++ b/packages/ui/src/ui/utils/errors/index.ts
@@ -38,10 +38,8 @@ export function getPermissionDeniedError<T extends YTErrorRaw>(error: T): T | un
     return getErrorWithCode([error], yt.codes.PERMISSION_DENIED);
 }
 
-export function appendInnerErrors(targetErr: any, innerErr: YTError) {
-    if (!targetErr) {
-        targetErr = new Error('Unexpected behavior: targetErr is undefined.');
-    }
+export function appendInnerErrors(_targetErr: any, innerErr: YTError) {
+    const targetErr = _targetErr || new Error('Unexpected behavior: targetErr is undefined.');
 
     if (!targetErr.inner_errors) {
         targetErr.inner_errors = [innerErr];

--- a/packages/ui/src/ui/utils/index.ts
+++ b/packages/ui/src/ui/utils/index.ts
@@ -227,10 +227,10 @@ export function valueOrDefault<T>(value: T, defaultValue: T): T {
 export function prepareTableColumns<T extends {caption?: string}>(columns: Record<string, T>) {
     return reduce_(
         columns,
-        (preparedColumns, column, name) => {
-            preparedColumns[name] = {...column, name, caption: column.caption};
+        (accPreparedColumns, column, name) => {
+            accPreparedColumns[name] = {...column, name, caption: column.caption};
 
-            return preparedColumns;
+            return accPreparedColumns;
         },
         {} as Record<string, T & {name: string}>,
     );

--- a/packages/ui/src/ui/utils/navigation/content/table/columns.js
+++ b/packages/ui/src/ui/utils/navigation/content/table/columns.js
@@ -111,9 +111,9 @@ export default class Columns {
 
         const storedColumnsMap = reduce_(
             storedColumns,
-            (storedColumnsMap, column) => {
-                storedColumnsMap[column.name] = column;
-                return storedColumnsMap;
+            (accStoredColumnsMap, column) => {
+                accStoredColumnsMap[column.name] = column;
+                return accStoredColumnsMap;
             },
             {},
         );

--- a/packages/ui/src/ui/utils/navigation/index.ts
+++ b/packages/ui/src/ui/utils/navigation/index.ts
@@ -15,7 +15,7 @@ export function autoCorrectPath(path: string) {
     const secondToLastToken = path[length - 2];
 
     if (length > 1 && lastToken === '/' && secondToLastToken !== '\\') {
-        path = path.slice(0, length - 1);
+        return path.slice(0, length - 1);
     }
 
     return path;
@@ -40,12 +40,17 @@ interface RelativePath {
 }
 
 export function prepareRequest(
-    relativePath: string | RelativePath,
-    parameters: Partial<RelativePath> = {},
+    _relativePath: string | RelativePath,
+    _parameters: Partial<RelativePath> = {},
 ) {
-    if (typeof relativePath !== 'string') {
-        parameters = relativePath;
+    let relativePath: string;
+    let parameters: Partial<RelativePath>;
+    if (typeof _relativePath !== 'string') {
+        parameters = _relativePath;
         relativePath = parameters.relativePath!;
+    } else {
+        relativePath = _relativePath;
+        parameters = _parameters;
     }
 
     const {path, relativePath: _x, transaction, ...rest} = parameters;

--- a/packages/ui/src/ui/utils/navigation/restore-object.js
+++ b/packages/ui/src/ui/utils/navigation/restore-object.js
@@ -11,9 +11,10 @@ function checkPathExists(initialPath, path, step = INITIAL_STEP) {
         .exists({path})
         .then((isExists) => {
             if (isExists) {
-                const newPath = getNextObjectName(initialPath, ++step);
+                const nextStep = step + 1;
+                const newPath = getNextObjectName(initialPath, nextStep);
 
-                return checkPathExists(initialPath, newPath, step);
+                return checkPathExists(initialPath, newPath, nextStep);
             }
 
             return path;

--- a/packages/ui/src/ui/utils/navigation/tabs/tables.js
+++ b/packages/ui/src/ui/utils/navigation/tabs/tables.js
@@ -186,8 +186,8 @@ export const tableItems = {
 
             return [total > 0 ? completed / total : 0, total > 0 ? failed / total : 0, total];
         },
-        overall(accAggregation, tablet, name) {
-            const aggregatedStorePreload = (accAggregation[name] = accAggregation[name] || {
+        overall(draftAggregation, tablet, name) {
+            const aggregatedStorePreload = (draftAggregation[name] = draftAggregation[name] || {
                 completed: 0,
                 failed: 0,
                 pending: 0,

--- a/packages/ui/src/ui/utils/navigation/tabs/tables.js
+++ b/packages/ui/src/ui/utils/navigation/tabs/tables.js
@@ -186,8 +186,8 @@ export const tableItems = {
 
             return [total > 0 ? completed / total : 0, total > 0 ? failed / total : 0, total];
         },
-        overall(aggregation, tablet, name) {
-            const aggregatedStorePreload = (aggregation[name] = aggregation[name] || {
+        overall(accAggregation, tablet, name) {
+            const aggregatedStorePreload = (accAggregation[name] = accAggregation[name] || {
                 completed: 0,
                 failed: 0,
                 pending: 0,

--- a/packages/ui/src/ui/utils/navigation/tabs/tablets.js
+++ b/packages/ui/src/ui/utils/navigation/tabs/tablets.js
@@ -7,19 +7,19 @@ import ypath from '../../../common/thor/ypath';
 import hammer from '../../../common/hammer';
 import {tableItems} from '../../../utils/navigation/tabs/tables';
 
-function prepareFlatColumns(columns, flatColumns = {}, prefix) {
+function prepareFlatColumns(columns, draftFlatColumns = {}, prefix) {
     const correctPrefix = prefix ? prefix + '_' : '';
 
     forEach_(columns, (column, columnName) => {
         if (column.group) {
-            prepareFlatColumns(column.items, flatColumns, columnName);
+            prepareFlatColumns(column.items, draftFlatColumns, columnName);
         } else {
             const flatColumnName = correctPrefix + columnName;
-            flatColumns[flatColumnName] = column;
+            draftFlatColumns[flatColumnName] = column;
         }
     });
 
-    return flatColumns;
+    return draftFlatColumns;
 }
 
 export function prepareDataForColumns(collection) {

--- a/packages/ui/src/ui/utils/operations/tabs/details/events/events.js
+++ b/packages/ui/src/ui/utils/operations/tabs/details/events/events.js
@@ -34,7 +34,7 @@ function prepareEvents(events, params) {
         let lastState;
         let prepared = reduce_(
             events,
-            (prepared, event, index) => {
+            (accPrepared, event, index) => {
                 const nextEvent = events[index + 1];
                 let duration;
                 let finishTime;
@@ -55,8 +55,8 @@ function prepareEvents(events, params) {
                     showAttributesColumn = true;
                 }
 
-                prepared.totalDuration += duration;
-                prepared.events.push(
+                accPrepared.totalDuration += duration;
+                accPrepared.events.push(
                     new Event({
                         duration,
                         finishTime,
@@ -68,7 +68,7 @@ function prepareEvents(events, params) {
                     }),
                 );
 
-                return prepared;
+                return accPrepared;
             },
             {events: [], totalDuration: 0, precedingDuration: 0},
         );
@@ -77,19 +77,19 @@ function prepareEvents(events, params) {
 
         prepared = reduce_(
             eventsDurations,
-            (prepared, duration, index) => {
-                const currentEvent = prepared.events[index];
-                const totalDuration = prepared.totalDuration;
-                const precedingDuration = prepared.precedingDuration;
+            (accPrepared, duration, index) => {
+                const currentEvent = accPrepared.events[index];
+                const totalDuration = accPrepared.totalDuration;
+                const precedingDuration = accPrepared.precedingDuration;
 
                 currentEvent.progress = {
                     duration: durationToPercentage(duration, totalDuration),
                     precedingDuration: durationToPercentage(precedingDuration, totalDuration),
                 };
 
-                prepared.precedingDuration += duration;
+                accPrepared.precedingDuration += duration;
 
-                return prepared;
+                return accPrepared;
             },
             prepared,
         );

--- a/packages/ui/src/ui/utils/operations/tabs/details/tasks.js
+++ b/packages/ui/src/ui/utils/operations/tabs/details/tasks.js
@@ -71,14 +71,14 @@ function prepareJobTypeOrder(jobTypeOrder) {
     const SINK = 'sink';
 
     // REMOVE source, sink
-    jobTypeOrder = filter_(jobTypeOrder, (jobType) => {
+    const filtered = filter_(jobTypeOrder, (jobType) => {
         const type = String(jobType).toLowerCase();
         return type !== SOURCE && type !== SINK;
     });
     // ADD total
-    jobTypeOrder.push('total');
+    filtered.push('total');
 
-    return jobTypeOrder;
+    return filtered;
 }
 
 export function prepareDataFromGraph(operation) {

--- a/packages/ui/src/ui/utils/operations/tabs/details/tasks.js
+++ b/packages/ui/src/ui/utils/operations/tabs/details/tasks.js
@@ -21,14 +21,14 @@ function prepareCategoryCounters(counters, category) {
     if (typeof counters[category] === 'object') {
         const prepared = reduce_(
             counters[category],
-            (statistics, count, key) => {
-                statistics.counters.push({
+            (accStatistics, count, key) => {
+                accStatistics.counters.push({
                     value: count,
                     key,
                 });
-                statistics.total += count;
+                accStatistics.total += count;
 
-                return statistics;
+                return accStatistics;
             },
             {
                 counters: [],

--- a/packages/ui/src/ui/utils/parse-serialize.ts
+++ b/packages/ui/src/ui/utils/parse-serialize.ts
@@ -141,7 +141,7 @@ export function makeObjectParseSerialize<T extends object>(initialValue: T, io: 
 
                     const {serialize} = io?.[k] ?? {};
                     if (serialize) {
-                        acc += `${acc.length ? ',' : ''}${key}-${serialize(v)}`;
+                        return `${acc}${acc.length ? ',' : ''}${key}-${serialize(v)}`;
                     }
                     return acc;
                 },

--- a/packages/ui/src/ui/utils/scheduling/pool-child.ts
+++ b/packages/ui/src/ui/utils/scheduling/pool-child.ts
@@ -19,18 +19,18 @@ const RESOURCE_LIMIT_MAPPER: Partial<
 };
 
 function preparePoolChildResource<T extends 'pool' | 'operation'>(
-    data: PoolOrOperation<T>,
+    accData: PoolOrOperation<T>,
     _type: T,
     treeResources: TreeResources,
     resource: keyof Required<PoolData<'pool'>>['resources'],
 ) {
-    if (!data.resources) {
+    if (!accData.resources) {
         return;
     }
-    const attributes = data.attributes;
+    const attributes = accData.attributes;
 
-    if (data.name === ROOT_POOL_NAME) {
-        data.resources[resource] = {
+    if (accData.name === ROOT_POOL_NAME) {
+        accData.resources[resource] = {
             guaranteed: ypath.getNumber(treeResources, '/resource_limits/' + resource),
             usage: ypath.getNumber(treeResources, '/resource_usage/' + resource),
         };
@@ -50,11 +50,11 @@ function preparePoolChildResource<T extends 'pool' | 'operation'>(
 
         const limitResource = RESOURCE_LIMIT_MAPPER[resource] || resource;
         const resourceLimit = ypath.getNumber(
-            data.cypressAttributes,
+            accData.cypressAttributes,
             '/resource_limits/' + limitResource,
         );
         const specifiedResourceLimit = ypath.getNumber(
-            data.attributes,
+            accData.attributes,
             '/specified_resource_limits/' + limitResource,
         );
 
@@ -62,7 +62,7 @@ function preparePoolChildResource<T extends 'pool' | 'operation'>(
         const detailed =
             treeLimit * ypath.getNumber(attributes, '/detailed_fair_share/total/' + limitResource);
 
-        data.resources[resource] = {
+        accData.resources[resource] = {
             min,
             guaranteed,
             effectiveGuaranteed,
@@ -165,33 +165,33 @@ export type PoolOrOperation<T extends 'pool' | 'operation'> = T extends 'pool'
     : PoolLeafNode;
 
 export function updatePoolChild<T extends 'pool' | 'operation'>(
-    data: PoolOrOperation<T>,
+    accData: PoolOrOperation<T>,
     cypressData: unknown,
     type: T,
     treeResources: TreeResources,
 ): PoolOrOperation<T> {
     try {
-        const attributes = data.attributes;
+        const attributes = accData.attributes;
         const cypressAttributes = ypath.getAttributes(cypressData);
 
-        data.cypressAttributes = cypressAttributes;
-        data.type = type;
+        accData.cypressAttributes = cypressAttributes;
+        accData.type = type;
 
-        if (isPoolItem(data)) {
-            if (typeof attributes === 'undefined' && data.parent) {
+        if (isPoolItem(accData)) {
+            if (typeof attributes === 'undefined' && accData.parent) {
                 // eslint-disable-next-line no-console
                 console.error(
                     'Pool "%s" without attributes inited by "%s"',
-                    data.name,
-                    data._initedBy,
+                    accData.name,
+                    accData._initedBy,
                 );
             }
 
-            data.mode = ypath.getValue(attributes, '/mode');
+            accData.mode = ypath.getValue(attributes, '/mode');
 
-            data.leaves = map_(data.leaves, (leaf) => {
+            accData.leaves = map_(accData.leaves, (leaf) => {
                 const res = updatePoolChild(
-                    Object.assign(leaf, {pool: data.name}),
+                    Object.assign(leaf, {pool: accData.name}),
                     {},
                     'operation',
                     treeResources,
@@ -200,12 +200,12 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
             });
 
             const child_pool_count = ypath.getNumber(attributes, '/child_pool_count');
-            if (child_pool_count > 0 && !data.children.length) {
+            if (child_pool_count > 0 && !accData.children.length) {
                 for (let i = 0; i < child_pool_count; ++i) {
-                    data.children.push({
-                        parent: data.name,
+                    accData.children.push({
+                        parent: accData.name,
                         type: 'pool',
-                        name: `#key_${data.name}_${i}`,
+                        name: `#key_${accData.name}_${i}`,
                         attributes: {},
                         leaves: [],
                         incomplete: true,
@@ -214,89 +214,89 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
                 }
             }
 
-            if (!data.leaves?.length) {
-                data.pool_operation_count = ypath.getNumber(
+            if (!accData.leaves?.length) {
+                accData.pool_operation_count = ypath.getNumber(
                     attributes,
                     '/pool_operation_count',
                     NaN,
                 );
-                if (data.pool_operation_count! > 0) {
+                if (accData.pool_operation_count! > 0) {
                     const emptyOp = updatePoolChild(
                         {
                             attributes: {},
                             isLeafNode: true,
                             name: '',
                             type: 'operation',
-                            pool: data.name,
+                            pool: accData.name,
                         },
                         {},
                         'operation',
                         treeResources,
                     );
-                    data.leaves = [];
-                    for (let i = 0; i < data.pool_operation_count!; ++i) {
-                        data.leaves.push({
+                    accData.leaves = [];
+                    for (let i = 0; i < accData.pool_operation_count!; ++i) {
+                        accData.leaves.push({
                             ...emptyOp,
-                            name: `##fake_operation_${data.name}_${i}`,
-                            pool: data.name,
+                            name: `##fake_operation_${accData.name}_${i}`,
+                            pool: accData.name,
                         });
                     }
                 }
             }
 
             // Operations
-            data.operationCount = ypath.getNumber(attributes, '/operation_count');
-            data.maxOperationCount = ypath.getNumber(attributes, '/max_operation_count');
-            data.maxOperationCountEdited = ypath.getNumber(
+            accData.operationCount = ypath.getNumber(attributes, '/operation_count');
+            accData.maxOperationCount = ypath.getNumber(attributes, '/max_operation_count');
+            accData.maxOperationCountEdited = ypath.getNumber(
                 cypressAttributes,
                 '/max_operation_count',
             );
-            data.lightweightRunningOperationCount = ypath.getNumber(
+            accData.lightweightRunningOperationCount = ypath.getNumber(
                 attributes,
                 '/lightweight_running_operation_count',
             );
-            data.runningOperationCount = ypath.getNumber(attributes, '/running_operation_count');
-            data.maxRunningOperationCount = ypath.getNumber(
+            accData.runningOperationCount = ypath.getNumber(attributes, '/running_operation_count');
+            accData.maxRunningOperationCount = ypath.getNumber(
                 attributes,
                 '/max_running_operation_count',
             );
-            data.maxRunningOperationCountEdited = ypath.getNumber(
+            accData.maxRunningOperationCountEdited = ypath.getNumber(
                 cypressAttributes,
                 '/max_running_operation_count',
             );
         }
 
         if (type === 'operation') {
-            data.operationType = ypath.getValue(attributes, '/type');
-            data.user = ypath.getValue(attributes, '/user');
-            data.startTime = ypath.getValue(attributes, '/start_time');
+            accData.operationType = ypath.getValue(attributes, '/type');
+            accData.user = ypath.getValue(attributes, '/user');
+            accData.startTime = ypath.getValue(attributes, '/start_time');
         }
 
-        data.id = data.name;
-        data.starvation_status = ypath.getValue(attributes, '/starvation_status');
+        accData.id = accData.name;
+        accData.starvation_status = ypath.getValue(attributes, '/starvation_status');
 
         // General
-        data.weight = ypath.getNumber(attributes, '/weight');
-        data.weightEdited = ypath.getNumber(cypressAttributes, '/weight');
-        data.minShareRatio = ypath.getNumber(attributes, '/min_share_ratio');
-        data.maxShareRatio = ypath.getNumber(attributes, '/max_share_ratio');
-        data.fairShareRatio = ypath.getNumber(attributes, '/fair_share_ratio');
-        data.fifoIndex = ypath.getNumber(attributes, '/fifo_index');
-        data.usageRatio = ypath.getNumber(attributes, '/usage_ratio');
-        data.demandRatio = ypath.getNumber(attributes, '/demand_ratio');
-        data.isEphemeral = ypath.getBoolean(attributes, '/is_ephemeral');
-        data.isEffectiveLightweight = ypath.getBoolean(
+        accData.weight = ypath.getNumber(attributes, '/weight');
+        accData.weightEdited = ypath.getNumber(cypressAttributes, '/weight');
+        accData.minShareRatio = ypath.getNumber(attributes, '/min_share_ratio');
+        accData.maxShareRatio = ypath.getNumber(attributes, '/max_share_ratio');
+        accData.fairShareRatio = ypath.getNumber(attributes, '/fair_share_ratio');
+        accData.fifoIndex = ypath.getNumber(attributes, '/fifo_index');
+        accData.usageRatio = ypath.getNumber(attributes, '/usage_ratio');
+        accData.demandRatio = ypath.getNumber(attributes, '/demand_ratio');
+        accData.isEphemeral = ypath.getBoolean(attributes, '/is_ephemeral');
+        accData.isEffectiveLightweight = ypath.getBoolean(
             attributes,
             '/effective_lightweight_operations_enabled',
         );
 
-        data.integralType = ypath.getValue(attributes, '/integral_guarantee_type');
+        accData.integralType = ypath.getValue(attributes, '/integral_guarantee_type');
         const userDefinedBurstCPU = ypath.getNumber(
             cypressAttributes,
             '/integral_guarantees/burst_guarantee_resources/cpu',
             NaN,
         );
-        data.burstCPU = ypath.getNumber(
+        accData.burstCPU = ypath.getNumber(
             attributes,
             '/specified_burst_guarantee_resources/cpu',
             userDefinedBurstCPU,
@@ -306,7 +306,7 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
             '/integral_guarantees/resource_flow/cpu',
             NaN,
         );
-        data.flowCPU = ypath.getNumber(
+        accData.flowCPU = ypath.getNumber(
             attributes,
             '/specified_resource_flow/cpu',
             userDefinedFlowCPU,
@@ -316,45 +316,45 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
             '/integral_guarantees/resource_flow/gpu',
             NaN,
         );
-        data.flowGPU = ypath.getNumber(
+        accData.flowGPU = ypath.getNumber(
             attributes,
             '/specified_resource_flow/gpu',
             userDefinedFlowGPU,
         );
 
-        data.accumulated = ypath.getValue(attributes, '/accumulated_resource_ratio_volume');
-        data.accumulatedCpu = ypath.getValue(attributes, '/accumulated_resource_volume/cpu');
-        data.burstDuration = ypath.getValue(attributes, '/estimated_burst_usage_duration_sec');
+        accData.accumulated = ypath.getValue(attributes, '/accumulated_resource_ratio_volume');
+        accData.accumulatedCpu = ypath.getValue(attributes, '/accumulated_resource_volume/cpu');
+        accData.burstDuration = ypath.getValue(attributes, '/estimated_burst_usage_duration_sec');
 
         const fifoSortParams = map_(
             ypath.getValue(attributes, '/fifo_sort_parameters') ||
                 ypath.getValue(cypressAttributes, '/fifo_sort_parameters'),
             (param) => ypath.getValue(param),
         );
-        data.fifoSortParams =
+        accData.fifoSortParams =
             fifoSortParams.length > 0
                 ? fifoSortParams
                 : ['start_time', 'weight', 'pending_job_count'];
-        data.abc = ypath.getValue(attributes, '/abc') || {};
-        data.forbidImmediateOperations =
+        accData.abc = ypath.getValue(attributes, '/abc') || {};
+        accData.forbidImmediateOperations =
             ypath.getBoolean(cypressAttributes, '/forbid_immediate_operations') || false;
-        data.createEphemeralSubpools =
+        accData.createEphemeralSubpools =
             ypath.getBoolean(cypressAttributes, '/create_ephemeral_subpools') || false;
 
         // Resources
-        data.dominantResource = ypath.getValue(attributes, '/dominant_resource');
+        accData.dominantResource = ypath.getValue(attributes, '/dominant_resource');
 
-        data.resources = {};
+        accData.resources = {};
 
-        preparePoolChildResource(data, type, treeResources, 'cpu');
-        preparePoolChildResource(data, type, treeResources, 'user_memory');
-        preparePoolChildResource(data, type, treeResources, 'gpu');
-        preparePoolChildResource(data, type, treeResources, 'user_slots');
+        preparePoolChildResource(accData, type, treeResources, 'cpu');
+        preparePoolChildResource(accData, type, treeResources, 'user_memory');
+        preparePoolChildResource(accData, type, treeResources, 'gpu');
+        preparePoolChildResource(accData, type, treeResources, 'user_slots');
 
-        return data;
+        return accData;
     } catch (e) {
         throw appendInnerErrors(e, {
-            message: `An error occured while parsing pool "${data.name}" data.`,
+            message: `An error occured while parsing pool "${accData.name}" data.`,
         });
     }
 }

--- a/packages/ui/src/ui/utils/scheduling/pool-child.ts
+++ b/packages/ui/src/ui/utils/scheduling/pool-child.ts
@@ -19,18 +19,18 @@ const RESOURCE_LIMIT_MAPPER: Partial<
 };
 
 function preparePoolChildResource<T extends 'pool' | 'operation'>(
-    accData: PoolOrOperation<T>,
+    draftData: PoolOrOperation<T>,
     _type: T,
     treeResources: TreeResources,
     resource: keyof Required<PoolData<'pool'>>['resources'],
 ) {
-    if (!accData.resources) {
+    if (!draftData.resources) {
         return;
     }
-    const attributes = accData.attributes;
+    const attributes = draftData.attributes;
 
-    if (accData.name === ROOT_POOL_NAME) {
-        accData.resources[resource] = {
+    if (draftData.name === ROOT_POOL_NAME) {
+        draftData.resources[resource] = {
             guaranteed: ypath.getNumber(treeResources, '/resource_limits/' + resource),
             usage: ypath.getNumber(treeResources, '/resource_usage/' + resource),
         };
@@ -50,11 +50,11 @@ function preparePoolChildResource<T extends 'pool' | 'operation'>(
 
         const limitResource = RESOURCE_LIMIT_MAPPER[resource] || resource;
         const resourceLimit = ypath.getNumber(
-            accData.cypressAttributes,
+            draftData.cypressAttributes,
             '/resource_limits/' + limitResource,
         );
         const specifiedResourceLimit = ypath.getNumber(
-            accData.attributes,
+            draftData.attributes,
             '/specified_resource_limits/' + limitResource,
         );
 
@@ -62,7 +62,7 @@ function preparePoolChildResource<T extends 'pool' | 'operation'>(
         const detailed =
             treeLimit * ypath.getNumber(attributes, '/detailed_fair_share/total/' + limitResource);
 
-        accData.resources[resource] = {
+        draftData.resources[resource] = {
             min,
             guaranteed,
             effectiveGuaranteed,
@@ -165,33 +165,33 @@ export type PoolOrOperation<T extends 'pool' | 'operation'> = T extends 'pool'
     : PoolLeafNode;
 
 export function updatePoolChild<T extends 'pool' | 'operation'>(
-    accData: PoolOrOperation<T>,
+    draftData: PoolOrOperation<T>,
     cypressData: unknown,
     type: T,
     treeResources: TreeResources,
 ): PoolOrOperation<T> {
     try {
-        const attributes = accData.attributes;
+        const attributes = draftData.attributes;
         const cypressAttributes = ypath.getAttributes(cypressData);
 
-        accData.cypressAttributes = cypressAttributes;
-        accData.type = type;
+        draftData.cypressAttributes = cypressAttributes;
+        draftData.type = type;
 
-        if (isPoolItem(accData)) {
-            if (typeof attributes === 'undefined' && accData.parent) {
+        if (isPoolItem(draftData)) {
+            if (typeof attributes === 'undefined' && draftData.parent) {
                 // eslint-disable-next-line no-console
                 console.error(
                     'Pool "%s" without attributes inited by "%s"',
-                    accData.name,
-                    accData._initedBy,
+                    draftData.name,
+                    draftData._initedBy,
                 );
             }
 
-            accData.mode = ypath.getValue(attributes, '/mode');
+            draftData.mode = ypath.getValue(attributes, '/mode');
 
-            accData.leaves = map_(accData.leaves, (leaf) => {
+            draftData.leaves = map_(draftData.leaves, (leaf) => {
                 const res = updatePoolChild(
-                    Object.assign(leaf, {pool: accData.name}),
+                    Object.assign(leaf, {pool: draftData.name}),
                     {},
                     'operation',
                     treeResources,
@@ -200,12 +200,12 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
             });
 
             const child_pool_count = ypath.getNumber(attributes, '/child_pool_count');
-            if (child_pool_count > 0 && !accData.children.length) {
+            if (child_pool_count > 0 && !draftData.children.length) {
                 for (let i = 0; i < child_pool_count; ++i) {
-                    accData.children.push({
-                        parent: accData.name,
+                    draftData.children.push({
+                        parent: draftData.name,
                         type: 'pool',
-                        name: `#key_${accData.name}_${i}`,
+                        name: `#key_${draftData.name}_${i}`,
                         attributes: {},
                         leaves: [],
                         incomplete: true,
@@ -214,89 +214,92 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
                 }
             }
 
-            if (!accData.leaves?.length) {
-                accData.pool_operation_count = ypath.getNumber(
+            if (!draftData.leaves?.length) {
+                draftData.pool_operation_count = ypath.getNumber(
                     attributes,
                     '/pool_operation_count',
                     NaN,
                 );
-                if (accData.pool_operation_count! > 0) {
+                if (draftData.pool_operation_count! > 0) {
                     const emptyOp = updatePoolChild(
                         {
                             attributes: {},
                             isLeafNode: true,
                             name: '',
                             type: 'operation',
-                            pool: accData.name,
+                            pool: draftData.name,
                         },
                         {},
                         'operation',
                         treeResources,
                     );
-                    accData.leaves = [];
-                    for (let i = 0; i < accData.pool_operation_count!; ++i) {
-                        accData.leaves.push({
+                    draftData.leaves = [];
+                    for (let i = 0; i < draftData.pool_operation_count!; ++i) {
+                        draftData.leaves.push({
                             ...emptyOp,
-                            name: `##fake_operation_${accData.name}_${i}`,
-                            pool: accData.name,
+                            name: `##fake_operation_${draftData.name}_${i}`,
+                            pool: draftData.name,
                         });
                     }
                 }
             }
 
             // Operations
-            accData.operationCount = ypath.getNumber(attributes, '/operation_count');
-            accData.maxOperationCount = ypath.getNumber(attributes, '/max_operation_count');
-            accData.maxOperationCountEdited = ypath.getNumber(
+            draftData.operationCount = ypath.getNumber(attributes, '/operation_count');
+            draftData.maxOperationCount = ypath.getNumber(attributes, '/max_operation_count');
+            draftData.maxOperationCountEdited = ypath.getNumber(
                 cypressAttributes,
                 '/max_operation_count',
             );
-            accData.lightweightRunningOperationCount = ypath.getNumber(
+            draftData.lightweightRunningOperationCount = ypath.getNumber(
                 attributes,
                 '/lightweight_running_operation_count',
             );
-            accData.runningOperationCount = ypath.getNumber(attributes, '/running_operation_count');
-            accData.maxRunningOperationCount = ypath.getNumber(
+            draftData.runningOperationCount = ypath.getNumber(
+                attributes,
+                '/running_operation_count',
+            );
+            draftData.maxRunningOperationCount = ypath.getNumber(
                 attributes,
                 '/max_running_operation_count',
             );
-            accData.maxRunningOperationCountEdited = ypath.getNumber(
+            draftData.maxRunningOperationCountEdited = ypath.getNumber(
                 cypressAttributes,
                 '/max_running_operation_count',
             );
         }
 
         if (type === 'operation') {
-            accData.operationType = ypath.getValue(attributes, '/type');
-            accData.user = ypath.getValue(attributes, '/user');
-            accData.startTime = ypath.getValue(attributes, '/start_time');
+            draftData.operationType = ypath.getValue(attributes, '/type');
+            draftData.user = ypath.getValue(attributes, '/user');
+            draftData.startTime = ypath.getValue(attributes, '/start_time');
         }
 
-        accData.id = accData.name;
-        accData.starvation_status = ypath.getValue(attributes, '/starvation_status');
+        draftData.id = draftData.name;
+        draftData.starvation_status = ypath.getValue(attributes, '/starvation_status');
 
         // General
-        accData.weight = ypath.getNumber(attributes, '/weight');
-        accData.weightEdited = ypath.getNumber(cypressAttributes, '/weight');
-        accData.minShareRatio = ypath.getNumber(attributes, '/min_share_ratio');
-        accData.maxShareRatio = ypath.getNumber(attributes, '/max_share_ratio');
-        accData.fairShareRatio = ypath.getNumber(attributes, '/fair_share_ratio');
-        accData.fifoIndex = ypath.getNumber(attributes, '/fifo_index');
-        accData.usageRatio = ypath.getNumber(attributes, '/usage_ratio');
-        accData.demandRatio = ypath.getNumber(attributes, '/demand_ratio');
-        accData.isEphemeral = ypath.getBoolean(attributes, '/is_ephemeral');
-        accData.isEffectiveLightweight = ypath.getBoolean(
+        draftData.weight = ypath.getNumber(attributes, '/weight');
+        draftData.weightEdited = ypath.getNumber(cypressAttributes, '/weight');
+        draftData.minShareRatio = ypath.getNumber(attributes, '/min_share_ratio');
+        draftData.maxShareRatio = ypath.getNumber(attributes, '/max_share_ratio');
+        draftData.fairShareRatio = ypath.getNumber(attributes, '/fair_share_ratio');
+        draftData.fifoIndex = ypath.getNumber(attributes, '/fifo_index');
+        draftData.usageRatio = ypath.getNumber(attributes, '/usage_ratio');
+        draftData.demandRatio = ypath.getNumber(attributes, '/demand_ratio');
+        draftData.isEphemeral = ypath.getBoolean(attributes, '/is_ephemeral');
+        draftData.isEffectiveLightweight = ypath.getBoolean(
             attributes,
             '/effective_lightweight_operations_enabled',
         );
 
-        accData.integralType = ypath.getValue(attributes, '/integral_guarantee_type');
+        draftData.integralType = ypath.getValue(attributes, '/integral_guarantee_type');
         const userDefinedBurstCPU = ypath.getNumber(
             cypressAttributes,
             '/integral_guarantees/burst_guarantee_resources/cpu',
             NaN,
         );
-        accData.burstCPU = ypath.getNumber(
+        draftData.burstCPU = ypath.getNumber(
             attributes,
             '/specified_burst_guarantee_resources/cpu',
             userDefinedBurstCPU,
@@ -306,7 +309,7 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
             '/integral_guarantees/resource_flow/cpu',
             NaN,
         );
-        accData.flowCPU = ypath.getNumber(
+        draftData.flowCPU = ypath.getNumber(
             attributes,
             '/specified_resource_flow/cpu',
             userDefinedFlowCPU,
@@ -316,45 +319,45 @@ export function updatePoolChild<T extends 'pool' | 'operation'>(
             '/integral_guarantees/resource_flow/gpu',
             NaN,
         );
-        accData.flowGPU = ypath.getNumber(
+        draftData.flowGPU = ypath.getNumber(
             attributes,
             '/specified_resource_flow/gpu',
             userDefinedFlowGPU,
         );
 
-        accData.accumulated = ypath.getValue(attributes, '/accumulated_resource_ratio_volume');
-        accData.accumulatedCpu = ypath.getValue(attributes, '/accumulated_resource_volume/cpu');
-        accData.burstDuration = ypath.getValue(attributes, '/estimated_burst_usage_duration_sec');
+        draftData.accumulated = ypath.getValue(attributes, '/accumulated_resource_ratio_volume');
+        draftData.accumulatedCpu = ypath.getValue(attributes, '/accumulated_resource_volume/cpu');
+        draftData.burstDuration = ypath.getValue(attributes, '/estimated_burst_usage_duration_sec');
 
         const fifoSortParams = map_(
             ypath.getValue(attributes, '/fifo_sort_parameters') ||
                 ypath.getValue(cypressAttributes, '/fifo_sort_parameters'),
             (param) => ypath.getValue(param),
         );
-        accData.fifoSortParams =
+        draftData.fifoSortParams =
             fifoSortParams.length > 0
                 ? fifoSortParams
                 : ['start_time', 'weight', 'pending_job_count'];
-        accData.abc = ypath.getValue(attributes, '/abc') || {};
-        accData.forbidImmediateOperations =
+        draftData.abc = ypath.getValue(attributes, '/abc') || {};
+        draftData.forbidImmediateOperations =
             ypath.getBoolean(cypressAttributes, '/forbid_immediate_operations') || false;
-        accData.createEphemeralSubpools =
+        draftData.createEphemeralSubpools =
             ypath.getBoolean(cypressAttributes, '/create_ephemeral_subpools') || false;
 
         // Resources
-        accData.dominantResource = ypath.getValue(attributes, '/dominant_resource');
+        draftData.dominantResource = ypath.getValue(attributes, '/dominant_resource');
 
-        accData.resources = {};
+        draftData.resources = {};
 
-        preparePoolChildResource(accData, type, treeResources, 'cpu');
-        preparePoolChildResource(accData, type, treeResources, 'user_memory');
-        preparePoolChildResource(accData, type, treeResources, 'gpu');
-        preparePoolChildResource(accData, type, treeResources, 'user_slots');
+        preparePoolChildResource(draftData, type, treeResources, 'cpu');
+        preparePoolChildResource(draftData, type, treeResources, 'user_memory');
+        preparePoolChildResource(draftData, type, treeResources, 'gpu');
+        preparePoolChildResource(draftData, type, treeResources, 'user_slots');
 
-        return accData;
+        return draftData;
     } catch (e) {
         throw appendInnerErrors(e, {
-            message: `An error occured while parsing pool "${accData.name}" data.`,
+            message: `An error occured while parsing pool "${draftData.name}" data.`,
         });
     }
 }

--- a/packages/ui/src/ui/utils/system/proxies.ts
+++ b/packages/ui/src/ui/utils/system/proxies.ts
@@ -14,11 +14,11 @@ import {type NodeEffectiveState, type NodeState} from '../../store/reducers/syst
 export function extractRoleGroups(proxies: Array<RoleGroupItemInfo>): Array<RoleGroupInfo> {
     const roleGroups = reduce_(
         proxies,
-        (roles, proxy) => {
+        (accRoles, proxy) => {
             const roleName = proxy.role || 'default';
-            let role = roles[roleName];
+            let role = accRoles[roleName];
             if (!role) {
-                role = roles[roleName] = {
+                role = accRoles[roleName] = {
                     items: [],
                     name: roleName,
                     counters: {
@@ -34,7 +34,7 @@ export function extractRoleGroups(proxies: Array<RoleGroupItemInfo>): Array<Role
             ++role.counters.total;
             role.items.push(proxy);
             incrementCounters(proxy, role.counters);
-            return roles;
+            return accRoles;
         },
         {} as Record<string, RoleGroupInfo>,
     );
@@ -50,17 +50,17 @@ export function getNodeffectiveState(state: NodeState): NodeEffectiveState {
 }
 
 export function incrementStateCounter<K extends string>(
-    counters: Partial<Record<K, number>>,
+    accCounters: Partial<Record<K, number>>,
     k?: K,
 ) {
     if (!k) {
         return;
     }
 
-    if (counters[k] === undefined) {
-        counters[k] = 1;
+    if (accCounters[k] === undefined) {
+        accCounters[k] = 1;
     } else {
-        ++counters[k]!;
+        ++accCounters[k]!;
     }
 }
 

--- a/packages/ui/src/ui/utils/system/proxies.ts
+++ b/packages/ui/src/ui/utils/system/proxies.ts
@@ -50,17 +50,17 @@ export function getNodeffectiveState(state: NodeState): NodeEffectiveState {
 }
 
 export function incrementStateCounter<K extends string>(
-    accCounters: Partial<Record<K, number>>,
+    draftCounters: Partial<Record<K, number>>,
     k?: K,
 ) {
     if (!k) {
         return;
     }
 
-    if (accCounters[k] === undefined) {
-        accCounters[k] = 1;
+    if (draftCounters[k] === undefined) {
+        draftCounters[k] = 1;
     } else {
-        ++accCounters[k]!;
+        ++draftCounters[k]!;
     }
 }
 

--- a/packages/ui/src/ui/utils/tablet/tablet.js
+++ b/packages/ui/src/ui/utils/tablet/tablet.js
@@ -28,9 +28,8 @@ export const histogramItems = {
 
 export function preparePartitions(contents) {
     const partitions = map_(contents.partitions, (partition, index) => {
-        partition.attributes = Object.assign({}, partition);
-        partition.index = index;
-        return new Partition(partition);
+        const preparedPartition = {...partition, attributes: {...partition}, index};
+        return new Partition(preparedPartition);
     });
 
     const eden = new Partition(

--- a/packages/ui/src/ui/utils/utils.tsx
+++ b/packages/ui/src/ui/utils/utils.tsx
@@ -426,13 +426,13 @@ export function showChangedProps(key: string, props: object, verbose?: boolean) 
 }
 
 export function updateIfChanged<T, K extends keyof T>(
-    obj: T,
+    draftObj: T,
     key: K,
     value: T[K],
     isEqual?: (l: T[K], r: T[K]) => boolean,
 ) {
-    if (isEqual ? !isEqual(obj[key], value) : obj[key] !== value) {
-        obj[key] = value;
+    if (isEqual ? !isEqual(draftObj[key], value) : draftObj[key] !== value) {
+        draftObj[key] = value;
     }
 }
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/L2BbXYDE7ndLbt
<!-- nda-end --> ## Summary by Sourcery

Clean up parameter mutation patterns across the UI codebase to satisfy the no-param-reassign lint rule while preserving existing behavior.

Enhancements:
- Resolve UI lint warnings by avoiding parameter reassignment throughout data processing, selectors, utilities, reducers, and components.
- Preserve intentional parameter mutations with focused ESLint suppressions where APIs or mutable draft structures require them.
- Use copies or derived values in several transformations to reduce unintended mutation of caller-owned data.