### PR TITLE
fix(System/Chunks): correctly resize chunk table

### DIFF
--- a/packages/ui/src/ui/pages/system/Chunks/Chunks.scss
+++ b/packages/ui/src/ui/pages/system/Chunks/Chunks.scss
@@ -6,39 +6,40 @@
 
     .chunk-cells {
         &__table {
+            table-layout: fixed;
             &-item_type {
                 &_cell-tag {
-                    width: 65px;
+                    width: 70px;
                 }
                 &_foreign-chunks {
-                    width: 105px;
+                    width: 70px;
                 }
                 &_overreplicated-chunks {
-                    width: 147px;
+                    width: 120px;
                 }
                 &_underreplicated-chunks {
-                    width: 156px;
+                    width: 130px;
                 }
                 &_quorum-missing-chunks {
-                    width: 156px;
+                    width: 130px;
                 }
                 &_data-missing-chunks {
-                    width: 131px;
+                    width: 105px;
                 }
                 &_parity-missing-chunks {
-                    width: 140px;
+                    width: 115px;
                 }
                 &_lost-chunks {
-                    width: 66px;
+                    width: 65px;
                 }
                 &_lost-vital-chunks {
-                    width: 102px;
+                    width: 80px;
                 }
                 &_unsafely-placed-chunks {
-                    width: 153px;
+                    width: 126px;
                 }
                 &_chunks {
-                    width: 125px;
+                    width: 120px;
                 }
             }
         }


### PR DESCRIPTION
before:
<img width="1205" height="228" alt="Screenshot 2026-08-31 at 14 44 53" src="https://github.com/user-attachments/assets/3ea9a994-fcd3-420f-a160-e20e8fa55920" />

after:
<img width="1309" height="194" alt="Screenshot 2026-08-31 at 14 50 32" src="https://github.com/user-attachments/assets/4a388ce4-bf30-4c7a-9acd-3e4282c5a5c4" />

## Summary by Sourcery

Bug Fixes:
- Correctly size the System Chunks table so its columns render consistently and the table fits more compactly.