### PR TITLE
chore(Bundles): add notice for failed state [YTFRONT-5842]

### DIFF
--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleGeneralMeta.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/BundleGeneralMeta.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import cn from 'bem-cn-lite';
 import {selectTabletsActiveBundleData} from '../../../store/selectors/tablet_cell_bundles';
 import {useSelector} from '../../../store/redux-hooks';
-import {MetaTable, type MetaTableItem} from '@ytsaurus/components';
-import {Progress} from '@gravity-ui/uikit';
+import {MetaTable, type MetaTableItem, Tooltip} from '@ytsaurus/components';
+import {Flex, Progress} from '@gravity-ui/uikit';
 
 // @ts-ignore
 import hammer from '@ytsaurus/interface-helpers/lib/hammer';
@@ -11,6 +11,7 @@ import ypath from '../../../common/thor/ypath';
 
 import AccountLink from '../../accounts/AccountLink';
 import {Health} from '../../../components/Health/Health';
+import Icon from '../../../components/Icon/Icon';
 import {calcProgressProps} from '../../../utils/utils';
 import {
     selectCluster,
@@ -47,7 +48,16 @@ export default function BundleGeneralMeta() {
         ...(UIFactory.getExtraMetaTableItemsForBundle({bundle: bundleData, clusterUiConfig}) || []),
         {
             key: i18n('field_health'),
-            value: <Health value={bundleData.health} />,
+            value: (
+                <Flex alignItems="center" gap={1}>
+                    <Health value={bundleData.health} />
+                    {bundleData.health === 'failed' && (
+                        <Tooltip useFlex content={i18n('context_failed-health')}>
+                            <Icon awesome="exclamation-triangle" color="warning" />
+                        </Tooltip>
+                    )}
+                </Flex>
+            ),
         },
         {
             key: i18n('field_tablet-cells'),

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/i18n/en.json
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundle/i18n/en.json
@@ -2,6 +2,7 @@
   "alert_no-selected-bundles": "You don't have any selected bundles",
   "alert_load-bundle-controller-details-error": "Cannot load bundle controller details for \"{{bundle}}\".",
   "context_choose-bundle": "Please choose one to display charts",
+  "context_failed-health": "Go to the Tablet cells tab to investigate the causes of tablet cell issues.",
   "title_general": "General",
   "title_bundle-configuration": "Bundle configuration",
   "field_health": "Health",


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/akGjlKKA7nW3Yg
<!-- nda-end --> ## Summary by Sourcery

New Features:
- Add a warning indicator and explanatory tooltip for bundles in the failed health state.