### PR TITLE
feat(Navigation): host metadata [YTFRONT-5757]

### DIFF
--- a/packages/ui/src/ui/pages/navigation/tabs/Consumer/Consumer.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Consumer/Consumer.tsx
@@ -11,6 +11,7 @@ import {
     selectConsumerMode,
     selectOwner,
     selectPartitionCount,
+    selectQueueAgentHost,
     selectReadDataWeightRate,
     selectReadRowCountRate,
     selectStatusError,
@@ -40,6 +41,7 @@ const Consumer: React.VFC<PropsFromRedux> = ({
     loadConsumerStatus,
     owner,
     partitionCount,
+    queueAgentHost,
     readDataWeightRate,
     readRowCountRate,
     consumerMode,
@@ -61,6 +63,7 @@ const Consumer: React.VFC<PropsFromRedux> = ({
             <Meta
                 owner={owner}
                 partitionCount={partitionCount}
+                queueAgentHost={queueAgentHost}
                 readDataWeightRate={readDataWeightRate}
                 readRowCountRate={readRowCountRate}
             />
@@ -83,6 +86,7 @@ function mapStateToProps(state: RootState) {
     return {
         owner: selectOwner(state),
         partitionCount: selectPartitionCount(state),
+        queueAgentHost: selectQueueAgentHost(state),
         readDataWeightRate: selectReadDataWeightRate(state),
         readRowCountRate: selectReadRowCountRate(state),
         consumerMode: selectConsumerMode(state),

--- a/packages/ui/src/ui/pages/navigation/tabs/Consumer/Meta/Meta.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Consumer/Meta/Meta.tsx
@@ -5,7 +5,7 @@ import {useSelector} from '../../../../../store/redux-hooks';
 import format from '../../../../../common/hammer/format';
 import ErrorBoundary from '../../../../../containers/ErrorBoundary/ErrorBoundary';
 import Label from '../../../../../components/Label';
-import {MetaTable} from '@ytsaurus/components';
+import {ClipboardButton, MetaTable} from '@ytsaurus/components';
 import Multimeter from '../../../../../components/Multimeter/Multimeter';
 import {SubjectCard} from '../../../../../components/SubjectLink/SubjectLink';
 
@@ -22,11 +22,18 @@ interface Props {
     targetQueue?: string;
     owner?: string;
     partitionCount?: number;
+    queueAgentHost?: string;
     readDataWeightRate?: TPerformanceCounters;
     readRowCountRate?: TPerformanceCounters;
 }
 
-const Meta: React.FC<Props> = ({owner, partitionCount, readDataWeightRate, readRowCountRate}) => {
+const Meta: React.FC<Props> = ({
+    owner,
+    partitionCount,
+    queueAgentHost,
+    readDataWeightRate,
+    readRowCountRate,
+}) => {
     const {vital} = useSelector(selectTargetQueue) ?? {};
 
     return (
@@ -64,6 +71,21 @@ const Meta: React.FC<Props> = ({owner, partitionCount, readDataWeightRate, readR
                             label: i18n('field_partition-count'),
                             value: partitionCount,
                             visible: !isNullable(partitionCount),
+                        },
+                        {
+                            key: 'queue-agent-host',
+                            label: i18n('field_queue-agent-host'),
+                            value: (
+                                <span className={block('queue-agent-host')}>
+                                    {queueAgentHost}
+                                    <ClipboardButton
+                                        text={queueAgentHost}
+                                        view="flat-secondary"
+                                        inlineMargins
+                                    />
+                                </span>
+                            ),
+                            visible: !isNullable(queueAgentHost),
                         },
                     ],
                     [

--- a/packages/ui/src/ui/pages/navigation/tabs/Consumer/Meta/i18n/en.json
+++ b/packages/ui/src/ui/pages/navigation/tabs/Consumer/Meta/i18n/en.json
@@ -5,6 +5,7 @@
   "value_true": "True",
   "value_false": "False",
   "field_partition-count": "Partition count",
+  "field_queue-agent-host": "Queue agent host",
   "field_data-weight-read-rate": "Data weight read rate",
   "field_rows-read-rate": "Rows read rate"
 }

--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/Meta/Meta.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/Meta/Meta.tsx
@@ -3,7 +3,7 @@ import cn from 'bem-cn-lite';
 
 import format from '../../../../../common/hammer/format';
 import ErrorBoundary from '../../../../../containers/ErrorBoundary/ErrorBoundary';
-import {MetaTable} from '@ytsaurus/components';
+import {ClipboardButton, MetaTable} from '@ytsaurus/components';
 import Multimeter from '../../../../../components/Multimeter/Multimeter';
 import {type TPerformanceCounters} from '../../../../../store/reducers/navigation/tabs/queue/types';
 import {isNullable} from '../../../../../utils';
@@ -16,6 +16,7 @@ const block = cn('queue-meta');
 interface Props {
     partitionCount?: number;
     family?: string;
+    queueAgentHost?: string;
     writeDataWeightRate?: TPerformanceCounters;
     writeRowCountRate?: TPerformanceCounters;
 }
@@ -23,6 +24,7 @@ interface Props {
 const Meta: React.VFC<Props> = ({
     partitionCount,
     family,
+    queueAgentHost,
     writeDataWeightRate,
     writeRowCountRate,
 }) => {
@@ -44,6 +46,21 @@ const Meta: React.VFC<Props> = ({
                             label: i18n('field_family'),
                             value: family,
                             visible: !isNullable(family),
+                        },
+                        {
+                            key: 'queue-agent-host',
+                            label: i18n('field_queue-agent-host'),
+                            value: (
+                                <span className={block('queue-agent-host')}>
+                                    {queueAgentHost}
+                                    <ClipboardButton
+                                        text={queueAgentHost}
+                                        view="flat-secondary"
+                                        inlineMargins
+                                    />
+                                </span>
+                            ),
+                            visible: !isNullable(queueAgentHost),
                         },
                     ],
                     [

--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/Meta/i18n/en.json
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/Meta/i18n/en.json
@@ -2,6 +2,7 @@
   "title_meta": "Meta",
   "field_partition-count": "Partition count",
   "field_family": "Family",
+  "field_queue-agent-host": "Queue agent host",
   "field_write-row-count-rate": "Rows write rate",
   "field_write-data-weight-rate": "Data weight write rate"
 }

--- a/packages/ui/src/ui/pages/navigation/tabs/Queue/Queue.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Queue/Queue.tsx
@@ -12,6 +12,7 @@ import {type RootState} from '../../../../store/reducers';
 import {
     selectFamily,
     selectPartitionCount,
+    selectQueueAgentHost,
     selectQueueMode,
     selectQueueStatusDataAlerts,
     selectStatusError,
@@ -44,6 +45,7 @@ const Queue: React.VFC<PropsFromRedux> = ({
     loadQueueStatus,
     family,
     partitionCount,
+    queueAgentHost,
     writeDataWeightRate,
     writeRowCountRate,
     queueMode,
@@ -67,6 +69,7 @@ const Queue: React.VFC<PropsFromRedux> = ({
             <Meta
                 family={family}
                 partitionCount={partitionCount}
+                queueAgentHost={queueAgentHost}
                 writeDataWeightRate={writeDataWeightRate}
                 writeRowCountRate={writeRowCountRate}
             />
@@ -88,6 +91,7 @@ function mapStateToProps(state: RootState) {
     return {
         family: selectFamily(state),
         partitionCount: selectPartitionCount(state),
+        queueAgentHost: selectQueueAgentHost(state),
         writeDataWeightRate: selectWriteDataWeightRate(state),
         writeRowCountRate: selectWriteRowCountRate(state),
         queueMode: selectQueueMode(state),

--- a/packages/ui/src/ui/store/reducers/navigation/tabs/consumer/status.ts
+++ b/packages/ui/src/ui/store/reducers/navigation/tabs/consumer/status.ts
@@ -29,6 +29,7 @@ export interface ConsumerStatusState {
     statusLoaded: boolean;
     statusError: YTError | null;
     consumerData: {
+        queue_agent_host?: string;
         queues?: Record<string, YtConsumerStatus>;
         registrations?: Array<ConsumerQueueInfo>;
     } | null;

--- a/packages/ui/src/ui/store/reducers/navigation/tabs/queue/types.ts
+++ b/packages/ui/src/ui/store/reducers/navigation/tabs/queue/types.ts
@@ -10,6 +10,7 @@ export interface YtQueueStatus {
     error?: YTError;
     partition_count: number;
     family: string;
+    queue_agent_host?: string;
     // alerts: list of TError;  // (unimplemented)
     write_data_weight_rate: TPerformanceCounters; // (unimplemented)
     read_data_weight_rate: TPerformanceCounters; // (unimplemented)

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/consumer.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/consumer.ts
@@ -20,6 +20,9 @@ export const selectTargetQueue = (state: RootState) =>
 export const selectConsumerRegisteredQueues = (state: RootState) =>
     state.navigation.tabs.consumer.status.consumerData?.registrations;
 
+export const selectQueueAgentHost = (state: RootState) =>
+    state.navigation.tabs.consumer.status.consumerData?.queue_agent_host;
+
 const selectStatusData = (state: RootState) => state.navigation.tabs.consumer.status.consumerData;
 
 const selectTargetQueueStatusData = (state: RootState) => {

--- a/packages/ui/src/ui/store/selectors/navigation/tabs/queue.ts
+++ b/packages/ui/src/ui/store/selectors/navigation/tabs/queue.ts
@@ -11,6 +11,9 @@ export const selectFamily = (state: RootState) =>
 export const selectPartitionCount = (state: RootState) =>
     state.navigation.tabs.queue.status.statusData?.partition_count;
 
+export const selectQueueAgentHost = (state: RootState) =>
+    state.navigation.tabs.queue.status.statusData?.queue_agent_host;
+
 export const selectReadDataWeightRate = (state: RootState) =>
     state.navigation.tabs.queue.status.statusData?.read_data_weight_rate ?? emptyRate;
 


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/xNLPQsdS7pFS2J
<!-- nda-end -->## Summary by Sourcery

Show queue agent host metadata for consumers and queues in the navigation interface.

New Features:
- Display the queue agent host in consumer and queue navigation metadata with a copy-to-clipboard action.

Enhancements:
- Expose queue agent host data through navigation state types and selectors.