### PR TITLE
fix(Operations): progress can be null [YTFRONT-5928]

### DIFF
--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/job-sizes/JobSizes/JobSizes.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/job-sizes/JobSizes/JobSizes.tsx
@@ -21,6 +21,7 @@ import {selectOperationDetailsLoadingStatus} from '../../../../../../store/selec
 import {useAppRumMeasureStart} from '../../../../../../rum/rum-app-measures';
 import {RumMeasureTypes} from '../../../../../../rum/rum-measure-types';
 import {isFinalLoadingStatus} from '../../../../../../utils/utils';
+import {isNull} from '../../../../../../utils';
 import {useRumMeasureStop} from '../../../../../../rum/RumUiContext';
 import {type RootState} from '../../../../../../store/reducers';
 import YTHistogram, {
@@ -170,7 +171,8 @@ class JobSizes extends React.Component<Props, State> {
 
     renderContent() {
         const {operation} = this.props;
-        const tasks = ypath.getValue(this.props.operation, '/@progress/tasks');
+        const progress = ypath.getValue(this.props.operation, '/@progress');
+        const tasks = isNull(progress) ? undefined : ypath.getValue(progress, '/tasks');
         return (
             <ErrorBoundary>
                 <div className={block()}>

--- a/packages/ui/src/ui/pages/operations/selectors.ts
+++ b/packages/ui/src/ui/pages/operations/selectors.ts
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import ypath from '../../common/thor/ypath';
 import hammer from '../../common/hammer';
+import {isNull} from '../../utils';
 import {createSelector} from 'reselect';
 import {remoteInputUrl} from '../../utils/operations/tabs/details/specification/specification';
 import {type FIX_MY_TYPE} from '../../types';
@@ -178,7 +179,7 @@ export class ListOperationSelector extends OperationSelector {
         this.duration = (moment(this.finishTime) as any) - (moment(this.startTime) as any);
 
         const progress = ypath.getValue(attributes, '/brief_progress');
-        const jobs = (this.jobs = ypath.getValue(progress, '/jobs'));
+        const jobs = (this.jobs = isNull(progress) ? undefined : ypath.getValue(progress, '/jobs'));
 
         if (typeof jobs !== 'undefined') {
             this.completedJobs =
@@ -292,7 +293,7 @@ export class DetailedOperationSelector extends OperationSelector {
         this.computePools(attributes);
 
         const progress = ypath.getValue(attributes, '/progress');
-        const jobs = (this.jobs = ypath.getValue(progress, '/jobs'));
+        const jobs = (this.jobs = isNull(progress) ? undefined : ypath.getValue(progress, '/jobs'));
 
         if (typeof jobs !== 'undefined') {
             this.completedJobs =
@@ -313,7 +314,9 @@ export class DetailedOperationSelector extends OperationSelector {
                 : 0;
         }
 
-        this.live_preview = ypath.getValue(progress, '/live_preview');
+        this.live_preview = isNull(progress)
+            ? undefined
+            : ypath.getValue(progress, '/live_preview');
     }
 
     getLivePreviewPath(

--- a/packages/ui/src/ui/store/selectors/operations/operation.ts
+++ b/packages/ui/src/ui/store/selectors/operations/operation.ts
@@ -6,6 +6,7 @@ import {createSelector} from 'reselect';
 import {formatByParams} from '../../../../shared/utils/format';
 import {type RootState} from '../../../store/reducers';
 import ypath from '../../../common/thor/ypath';
+import {isNull} from '../../../utils/index';
 import {type AlertInfo} from '../../../components/AlertEvents/AlertEvents';
 import {calculateLoadingStatus} from '../../../utils/utils';
 import {type FIX_MY_TYPE} from '../../../types';
@@ -80,7 +81,8 @@ export const selectOperationId = (state: RootState) =>
 export const selectOperationTasks = createSelector(
     [selectOperation],
     (operation): Array<OperationTask> | undefined => {
-        return ypath.getValue(operation, '/@progress/tasks');
+        const progress = ypath.getValue(operation, '/@progress');
+        return isNull(progress) ? undefined : ypath.getValue(progress, '/tasks');
     },
 );
 export const selectOperationTasksNames = createSelector(

--- a/packages/ui/src/ui/store/selectors/operations/statistics-v2.ts
+++ b/packages/ui/src/ui/store/selectors/operations/statistics-v2.ts
@@ -19,6 +19,7 @@ import {
 import format from '../../../common/hammer/format';
 
 import ypath from '../../../common/thor/ypath';
+import {isNull} from '../../../utils/index';
 import {STATISTICS_FILTER_ALL_VALUE} from '../../../constants/operations/statistics';
 import {type RootState} from '../../../store/reducers';
 import {type ValueOf} from '../../../../@types/types';
@@ -33,7 +34,8 @@ const selectOperationDetailsOperation = (state: RootState) => state.operations.d
 export const selectOperationStatisticsV2 = createSelector(
     [selectOperationDetailsOperation],
     (operation) => {
-        return ypath.getValue(operation, '/@progress/job_statistics_v2') as
+        const progress = ypath.getValue(operation, '/@progress');
+        return (isNull(progress) ? undefined : ypath.getValue(progress, '/job_statistics_v2')) as
             StatisticTreeRoot | undefined;
     },
 );

--- a/packages/ui/src/ui/utils/operations/jobs.ts
+++ b/packages/ui/src/ui/utils/operations/jobs.ts
@@ -2,9 +2,11 @@ import isEmpty_ from 'lodash/isEmpty';
 import some_ from 'lodash/some';
 
 import ypath from '../../common/thor/ypath';
+import {isNull} from '../index';
 
 export function hasTaskHistograms(operation: unknown) {
-    const tasks = ypath.getValue(operation, '/@progress/tasks');
+    const progress = ypath.getValue(operation, '/@progress');
+    const tasks = isNull(progress) ? undefined : ypath.getValue(progress, '/tasks');
     return some_(tasks, ({estimated_input_data_weight_histogram, input_data_weight_histogram}) => {
         return (
             !isEmpty_(estimated_input_data_weight_histogram) ||

--- a/packages/ui/src/ui/utils/operations/tabs/details/data-flow.js
+++ b/packages/ui/src/ui/utils/operations/tabs/details/data-flow.js
@@ -6,14 +6,22 @@ import some_ from 'lodash/some';
 import sortBy_ from 'lodash/sortBy';
 
 import ypath from '../../../../common/thor/ypath';
+import {isNull} from '../../../index';
 import i18n from './i18n';
+
+export function getOperationProgress(operation) {
+    return ypath.getValue(operation, '/@progress');
+}
 
 function prepareGraphData(operation) {
     if (hasProgressTasks(operation)) {
         return prepareGraphDataByTasks(operation);
     }
 
-    const dataFlowGraph = ypath.getValue(operation, '/@progress/data_flow_graph');
+    const progress = getOperationProgress(operation);
+    const dataFlowGraph = isNull(progress)
+        ? undefined
+        : ypath.getValue(progress, '/data_flow_graph');
     const jobTypeOrder = ypath.getValue(dataFlowGraph, '/topological_ordering');
     const statistics = ypath.getValue(dataFlowGraph, '/edges');
 
@@ -35,8 +43,9 @@ function prepareGraphData(operation) {
 }
 
 function prepareGraphDataByTasks(operation) {
-    const dataFlow = ypath.getValue(operation, '/@progress/data_flow');
-    const tasks = ypath.getValue(operation, '/@progress/tasks');
+    const progress = getOperationProgress(operation);
+    const dataFlow = isNull(progress) ? undefined : ypath.getValue(progress, '/data_flow');
+    const tasks = isNull(progress) ? undefined : ypath.getValue(progress, '/tasks');
 
     const res = reduce_(
         dataFlow,
@@ -93,15 +102,12 @@ function isEmptyStatistics(stats) {
 }
 
 export function prepareCompletedUsage(operation) {
-    const progress = ypath.getValue(operation, '/@progress');
+    const progress = getOperationProgress(operation);
 
     if (progress) {
         let statistics = [];
 
-        const estimatedInputStatistics = ypath.getValue(
-            operation,
-            '/@progress/estimated_input_statistics',
-        );
+        const estimatedInputStatistics = ypath.getValue(progress, '/estimated_input_statistics');
 
         if (estimatedInputStatistics) {
             statistics.push({
@@ -124,5 +130,6 @@ export function prepareIntermediateUsage(operation, intermediate) {
 }
 
 export function hasProgressTasks(operation) {
-    return ypath.getValue(operation, '/@progress/tasks');
+    const progress = getOperationProgress(operation);
+    return isNull(progress) ? undefined : ypath.getValue(progress, '/tasks');
 }

--- a/packages/ui/src/ui/utils/operations/tabs/details/tasks.js
+++ b/packages/ui/src/ui/utils/operations/tabs/details/tasks.js
@@ -5,8 +5,8 @@ import reduce_ from 'lodash/reduce';
 
 import ypath from '../../../../common/thor/ypath';
 import hammer from '../../../../common/hammer';
-import {hasProgressTasks} from './data-flow';
-import {prepareTableColumns} from '../../../../utils/index';
+import {getOperationProgress, hasProgressTasks} from './data-flow';
+import {isNull, prepareTableColumns} from '../../../../utils/index';
 import i18n from './i18n';
 
 function sortCounters(reasonA, reasonB) {
@@ -18,6 +18,9 @@ function sortCounters(reasonA, reasonB) {
 }
 
 function prepareCategoryCounters(counters, category) {
+    if (!counters) {
+        return {total: 0};
+    }
     if (typeof counters[category] === 'object') {
         const prepared = reduce_(
             counters[category],
@@ -47,22 +50,22 @@ function prepareCategoryCounters(counters, category) {
 }
 
 function prepareCompletedStatistics(counters) {
-    const completed = counters.completed;
+    const completed = counters?.completed;
 
     return {
         interrupted: prepareCategoryCounters(completed, 'interrupted'),
         nonInterrupted: prepareCategoryCounters(completed, 'non-interrupted'), // XXX API NAMING BUG
-        total: completed['total'],
+        total: completed?.['total'],
     };
 }
 
 function prepareAbortedStatistics(counters) {
-    const aborted = counters.aborted;
+    const aborted = counters?.aborted;
 
     return {
         scheduled: prepareCategoryCounters(aborted, 'scheduled'),
         nonScheduled: prepareCategoryCounters(aborted, 'non_scheduled'),
-        total: aborted['total'],
+        total: aborted?.['total'],
     };
 }
 
@@ -86,7 +89,10 @@ export function prepareDataFromGraph(operation) {
         return prepareDataFromGraphByTasks(operation);
     }
 
-    const dataFlowGraph = ypath.getValue(operation, '/@progress/data_flow_graph');
+    const progress = getOperationProgress(operation);
+    const dataFlowGraph = isNull(progress)
+        ? undefined
+        : ypath.getValue(progress, '/data_flow_graph');
     let jobTypeOrder = ypath.getValue(dataFlowGraph, '/topological_ordering');
     const countersByType = ypath.getValue(dataFlowGraph, '/vertices');
     let data = [];
@@ -123,7 +129,8 @@ export function prepareDataFromGraph(operation) {
 }
 
 function prepareDataFromGraphByTasks(operation) {
-    const tasks = ypath.getValue(operation, '/@progress/tasks');
+    const progress = getOperationProgress(operation);
+    const tasks = isNull(progress) ? undefined : ypath.getValue(progress, '/tasks');
 
     const res = map_(tasks, (task) => {
         const {task_name, job_type, job_counter} = task;
@@ -136,7 +143,9 @@ function prepareDataFromGraphByTasks(operation) {
         };
     });
 
-    const totalCounters = ypath.getValue(operation, '/@progress/total_job_counter');
+    const totalCounters = isNull(progress)
+        ? undefined
+        : ypath.getValue(progress, '/total_job_counter');
     res.push({
         type: 'total',
         caption: 'total',


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/B_5-_D_x7nsQAv
<!-- nda-end -->   ## Summary by Sourcery

Prevent operation views from failing when progress data is null by treating unavailable progress fields as undefined.

Bug Fixes:
- Handle null operation progress safely across operation details, selectors, statistics, job utilities, data-flow views, and task views.

Enhancements:
- Make task and statistics preparation resilient when progress data or nested counters are unavailable.