### PR TITLE
fix(Scheduling): wrong filter color [YTFRONT-6016]

### DIFF
--- a/packages/ui/src/ui/components/ColumnHeader/ColumnHeader.tsx
+++ b/packages/ui/src/ui/components/ColumnHeader/ColumnHeader.tsx
@@ -167,7 +167,7 @@ export default function ColumnHeader<T extends string = string>(props: ColumnHea
                         className={block('label', {'sub-column': true})}
                         variant="caption-2"
                         title={subColumn?.titleContent}
-                        color="dark-secondary"
+                        color="secondary"
                     >
                         {subColumn?.nameContent}
                     </Text>


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/1CkKg0aT7pVyTp
<!-- nda-end -->## Summary by Sourcery

Bug Fixes:
- Correct the color of sub-column labels in column headers.