### PR TITLE
fix(Queries): double scroll [YTFRONT-5943]

### DIFF
--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/Columns/selectQueryListColumns.ts
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/Columns/selectQueryListColumns.ts
@@ -1,0 +1,32 @@
+import {createSelector} from 'reselect';
+import intersectionBy_ from 'lodash/intersectionBy';
+import {QueriesListAuthorFilter} from '../../../../../types/query-tracker/queryList';
+import {
+    selectQueriesFilters,
+    selectQueryListHistoryColumns,
+} from '../../../../../store/selectors/query-tracker/queriesList';
+import {ActionColumns, AllColumns, AuthorColumns, MyColumns, NameColumns} from './columns';
+
+const ALL_COLUMN_NAMES = intersectionBy_(AllColumns, MyColumns, 'name').map((item) => item.name);
+const EXCLUDED_COLUMNS = [NameColumns.name, AuthorColumns.name, ActionColumns.name];
+
+export const selectQueryListColumns = createSelector(
+    [selectQueriesFilters, selectQueryListHistoryColumns],
+    (filter, selectedColumns) => {
+        const currentColumnsPreset =
+            filter.user === QueriesListAuthorFilter.My ? MyColumns : AllColumns;
+
+        const selectedColumnNames = new Set(selectedColumns ?? ALL_COLUMN_NAMES);
+
+        selectedColumnNames.add(NameColumns.name);
+        selectedColumnNames.add(AuthorColumns.name);
+        selectedColumnNames.add(ActionColumns.name);
+
+        return {
+            columns: currentColumnsPreset.filter(({name}) => selectedColumnNames.has(name)),
+            allowedColumns: currentColumnsPreset
+                .filter((item) => !EXCLUDED_COLUMNS.includes(item.name))
+                .map(({name}) => ({name, checked: selectedColumnNames.has(name)})),
+        };
+    },
+);

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/FullTextSearch/FullTextSearch.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/FullTextSearch/FullTextSearch.tsx
@@ -1,7 +1,8 @@
-import React, {type FC} from 'react';
+import React, {type FC, useCallback} from 'react';
 import {Flex, List, Loader} from '@gravity-ui/uikit';
-import {useSelector} from '../../../../../store/redux-hooks';
+import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {
+    selectHasNextPage,
     selectIsQueriesListLoading,
     selectQueriesFilters,
     selectQueriesList,
@@ -12,15 +13,23 @@ import {NoContent} from '@ytsaurus/components';
 import block from 'bem-cn-lite';
 import './FullTextSearch.scss';
 import i18n from './i18n';
+import {loadNextQueriesList} from '../../../../../store/actions/query-tracker/queriesList';
+import {QueriesHistoryCursorDirection} from '../../../../../store/reducers/query-tracker/query-tracker-contants';
 
 const b = block('yt-queries-full-text-search');
 const LIST_ITEM_HEIGHT = 162;
 const MAX_PREVIEW_LINES = 4;
 
 export const FullTextSearch: FC = () => {
+    const dispatch = useDispatch();
     const {filter} = useSelector(selectQueriesFilters);
     const items = useSelector(selectQueriesList);
     const isLoading = useSelector(selectIsQueriesListLoading);
+    const hasNextPage = useSelector(selectHasNextPage);
+
+    const handleLoadMore = useCallback(() => {
+        dispatch(loadNextQueriesList(QueriesHistoryCursorDirection.PAST));
+    }, [dispatch]);
 
     if (isLoading && !items.length) {
         return (
@@ -48,6 +57,8 @@ export const FullTextSearch: FC = () => {
             itemsHeight={items.length * LIST_ITEM_HEIGHT}
             filterable={false}
             items={prepareFullTextSearchItems({items, filter, maxLines: MAX_PREVIEW_LINES})}
+            loading={hasNextPage}
+            onLoadMore={hasNextPage ? handleLoadMore : undefined}
             renderItem={(item) => {
                 return (
                     <FullTextSearchItem

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/HistoryList/HistoryList.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/HistoryList/HistoryList.tsx
@@ -1,11 +1,12 @@
-import React, {useMemo} from 'react';
-import {useSelector} from '../../../../../store/redux-hooks';
+import React, {useCallback, useMemo} from 'react';
+import {useDispatch, useSelector} from '../../../../../store/redux-hooks';
 import {List, type ListItemData} from '@gravity-ui/uikit';
 import {
+    selectHasNextPage,
     selectIsQueriesListLoading,
     selectQueryListByDate,
-    selectQueryListColumns,
 } from '../../../../../store/selectors/query-tracker/queriesList';
+import {selectQueryListColumns} from '../Columns/selectQueryListColumns';
 import {selectQuery} from '../../../../../store/selectors/query-tracker/query';
 import block from 'bem-cn-lite';
 
@@ -13,14 +14,18 @@ import './HistoryList.scss';
 import {type TableItem, isHeaderTableItem} from '../Columns/columns';
 import {HistoryListHeader} from './HistoryListHeader';
 import {HistoryListRow} from './HistoryListRow';
+import {loadNextQueriesList} from '../../../../../store/actions/query-tracker/queriesList';
+import {QueriesHistoryCursorDirection} from '../../../../../store/reducers/query-tracker/query-tracker-contants';
 
 const b = block('yt-queries-history-list');
 
 const LIST_ITEM_HEIGHT = 45;
 
 export function HistoryList() {
+    const dispatch = useDispatch();
     const itemsByDate = useSelector(selectQueryListByDate);
     const isLoading = useSelector(selectIsQueriesListLoading);
+    const hasNextPage = useSelector(selectHasNextPage);
     const {columns} = useSelector(selectQueryListColumns);
     const selectedId = useSelector(selectQuery)?.id;
 
@@ -29,10 +34,15 @@ export function HistoryList() {
             return isHeaderTableItem(item) ? {...item, disabled: true} : item;
         });
     }, [itemsByDate]);
+    const isInitialLoading = isLoading && items.length === 0;
 
     const selectedItemIndex = useMemo(() => {
         return items.findIndex((item) => !isHeaderTableItem(item) && item.id === selectedId);
     }, [items, selectedId]);
+
+    const handleLoadMore = useCallback(() => {
+        dispatch(loadNextQueriesList(QueriesHistoryCursorDirection.PAST));
+    }, [dispatch]);
 
     return (
         <div className={b()}>
@@ -44,7 +54,8 @@ export function HistoryList() {
                 itemHeight={LIST_ITEM_HEIGHT}
                 itemsHeight={LIST_ITEM_HEIGHT * items.length}
                 items={items}
-                loading={isLoading && items.length === 0}
+                loading={isInitialLoading || hasNextPage}
+                onLoadMore={hasNextPage ? handleLoadMore : undefined}
                 selectedItemIndex={selectedItemIndex}
                 renderItem={(row) => {
                     return <HistoryListRow item={row} columns={columns} />;

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/QueriesHistoryList.scss
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/QueriesHistoryList.scss
@@ -6,8 +6,4 @@
         padding: 12px 12px 0;
         margin-bottom: 8px;
     }
-
-    &__pagination {
-        padding: 8px 0;
-    }
 }

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesHistoryList/index.tsx
@@ -4,20 +4,11 @@ import {useUpdater} from '../../../../hooks/use-updater';
 import block from 'bem-cn-lite';
 
 import './QueriesHistoryList.scss';
-import {
-    loadNextQueriesList,
-    requestQueriesList,
-} from '../../../../store/actions/query-tracker/queriesList';
+import {requestQueriesList} from '../../../../store/actions/query-tracker/queriesList';
 import {QUERY_POLLING_INTERVAL} from '../../../../constants/queries';
 import {HistoryList} from './HistoryList';
-import {
-    selectIsFullTextSearchMode,
-    selectIsQueriesListLoading,
-    selectPaginationIsVisible,
-} from '../../../../store/selectors/query-tracker/queriesList';
+import {selectIsFullTextSearchMode} from '../../../../store/selectors/query-tracker/queriesList';
 import {FullTextSearch} from './FullTextSearch';
-import {InfiniteScrollLoader} from '../../../../components/InfiniteScrollLoader';
-import {QueriesHistoryCursorDirection} from '../../../../store/reducers/query-tracker/query-tracker-contants';
 
 const b = block('queries-history-list');
 
@@ -34,26 +25,12 @@ function QueriesHistoryListUpdater() {
 }
 
 export function QueriesHistoryList() {
-    const dispatch = useDispatch();
-    const isLoading = useSelector(selectIsQueriesListLoading);
     const isFullTextSearchMode = useSelector(selectIsFullTextSearchMode);
-    const showPagination = useSelector(selectPaginationIsVisible);
-
-    const handleLoadMore = () => {
-        dispatch(loadNextQueriesList(QueriesHistoryCursorDirection.PAST));
-    };
 
     return (
         <div className={b()}>
             <QueriesHistoryListUpdater />
             {isFullTextSearchMode ? <FullTextSearch /> : <HistoryList />}
-            {showPagination && (
-                <InfiniteScrollLoader
-                    className={b('pagination')}
-                    loading={isLoading}
-                    onLoadMore={handleLoadMore}
-                />
-            )}
         </div>
     );
 }

--- a/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.tsx
+++ b/packages/ui/src/ui/pages/query-tracker/QueriesList/QueriesListFilter/index.tsx
@@ -17,8 +17,8 @@ import {
     selectHasCustomHistoryFilters,
     selectQueriesFilters,
     selectQueriesListMode,
-    selectQueryListColumns,
 } from '../../../../store/selectors/query-tracker/queriesList';
+import {selectQueryListColumns} from '../QueriesHistoryList/Columns/selectQueryListColumns';
 import {applyFilter} from '../../../../store/actions/query-tracker/queriesList';
 import {setSettingByKey} from '../../../../store/actions/settings';
 import TextInputWithDebounce from '../../../../components/TextInputWithDebounce/TextInputWithDebounce';

--- a/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
+++ b/packages/ui/src/ui/store/selectors/query-tracker/queriesList.ts
@@ -5,7 +5,6 @@ import {type QueriesListParams, type QueryItem} from '../../../types/query-track
 import {isQueryProgress} from '../../../pages/query-tracker/utils/query';
 import {
     DefaultQueriesListFilter,
-    QueriesListAuthorFilter,
     QueriesListFilterPresets,
     QueriesListMode,
 } from '../../../types/query-tracker/queryList';
@@ -13,14 +12,6 @@ import {selectSettingsData} from '../settings/settings-base';
 import {selectIsVcsVisible} from './vcs';
 import groupBy_ from 'lodash/groupBy';
 import moment from 'moment';
-import intersectionBy_ from 'lodash/intersectionBy';
-import {
-    ActionColumns,
-    AllColumns,
-    AuthorColumns,
-    MyColumns,
-    NameColumns,
-} from '../../../pages/query-tracker/QueriesList/QueriesHistoryList/Columns/columns';
 import {selectIsSupportedTutorials} from './queryAco';
 
 export const selectQueriesListState = (state: RootState) => state.queryTracker.list;
@@ -36,7 +27,7 @@ export const selectQueriesListSearchMode = (state: RootState) =>
 
 export const selectQueriesFilters = (state: RootState) =>
     selectQueriesListState(state).filter || {};
-export const selectPaginationIsVisible = (state: RootState) => {
+export const selectHasNextPage = (state: RootState) => {
     const hasMore = selectHasQueriesListMore(state);
     const items = selectQueriesList(state);
 
@@ -79,33 +70,6 @@ export const selectQueriesListTabs = createSelector([selectIsVcsVisible], (vcsVi
         ? queriesListMode
         : queriesListMode.filter((item) => item !== QueriesListMode.VCS);
 });
-
-export const selectQueryListColumns = createSelector(
-    [selectQueriesFilters, selectQueryListHistoryColumns],
-    (filter, selectedColumns) => {
-        const ALL_COLUMN_NAMES = intersectionBy_(AllColumns, MyColumns, 'name').map(
-            (item) => item.name,
-        );
-        const EXCLUDED_COLUMNS = [NameColumns.name, AuthorColumns.name, ActionColumns.name];
-        const currentColumnsPreset =
-            filter.user === QueriesListAuthorFilter.My ? MyColumns : AllColumns;
-
-        const selectedColumnNames = new Set(
-            Array.isArray(selectedColumns) ? selectedColumns : ALL_COLUMN_NAMES,
-        );
-
-        selectedColumnNames.add(NameColumns.name);
-        selectedColumnNames.add(AuthorColumns.name);
-        selectedColumnNames.add(ActionColumns.name);
-
-        return {
-            columns: currentColumnsPreset.filter(({name}) => selectedColumnNames.has(name)),
-            allowedColumns: currentColumnsPreset
-                .filter((item) => !EXCLUDED_COLUMNS.includes(item.name))
-                .map(({name}) => ({name, checked: selectedColumnNames.has(name)})),
-        };
-    },
-);
 
 export const selectHasCustomHistoryFilters = createSelector(
     [selectQueriesFilters, selectSettingsData],


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/eAVPsP4g7nsCAn
<!-- nda-end --> ## Summary by Sourcery

Integrate query history pagination with the result lists to provide a single, consistent infinite-scroll experience.

New Features:
- Support loading additional query history directly as users scroll through both the history table and full-text search results.

Bug Fixes:
- Prevent duplicate or competing pagination controls from causing double scrolling in query history views.

Enhancements:
- Move query list column selection logic into a dedicated UI selector and preserve required columns across presets.