### PR TITLE
fix(Queries): change yql version default logic [YTFRONT-5876]

### DIFF
--- a/packages/ui/src/shared/constants/settings-types.ts
+++ b/packages/ui/src/shared/constants/settings-types.ts
@@ -192,9 +192,6 @@ export type QueryTrackerLastDiscoveryPath = {
 export type QueryTrackerLastChytClique = {
     [key in `local::${Cluster}::queryTracker::lastChytClique`]: string;
 };
-export type QueryTrackerLastYqlVersion = {
-    [key in `local::${Cluster}::queryTracker::lastYqlVersion`]: string;
-};
 
 type SchedulingSettings = {
     'global::scheduling::expandStaticConfiguration': boolean;
@@ -240,7 +237,6 @@ export type DescribedSettings = GlobalSettings &
     QueryTrackerUserDefaultACOSettings &
     QueryTrackerLastDiscoveryPath &
     QueryTrackerLastChytClique &
-    QueryTrackerLastYqlVersion &
     ComponentsSettings &
     SchedulingSettings &
     DashboardSettings &

--- a/packages/ui/src/ui/store/actions/query-tracker/query.ts
+++ b/packages/ui/src/ui/store/actions/query-tracker/query.ts
@@ -69,7 +69,6 @@ import {
     selectLastUserChoiceQueryChytClique,
     selectLastUserChoiceQueryDiscoveryPath,
     selectLastUserChoiceQueryEngine,
-    selectLastUserChoiceYqlVersion,
 } from '../../selectors/settings/settings-queries';
 
 import {getClusterParams, prepareClusterUiConfig} from '../cluster-params';
@@ -129,7 +128,6 @@ export const setUserLastChoice =
         const engine = selectQueryEngine(state);
         const lastPath = selectLastUserChoiceQueryDiscoveryPath(state);
         const lastClique = selectLastUserChoiceQueryChytClique(state);
-        const lastVersion = selectLastUserChoiceYqlVersion(state);
         const defaultYqlVersion = selectDefaultYqlVersion(state);
         const isSpytConnectAvailable = selectAvailableSpytConnect(state);
 
@@ -160,9 +158,8 @@ export const setUserLastChoice =
         }
 
         if (engine === QueryEngine.YQL && !settings?.yql_version) {
-            const yqlVersion = lastVersion || defaultYqlVersion;
-            if (yqlVersion) {
-                newSettings.yql_version = yqlVersion;
+            if (defaultYqlVersion) {
+                newSettings.yql_version = defaultYqlVersion;
             }
         }
 
@@ -277,9 +274,6 @@ export const setQueryYqlVersion =
         const settings = selectQueryDraftSettings(getState());
 
         dispatch(updateQueryDraft({settings: {...settings, yql_version: version}}));
-        dispatch(
-            setSettingByKey(`local::${settings?.cluster}::queryTracker::lastYqlVersion`, version),
-        );
     };
 
 export const setQueryPath =

--- a/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
+++ b/packages/ui/src/ui/store/selectors/settings/settings-queries.ts
@@ -24,12 +24,6 @@ export const selectLastUserChoiceQueryChytClique = createSelector(
     },
 );
 
-export const selectLastUserChoiceYqlVersion = createSelector(
-    [selectSettingsData, selectQueryDraft],
-    (data, {settings}) => {
-        return data[`local::${settings?.cluster}::queryTracker::lastYqlVersion`];
-    },
-);
 export const selectQueryTokens = createSelector([selectSettingsData], (data) => {
     return data['global::queryTracker::tokens'] || [];
 });


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/DOaGXvdq7pFAZa
<!-- nda-end --> ## Summary by Sourcery

Use the default YQL version for new YQL queries and remove the persisted last-version preference.

Bug Fixes:
- Use the configured default YQL version when initializing YQL queries instead of restoring a previously saved user choice.

Enhancements:
- Remove persistent storage and selector support for the last selected YQL version.