### PR TITLE
feat(System): add new master status icons [YTFRONT-5992]

### DIFF
--- a/packages/ui/src/ui/pages/system/Masters/Instance.tsx
+++ b/packages/ui/src/ui/pages/system/Masters/Instance.tsx
@@ -5,6 +5,8 @@ import Icon from '../../../components/Icon/Icon';
 import {useDispatch} from '../../../store/redux-hooks';
 import ReadOnlyIcon from '../../../assets/img/svg/read-only-icon.svg';
 import WarmUpIcon from '../../../assets/img/svg/warmup-icon.svg';
+import SnowflakeIcon from '@gravity-ui/icons/svgs/snowflake.svg';
+import PuzzleIcon from '@gravity-ui/icons/svgs/puzzle.svg';
 import {makeShortSystemAddress} from '../helpers/makeShortSystemAddress';
 import {Flex, Text} from '@gravity-ui/uikit';
 import {ClipboardButton, Tooltip} from '@ytsaurus/components';
@@ -46,7 +48,13 @@ export const Instance: FC<Props> = ({instance, hostType, allowVoting, allowServi
     const dispatch = useDispatch();
     const {state, $address, $physicalAddress} = instance;
     const attributes = instance.$attributes as CypressNode<
-        {read_only: boolean; voting: boolean; warming_up: boolean},
+        {
+            read_only: boolean;
+            voting: boolean;
+            warming_up: boolean;
+            frozen: boolean;
+            discombobulated: boolean;
+        },
         unknown
     >['$attributes'];
     const address = hostType === 'host' ? $address : $physicalAddress;
@@ -91,6 +99,16 @@ export const Instance: FC<Props> = ({instance, hostType, allowVoting, allowServi
                 {attributes?.warming_up && (
                     <span className={b('icon-glyph')} title={i18n('value_warming-up')}>
                         <WarmUpIcon width={14} height={14} />
+                    </span>
+                )}
+                {attributes?.frozen && (
+                    <span className={b('icon-glyph')} title={i18n('value_frozen')}>
+                        <SnowflakeIcon width={14} height={14} />
+                    </span>
+                )}
+                {attributes?.discombobulated && (
+                    <span className={b('icon-glyph')} title={i18n('value_discombobulated')}>
+                        <PuzzleIcon width={14} height={14} />
                     </span>
                 )}
             </div>

--- a/packages/ui/src/ui/pages/system/Masters/i18n/en.json
+++ b/packages/ui/src/ui/pages/system/Masters/i18n/en.json
@@ -20,6 +20,8 @@
   "value_maintenance": "Maintenance",
   "value_read-only": "Read only",
   "value_warming-up": "Warming up",
+  "value_frozen": "Frozen",
+  "value_discombobulated": "Discombobulated",
   "title_edit-address": "Edit {{address}}",
   "value_nonvoting": "[nonvoting]",
   "title_switch-leader-for": "Switch leader for {{cellId}}",

--- a/packages/ui/src/ui/store/selectors/system/masters.ts
+++ b/packages/ui/src/ui/store/selectors/system/masters.ts
@@ -18,6 +18,8 @@ export class MasterInstance {
         read_only?: boolean;
         voting?: boolean;
         warming_up?: boolean;
+        frozen?: boolean;
+        discombobulated?: boolean;
         state?: MasterInstanceState;
         automaton_version?: string;
         committed_version?: string;


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/Z_7Suxre7oM5vP
<!-- nda-end --> ## Summary by Sourcery

Add visual indicators for frozen and discombobulated master statuses in the system UI.

New Features:
- Display dedicated status icons for frozen and discombobulated master instances.

Enhancements:
- Extend master instance attribute typing and state selection to support frozen and discombobulated statuses.