### PR TITLE
chore: add @gravity-ui/browserslist-config [YTFRONT-5995]

### DIFF
--- a/packages/ui/.browserslistrc
+++ b/packages/ui/.browserslistrc
@@ -1,0 +1,1 @@
+extends @gravity-ui/browserslist-config

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -35,6 +35,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@gravity-ui/app-builder": "^0.26.0",
+        "@gravity-ui/browserslist-config": "^4.4.0",
         "@gravity-ui/chartkit": "^7.11.1",
         "@gravity-ui/components": "^4.12.0",
         "@gravity-ui/dashkit": "^9.3.2",
@@ -5223,6 +5224,13 @@
       "dependencies": {
         "htmlescape": "^1.1.1"
       }
+    },
+    "node_modules/@gravity-ui/browserslist-config": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/browserslist-config/-/browserslist-config-4.4.0.tgz",
+      "integrity": "sha512-DaovMKIdawO1m+Mj6TkX+vJZ9pJ4m98tG7uTtO/NapbxTtrKFpMmUPip6u7oGBtJDtaGyP80uO9cgW2rEy+6fQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@gravity-ui/chartkit": {
       "version": "7.11.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -104,6 +104,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@gravity-ui/app-builder": "^0.26.0",
+    "@gravity-ui/browserslist-config": "^4.4.0",
     "@gravity-ui/chartkit": "^7.11.1",
     "@gravity-ui/components": "^4.12.0",
     "@gravity-ui/dashkit": "^9.3.2",


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/afhkUEPs7oNb5p
<!-- nda-end --> ## Summary by Sourcery

Configure the UI package to use the shared Gravity UI browser compatibility settings.

Enhancements:
- Adopt the shared Gravity UI Browserslist configuration for the UI package.

Build:
- Add the Browserslist configuration package and package-level browser support configuration.