### PR TITLE
chore: render nirvana_block_url error inline [YTFRONT-6000]

### DIFF
--- a/packages/components/src/components/MetaTable/presets/main.tsx
+++ b/packages/components/src/components/MetaTable/presets/main.tsx
@@ -57,7 +57,7 @@ export const metaTablePresetMain: Props = (attributes, cluster, config = {}) => 
               {
                   key: 'nirvana_block_url',
                   value: renderMarkdown ? (
-                      renderMarkdown({text: nirvanaBlockUrl})
+                      renderMarkdown({text: nirvanaBlockUrl, errorMode: 'inline'})
                   ) : (
                       <TemplateLink
                           url={nirvanaBlockUrl}

--- a/packages/components/src/types/navigationMeta.ts
+++ b/packages/components/src/types/navigationMeta.ts
@@ -43,6 +43,7 @@ export type MetaTableOperationLinkParams = {
 export type MetaTableRenderMarkdownParams = {
     text: string;
     allowHTML?: boolean;
+    errorMode?: 'block' | 'inline';
 };
 
 export type MetaTableAutomaticModeSwitchParams = {

--- a/packages/ui/src/ui/UIFactory/index.tsx
+++ b/packages/ui/src/ui/UIFactory/index.tsx
@@ -214,6 +214,11 @@ export type AiChatIntegration = {
     AskAiButton?: React.ComponentType<AskAiButtonProps>;
 };
 
+type RenderMarkdownParams = {
+    text: string;
+    errorMode?: 'block' | 'inline';
+};
+
 export interface UIFactory {
     isAccountCreateDisabled(params: {
         currentAccount: string;
@@ -540,7 +545,7 @@ export interface UIFactory {
         error: Error | YTError;
     }) => React.ReactNode;
 
-    renderMarkdown(props: {text: string}): React.ReactNode;
+    renderMarkdown(props: RenderMarkdownParams): React.ReactNode;
 
     getAnalyticsService(): AnalyticsService[];
 

--- a/packages/ui/src/ui/components/Markdown/Markdown.tsx
+++ b/packages/ui/src/ui/components/Markdown/Markdown.tsx
@@ -19,6 +19,7 @@ interface Props {
     text: string;
     ref?: React.Ref<HTMLDivElement>;
     allowHTML?: boolean;
+    errorMode?: 'block' | 'inline';
 }
 
 interface Response {
@@ -81,11 +82,11 @@ const MarkdownImpl = React.forwardRef(function MD({text}: Props, ref: React.Ref<
     );
 });
 
-export const Markdown = React.memo(function Markdown({text}: Props) {
+export const Markdown = React.memo(function Markdown({text, errorMode}: Props) {
     if (!text) {
         return null;
     }
-    const customMarkdown = UIFactory.renderMarkdown({text});
+    const customMarkdown = UIFactory.renderMarkdown({text, errorMode});
     return customMarkdown ?? <MarkdownImpl text={text} />;
 });
 

--- a/packages/ui/src/ui/components/MetaTable/presets/defaultRenderMarkdown.tsx
+++ b/packages/ui/src/ui/components/MetaTable/presets/defaultRenderMarkdown.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import {type MetaTableRenderMarkdownParams} from '@ytsaurus/components';
 import {Markdown} from '../../Markdown/Markdown';
 
-export const renderDefaultMarkdown = ({text, allowHTML}: MetaTableRenderMarkdownParams) => {
-    return <Markdown text={text} allowHTML={allowHTML} />;
+export const renderDefaultMarkdown = ({
+    text,
+    allowHTML,
+    errorMode,
+}: MetaTableRenderMarkdownParams) => {
+    return <Markdown text={text} allowHTML={allowHTML} errorMode={errorMode} />;
 };


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/HbeT87mu7pgvTH
<!-- nda-end -->## Summary by Sourcery

Support inline Markdown error rendering for Nirvana block URLs.

Bug Fixes:
- Render errors for the Nirvana block URL inline instead of using the default block presentation.

Enhancements:
- Propagate configurable Markdown error rendering modes through the MetaTable, Markdown component, and UI factory interfaces.