### PR TITLE
feat(javascript-wrapper): add patchOpSpec command [YTFRONT-5272]

### DIFF
--- a/packages/javascript-wrapper/lib/commands/v3.js
+++ b/packages/javascript-wrapper/lib/commands/v3.js
@@ -249,6 +249,12 @@ module.exports = {
             return parameters;
         },
     },
+    patchOpSpec: {
+        name: 'patch_op_spec',
+        method: 'POST',
+        dataType: 'text',
+        useBodyForParameters: true,
+    },
     map: v2.map,
     reduce: v2.reduce,
     mapReduce: v2.mapReduce,

--- a/packages/javascript-wrapper/lib/commands/v4.js
+++ b/packages/javascript-wrapper/lib/commands/v4.js
@@ -73,6 +73,10 @@ module.exports = {
     suspendOperation: v3.suspendOperation,
     completeOperation: v3.completeOperation,
     updateOperationParameters: v3.updateOperationParameters,
+    patchOpSpec: {
+        ...v3.patchOpSpec,
+        name: 'patch_operation_spec',
+    },
     map: v3.map,
     reduce: v3.reduce,
     mapReduce: v3.mapReduce,

--- a/packages/javascript-wrapper/test/yt.test.js
+++ b/packages/javascript-wrapper/test/yt.test.js
@@ -374,6 +374,37 @@ describe('yt', function () {
             _yt.setup.unsetGlobalOption('secure');
         });
 
+        it.each([
+            ['v3', 'patch_op_spec'],
+            ['v4', 'patch_operation_spec'],
+        ])('prepares %s.patchOpSpec request', function (apiVersion, command) {
+            _yt.setup.setGlobalOption('proxy', PROXY);
+
+            const parameters = {
+                operation_id: '33ab3f-bf1df917-b35fe9ed-c70a4bf4',
+                patches: [
+                    {path: '/max_failed_job_count', value: 15},
+                    {path: '/tasks/worker/job_count', value: 10},
+                ],
+            };
+
+            deeplyCompareAjaxParameters(_yt[apiVersion].patchOpSpec(parameters), {
+                url: `https://${PROXY}/api/${apiVersion}/${command}`,
+                headers: Object.assign({}, DEFAULT_HEADERS),
+                timeout: _yt.setup.getDefaultOption('timeout'),
+                responseType: 'text',
+                method: POST_METHOD,
+                withCredentials: false,
+                withXSRFToken: false,
+                transformResponse: [_yt.core._identity],
+                xsrfCookieName: '',
+                meta: {command},
+                data: JSON.stringify(parameters),
+            });
+
+            _yt.setup.unsetGlobalOption('proxy');
+        });
+
         afterEach(function (done) {
             _yt.core._request = _request;
             done();


### PR DESCRIPTION
## Summary by Sourcery

Add JavaScript wrapper support for patching operation specifications across API versions.

New Features:
- Add `patchOpSpec` commands to the JavaScript wrapper for API v3 and v4, enabling operation specification patches.

Tests:
- Add request preparation coverage for the v3 and v4 `patchOpSpec` commands.