### PR TITLE
fix(Navigation): broken download path [YTFRONT-5990]

### DIFF
--- a/packages/ui/src/ui/store/selectors/navigation/content/file.js
+++ b/packages/ui/src/ui/store/selectors/navigation/content/file.js
@@ -9,11 +9,9 @@ import {makeDirectDownloadPath} from '../../../../utils/navigation';
 
 export const selectDownloadPath = createSelector(
     [selectPath, selectCurrentClusterConfig, selectMergedUiSettings],
-    (cypressPath, {id: cluster, proxy, externalProxy}, uiSettings) => {
+    (cypressPath, clusterConfig, uiSettings) => {
         const path = makeDirectDownloadPath('read_file', {
-            cluster,
-            proxy,
-            externalProxy,
+            clusterConfig,
             uiSettings,
         });
         const query = [


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/dy_VraVX7oEdqu
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Restore correct file download paths by passing the complete cluster configuration to direct download path generation.