### PR TITLE
chore: enable noImplicitOverride [YTFRONT-6020]

### DIFF
--- a/packages/components/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/packages/components/src/components/ClipboardButton/ClipboardButton.tsx
@@ -107,7 +107,7 @@ export class ClipboardButton extends Component<ClipboardButtonProps> {
         event.stopPropagation();
     };
 
-    render() {
+    override render() {
         const {
             buttonText,
             hotkey,

--- a/packages/components/src/components/DataTableYT/DataTableYT.tsx
+++ b/packages/components/src/components/DataTableYT/DataTableYT.tsx
@@ -81,7 +81,7 @@ export class DataTableYT<T> extends React.Component<DataTableYtProps<T>> {
         throw e;
     };
 
-    render() {
+    override render() {
         const {className, disableRightGap, ...rest} = this.props;
 
         const {useThemeYT} = rest as WithThemeYT;

--- a/packages/components/src/components/Hotkey/Hotkey.tsx
+++ b/packages/components/src/components/Hotkey/Hotkey.tsx
@@ -29,7 +29,7 @@ interface PreparedHokeyItem {
 export class Hotkey extends Component<HotkeyProps> {
     preparedSettings: Array<PreparedHokeyItem> = [];
 
-    componentDidMount() {
+    override componentDidMount() {
         const {settings} = this.props;
 
         if (!key) {
@@ -50,7 +50,7 @@ export class Hotkey extends Component<HotkeyProps> {
         });
     }
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         if (!key) {
             return;
         }
@@ -105,7 +105,7 @@ export class Hotkey extends Component<HotkeyProps> {
         key.unbind(combination, scope);
     }
 
-    render() {
+    override render() {
         return null;
     }
 }

--- a/packages/components/src/components/MetaTable/MetaTable.tsx
+++ b/packages/components/src/components/MetaTable/MetaTable.tsx
@@ -153,7 +153,7 @@ export class MetaTable extends Component<MetaTableProps> {
         return <h2 className={block('title')}>{title}</h2>;
     }
 
-    render() {
+    override render() {
         const {items, className, title, subTitles, qa} = this.props;
         const {groups, withInnerGroups, groupTitles} = splitItems(items, subTitles);
 

--- a/packages/components/src/components/SchemaDataType/DataType/DataType.tsx
+++ b/packages/components/src/components/SchemaDataType/DataType/DataType.tsx
@@ -40,7 +40,7 @@ export class DataType extends React.Component<DataTypeProps, DataTypeState> {
         level: 0,
     };
 
-    state: DataTypeState = {
+    override state: DataTypeState = {
         expanded: (this.props.level ?? 0) < 2,
     };
 
@@ -55,7 +55,7 @@ export class DataType extends React.Component<DataTypeProps, DataTypeState> {
     renderStructTypeEntry = (entry: {key: string | number; type: DataTypeProps}, index: number) => {
         return <DataTypeStructKey key={index} level={(this.props.level ?? 0) + 1} entry={entry} />;
     };
-    render() {
+    override render() {
         const {optional, optionalLevel, complex, name, tagged, tags, type, struct, params} =
             this.props;
         const {expanded} = this.state;

--- a/packages/components/src/components/YqlValue/YqlValue.tsx
+++ b/packages/components/src/components/YqlValue/YqlValue.tsx
@@ -25,7 +25,7 @@ export class YqlValue extends React.Component<YqlValueProps> {
             : unipika.formatFromYQL(yqlValue, settings);
     }
 
-    render() {
+    override render() {
         const {value, type, inline, settings, ErrorBoundaryComponent} = this.props;
         const ConfigurableErrorBoundary = ErrorBoundaryComponent || DefaultErrorBoundary;
 

--- a/packages/components/src/internal/DefaultErrorBoundary/ErrorBoundary.tsx
+++ b/packages/components/src/internal/DefaultErrorBoundary/ErrorBoundary.tsx
@@ -19,24 +19,24 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
         };
     }
 
-    state: State = {
+    override state: State = {
         hasError: false,
         error: undefined,
     };
 
-    componentDidUpdate() {
+    override componentDidUpdate() {
         const {hasError, error} = this.state;
         if (hasError && error) {
             console.error(error);
         }
     }
 
-    componentDidCatch(error: unknown) {
+    override componentDidCatch(error: unknown) {
         console.error({type: 'error-boundary'}, error);
         this.props.onError?.(error);
     }
 
-    render() {
+    override render() {
         const {hasError, error} = this.state;
         const {children} = this.props;
 

--- a/packages/components/src/internal/Yson/Yson.tsx
+++ b/packages/components/src/internal/Yson/Yson.tsx
@@ -71,7 +71,7 @@ export class Yson extends Component<YsonProps, State> {
         return null;
     }
 
-    state: State = {
+    override state: State = {
         convertedValue: undefined as any, // getDerivedStateFromProps should provide correct vgitalue for this field
         value: INITIAL,
         settings: {format: ''},
@@ -94,7 +94,7 @@ export class Yson extends Component<YsonProps, State> {
         return unipika.format(convertedValue, settings);
     }
 
-    render() {
+    override render() {
         const {inline, children, className, ErrorBoundaryComponent} = this.props;
         const ConfigurableErrorBoundary = ErrorBoundaryComponent || DefaultErrorBoundary;
 

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "build",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "noImplicitOverride": true,
     "declaration": true,
     "declarationMap": true,
     "resolveJsonModule": true,
@@ -18,3 +19,4 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build"]
 }
+

--- a/packages/ui/src/server/tsconfig.json
+++ b/packages/ui/src/server/tsconfig.json
@@ -1,11 +1,10 @@
 {
-  "extends": "@gravity-ui/tsconfig",
+  "extends": "../../tsconfig",
   "compilerOptions": {
     // not dist/server, because when use server/, common/
     // it results with dist/server/server/, dist/server/common/ and ui-core fails to start server
     "noUnusedParameters": false,
     "outDir": "../../dist",
-    "resolveJsonModule": true,
     "declaration": true,
     "target": "es2021"
   },

--- a/packages/ui/src/ui/components/Button/Button.tsx
+++ b/packages/ui/src/ui/components/Button/Button.tsx
@@ -68,7 +68,7 @@ export default class Button extends Component<ButtonProps> {
         return <Tooltip {...tooltipProps}>{this.renderSimpleButton()}</Tooltip>;
     }
 
-    render() {
+    override render() {
         const {withTooltip} = this.props;
 
         return withTooltip ? this.renderButtonWithTooltip() : this.renderSimpleButton();

--- a/packages/ui/src/ui/components/CollapsableText/CollapsableText.tsx
+++ b/packages/ui/src/ui/components/CollapsableText/CollapsableText.tsx
@@ -42,18 +42,18 @@ class CollapsableText extends React.Component<CollapsableTextProps> {
         lineCount: 3,
     };
 
-    state: State = {
+    override state: State = {
         collapsed: this.props.collapsed,
     };
 
     private textRef = React.createRef<HTMLDivElement>();
     private textSize?: number;
 
-    componentDidMount() {
+    override componentDidMount() {
         this.textSize = this.getTextSize();
         this.forceUpdate();
     }
-    render() {
+    override render() {
         const {collapsed} = this.state;
 
         const className = block({collapsed: collapsed ? 'yes' : undefined});

--- a/packages/ui/src/ui/components/CollapsibleSection/CollapsibleSection.tsx
+++ b/packages/ui/src/ui/components/CollapsibleSection/CollapsibleSection.tsx
@@ -26,7 +26,7 @@ export class CollapsibleSectionStateLess extends Component<PropsStateLess> {
         onToggle(!this.props.collapsed);
     };
 
-    render() {
+    override render() {
         const {
             name,
             children,

--- a/packages/ui/src/ui/components/ColumnSelectorModal/ColumnSelectorModal.tsx
+++ b/packages/ui/src/ui/components/ColumnSelectorModal/ColumnSelectorModal.tsx
@@ -40,7 +40,7 @@ type State<T> = Pick<Props<T>, 'items' | 'srcItems'> & {
 };
 
 export default class ColumnSelectorModal<T = never> extends React.Component<Props<T>, State<T>> {
-    state: State<T> = {
+    override state: State<T> = {
         srcItems: this.props.srcItems || this.props.items,
         items: makeItemsCopy(this.props.items),
         itemsOrder: this._getItemsOrder(this.props.items),
@@ -49,7 +49,7 @@ export default class ColumnSelectorModal<T = never> extends React.Component<Prop
 
     // in React 16.3 there is another way to do it: getDerivedStateFromProps;
     // revise this place once received data is managed by Redux
-    componentDidUpdate(prevProps: Props<T>) {
+    override componentDidUpdate(prevProps: Props<T>) {
         const {items, srcItems, isVisible} = this.props;
         if (prevProps.items !== items || prevProps.srcItems !== srcItems) {
             // don't update itemsOrder
@@ -252,7 +252,7 @@ export default class ColumnSelectorModal<T = never> extends React.Component<Prop
         );
     }
 
-    render() {
+    override render() {
         const {isVisible} = this.props;
         const title = i18n('title_columns-setup');
 

--- a/packages/ui/src/ui/components/CommaSeparateListWithRestCounter/CommaSeparateListWithRestCounter.tsx
+++ b/packages/ui/src/ui/components/CommaSeparateListWithRestCounter/CommaSeparateListWithRestCounter.tsx
@@ -61,7 +61,7 @@ export default class CommaSeparatedListWithRestCounter extends React.Component<
     ref?: HTMLDivElement | null;
     unmounted = false;
 
-    state: State = {
+    override state: State = {
         restCounter: 0,
         rows: [],
         showDialog: false,
@@ -72,11 +72,11 @@ export default class CommaSeparatedListWithRestCounter extends React.Component<
         this.updateState();
     };
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         this.unmounted = true;
     }
 
-    componentDidUpdate() {
+    override componentDidUpdate() {
         this.updateState();
     }
 
@@ -266,7 +266,7 @@ export default class CommaSeparatedListWithRestCounter extends React.Component<
         return items.length <= Math.min(MAX_TOOLTIP_COUNT, maxTooltipCount);
     }
 
-    render() {
+    override render() {
         const {className} = this.props;
         return (
             <div ref={this.onRef} className={block(null, className)}>

--- a/packages/ui/src/ui/components/DownloadManager/DownloadManager.tsx
+++ b/packages/ui/src/ui/components/DownloadManager/DownloadManager.tsx
@@ -122,7 +122,7 @@ export abstract class DownloadManager<ExtraProps extends object = object> extend
         };
     }
 
-    componentDidUpdate(prevProps: Props) {
+    override componentDidUpdate(prevProps: Props) {
         /*
          * The filename depends on getDefaultFilename(), an abstract instance method,
          * so it can't be reset alongside the rest of the form in the static
@@ -133,7 +133,7 @@ export abstract class DownloadManager<ExtraProps extends object = object> extend
         }
     }
 
-    render() {
+    override render() {
         const {loading, className, visible, handleClose} = this.props;
 
         return (

--- a/packages/ui/src/ui/components/ElementsTable/ElementsTableHeader.tsx
+++ b/packages/ui/src/ui/components/ElementsTable/ElementsTableHeader.tsx
@@ -343,7 +343,7 @@ export default class ElementsTableHeader extends Component<ElementsTableHeaderPr
         );
     }
 
-    render() {
+    override render() {
         const {columnSet} = this.state;
         const hasGroups = columnSet.hasGroups;
         const headerClassName = b('head', this.props.headerClassName);

--- a/packages/ui/src/ui/components/Favourites/Favourites.tsx
+++ b/packages/ui/src/ui/components/Favourites/Favourites.tsx
@@ -54,7 +54,7 @@ export default class Favourites extends Component<Props, State> {
         return null;
     }
 
-    state = {
+    override state = {
         isActive: this.props.isActive,
     };
 
@@ -115,7 +115,7 @@ export default class Favourites extends Component<Props, State> {
         return <Button {...buttonProps} {...themeProps} />;
     }
 
-    render() {
+    override render() {
         const {toggleDisabled, className, theme} = this.props;
         const {isActive} = this.state;
 

--- a/packages/ui/src/ui/components/FilePicker/FilePicker.tsx
+++ b/packages/ui/src/ui/components/FilePicker/FilePicker.tsx
@@ -28,7 +28,7 @@ export default class FilePicker extends React.Component<Props> {
         this.props.onChange(event.target.files);
     };
 
-    render() {
+    override render() {
         const {children, multiple} = this.props;
         return (
             <ClickableText onClick={this.onLinkClick}>

--- a/packages/ui/src/ui/components/Filter/Filter.tsx
+++ b/packages/ui/src/ui/components/Filter/Filter.tsx
@@ -99,7 +99,7 @@ export default class Filter extends Component<FilterProps, State> {
         return props.externallyManaged ? {value: props.value} : null;
     }
 
-    state: State = {value: this.props.value};
+    override state: State = {value: this.props.value};
     prevScope = key.getScope();
 
     input: HTMLInputElement | HTMLTextAreaElement | null = null;
@@ -136,7 +136,7 @@ export default class Filter extends Component<FilterProps, State> {
         }
     };
 
-    render() {
+    override render() {
         const {
             className,
             size,

--- a/packages/ui/src/ui/components/FilterWithRegExp/FilterWithRegExp.tsx
+++ b/packages/ui/src/ui/components/FilterWithRegExp/FilterWithRegExp.tsx
@@ -51,7 +51,7 @@ export class FilterWithRegExp extends React.PureComponent<Props, State> {
     }
 
     input: HTMLInputElement | null = null;
-    state: State = {};
+    override state: State = {};
 
     onChange(filter: string, useRegexp?: boolean) {
         const {onChange} = this.props;
@@ -82,7 +82,7 @@ export class FilterWithRegExp extends React.PureComponent<Props, State> {
         this.onChange(filter, useRegexp);
     };
 
-    render() {
+    override render() {
         const {
             className,
             size,

--- a/packages/ui/src/ui/components/FlexSplitPane/FlexSplitPane.tsx
+++ b/packages/ui/src/ui/components/FlexSplitPane/FlexSplitPane.tsx
@@ -34,7 +34,7 @@ class FlexSplitPane extends React.Component<FlexSplitPaneProps, FlexSplitPaneSta
     static VERTICAL = 'vertical' as const;
     static HORIZONTAL = 'horizontal' as const;
 
-    state: FlexSplitPaneState = {
+    override state: FlexSplitPaneState = {
         initialSizes: null,
     };
 
@@ -43,16 +43,16 @@ class FlexSplitPane extends React.Component<FlexSplitPaneProps, FlexSplitPaneSta
     private paneSecond: HTMLDivElement | null = null;
     private splitInstance: ReturnType<typeof split> | null = null;
 
-    componentDidMount() {
+    override componentDidMount() {
         this.checkSplit();
         window.addEventListener('resize', this.handleResize);
     }
 
-    componentDidUpdate() {
+    override componentDidUpdate() {
         this.checkSplit();
     }
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         this.destroySplit();
         window.removeEventListener('resize', this.handleResize);
     }
@@ -219,7 +219,7 @@ class FlexSplitPane extends React.Component<FlexSplitPaneProps, FlexSplitPaneSta
         }
     }
 
-    render() {
+    override render() {
         const {direction, id, paneClassNames = []} = this.props;
         const [firstChild, ...restChildren] = React.Children.toArray(this.props.children);
 

--- a/packages/ui/src/ui/components/LabelsGroup/LabelsGroup.tsx
+++ b/packages/ui/src/ui/components/LabelsGroup/LabelsGroup.tsx
@@ -98,7 +98,7 @@ class LabelsGroup extends Component<LabelsGroupProps> {
         );
     }
 
-    render() {
+    override render() {
         const {items, renderToggler, onRemoveAll} = this.props;
 
         return (

--- a/packages/ui/src/ui/components/Linkify/Linkify.tsx
+++ b/packages/ui/src/ui/components/Linkify/Linkify.tsx
@@ -40,7 +40,7 @@ export class Linkify extends React.PureComponent<Props> {
         return res;
     }
 
-    render() {
+    override render() {
         const {text, className} = this.props;
         return <span className={className}>{Linkify.renderText(text, HREF_RE)}</span>;
     }

--- a/packages/ui/src/ui/components/Modal/Modal.tsx
+++ b/packages/ui/src/ui/components/Modal/Modal.tsx
@@ -46,11 +46,11 @@ class Modal extends Component<ModalProps> {
         confirmText: i18n('action_apply'),
     };
 
-    componentDidMount() {
+    override componentDidMount() {
         document.addEventListener('keydown', this.handleKeyDown);
     }
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         document.removeEventListener('keydown', this.handleKeyDown);
     }
 
@@ -147,7 +147,7 @@ class Modal extends Component<ModalProps> {
         );
     }
 
-    render() {
+    override render() {
         const {visible, onCancel, onTransitionInComplete, size, className} = this.props;
         return (
             <ModalWrapper

--- a/packages/ui/src/ui/components/Modal/SimpleModal.tsx
+++ b/packages/ui/src/ui/components/Modal/SimpleModal.tsx
@@ -81,7 +81,7 @@ class SimpleModal extends Component<SimpleModalProps> {
         return <div className={b('footer')}>{this.props.footerContent}</div>;
     }
 
-    render() {
+    override render() {
         const {visible, onCancel, size, className, wrapperClassName} = this.props;
         return (
             visible && (

--- a/packages/ui/src/ui/components/NumberInput/NumberInput.tsx
+++ b/packages/ui/src/ui/components/NumberInput/NumberInput.tsx
@@ -176,7 +176,7 @@ export class NumberInputWithError extends React.Component<NumberInputWithErrorPr
         return undefined;
     }
 
-    state: State = {parsedValue: NaN};
+    override state: State = {parsedValue: NaN};
 
     // eslint-disable-next-line react/sort-comp
     parseValue(rawValue: string): NumberInputWithErrorProps['value'] {
@@ -286,7 +286,7 @@ export class NumberInputWithError extends React.Component<NumberInputWithErrorPr
         );
     }
 
-    render() {
+    override render() {
         const {
             value: propsValue,
             className,
@@ -351,7 +351,7 @@ export default class NumberInput extends React.Component<NumberInputProps> {
         return formatValue(value, format, settings);
     }
 
-    render() {
+    override render() {
         const {
             value,
             error,

--- a/packages/ui/src/ui/components/QuotaEditor/QuotaEditor.tsx
+++ b/packages/ui/src/ui/components/QuotaEditor/QuotaEditor.tsx
@@ -52,7 +52,7 @@ interface SuggestProps {
 }
 
 export default class QuotaEditor extends React.Component<QuotaEditorProps> {
-    render() {
+    override render() {
         const {
             className,
             format,

--- a/packages/ui/src/ui/components/QuotaEditor/QuotaEditorWithHide.tsx
+++ b/packages/ui/src/ui/components/QuotaEditor/QuotaEditorWithHide.tsx
@@ -53,9 +53,9 @@ interface State {
 }
 
 export default class QuotaEditorWithHide extends React.Component<Props, State> {
-    state: State = {};
+    override state: State = {};
 
-    render() {
+    override render() {
         const {showConfirm} = this.state;
         return showConfirm ? this.renderConfirmation() : this.renderEditor();
     }

--- a/packages/ui/src/ui/components/RadioButton/RadioButton.tsx
+++ b/packages/ui/src/ui/components/RadioButton/RadioButton.tsx
@@ -40,7 +40,7 @@ export default class CustomRadioButton<T extends string = string> extends React.
         };
     }
 
-    render() {
+    override render() {
         const {items, className, ...props} = this.props;
 
         const options = items.map((item) => ({

--- a/packages/ui/src/ui/components/Select/Select.tsx
+++ b/packages/ui/src/ui/components/Select/Select.tsx
@@ -162,7 +162,7 @@ class CustomSelect extends React.Component<
         width: 'max',
     };
 
-    render() {
+    override render() {
         const {className, hideFilter, ...props} = this.props;
         return (
             <Select

--- a/packages/ui/src/ui/components/SortIcon/SortIcon.tsx
+++ b/packages/ui/src/ui/components/SortIcon/SortIcon.tsx
@@ -43,7 +43,7 @@ export default class SortIcon extends React.Component<Props> {
         onChange(nextOrder);
     };
 
-    render() {
+    override render() {
         const {className, label, order, hidden, size = 13} = this.props;
         const icon = ICON_BY_TYPE[order || ''];
 

--- a/packages/ui/src/ui/components/StatusBulb/StatusBulb.tsx
+++ b/packages/ui/src/ui/components/StatusBulb/StatusBulb.tsx
@@ -13,7 +13,7 @@ class StatusBulb extends Component<Props> {
         theme: PropTypes.string,
     };
 
-    render() {
+    override render() {
         const className = block('status-bulb')({theme: this.props.theme});
         return <div className={className}></div>;
     }

--- a/packages/ui/src/ui/components/Suggest/Suggest.tsx
+++ b/packages/ui/src/ui/components/Suggest/Suggest.tsx
@@ -130,11 +130,11 @@ export default class Suggest extends Component<SuggestProps, State> {
         return res;
     }
 
-    componentDidMount() {
+    override componentDidMount() {
         this.isClearClicked = false;
     }
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         this.isUnmounting = true;
     }
 
@@ -440,7 +440,7 @@ export default class Suggest extends Component<SuggestProps, State> {
         );
     }
 
-    render() {
+    override render() {
         const {className} = this.props;
         return (
             <div className={b(null, className)}>

--- a/packages/ui/src/ui/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/ui/components/Tabs/Tabs.tsx
@@ -49,7 +49,7 @@ class Tabs<ValueT extends string = string> extends React.Component<Props<ValueT>
         layout: 'horizontal',
     };
 
-    render() {
+    override render() {
         const {className} = this.props;
 
         return (

--- a/packages/ui/src/ui/components/Timeline/Timeline.tsx
+++ b/packages/ui/src/ui/components/Timeline/Timeline.tsx
@@ -157,7 +157,7 @@ export class Timeline extends React.Component<TimelineProps> {
             />
         );
     }
-    render() {
+    override render() {
         return this.props.wrapper!({
             picker: this.renderPicker(),
             ruler: this.renderRuler(),

--- a/packages/ui/src/ui/components/WithStickyToolbar/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/ui/components/WithStickyToolbar/Toolbar/Toolbar.tsx
@@ -39,7 +39,7 @@ export class Toolbar extends React.Component<Props> {
         itemsToWrap: PropTypes.arrayOf(PropTypes.shape(ToolbarItemPropTypes)),
     };
 
-    render() {
+    override render() {
         const {className, children, marginTopSkip} = this.props;
         return (
             <div className={block({'margin-top-skip': marginTopSkip}, className)}>

--- a/packages/ui/src/ui/components/YTGraph/PopupLayer/PopupLayer.ts
+++ b/packages/ui/src/ui/components/YTGraph/PopupLayer/PopupLayer.ts
@@ -20,7 +20,7 @@ export class PopupLayer extends Layer<AreaLayerProps, AreaLayerContext> {
         this.getHTML().style.setProperty('--nv-graph-scale', `${state.scale}`);
     };
 
-    protected afterInit() {
+    protected override afterInit() {
         const html = this.getHTML();
 
         html.style.isolation = 'isolate';
@@ -32,7 +32,7 @@ export class PopupLayer extends Layer<AreaLayerProps, AreaLayerContext> {
         super.afterInit();
     }
 
-    protected unmount(): void {
+    protected override unmount(): void {
         super.unmount();
         this.context.camera.off('update', this.updateHTMLCamera);
     }

--- a/packages/ui/src/ui/components/YTGraph/canvas/NoopComponent.ts
+++ b/packages/ui/src/ui/components/YTGraph/canvas/NoopComponent.ts
@@ -1,7 +1,7 @@
 import {Component} from '@gravity-ui/graph';
 
 export class NoopComponent extends Component {
-    render() {
+    override render() {
         // noop;
         return;
     }

--- a/packages/ui/src/ui/components/YTGraph/canvas/YTGrapCanvasBlock.ts
+++ b/packages/ui/src/ui/components/YTGraph/canvas/YTGrapCanvasBlock.ts
@@ -81,7 +81,7 @@ export class YTGraphCanvasBlock<T extends YTGraphBlock<string, {}>> extends Canv
         });
     }
 
-    getGeometry() {
+    override getGeometry() {
         return this.connectedState.$geometry.value;
     }
 

--- a/packages/ui/src/ui/components/common/RangeInputPicker/RangeInputPicker.tsx
+++ b/packages/ui/src/ui/components/common/RangeInputPicker/RangeInputPicker.tsx
@@ -134,7 +134,7 @@ export class RangeInputPicker extends Component<RangeInputPickerProps, RangeInpu
         this.state = RangeInputPicker.getPreparedState(props);
     }
 
-    componentDidMount() {
+    override componentDidMount() {
         const {onOutsideClick} = this.props;
 
         if (onOutsideClick) {
@@ -143,7 +143,7 @@ export class RangeInputPicker extends Component<RangeInputPickerProps, RangeInpu
         }
     }
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         this.debouncedCallOnUpdate.cancel();
         this.debouncedHandleOnAfterUpdate.cancel();
 
@@ -151,7 +151,7 @@ export class RangeInputPicker extends Component<RangeInputPickerProps, RangeInpu
         document.removeEventListener('mousedown', this.handleOutsideClick);
     }
 
-    render() {
+    override render() {
         const {
             placeholder,
             autoFocus,

--- a/packages/ui/src/ui/components/common/Timeline/TimelinePicker/TimelinePicker.tsx
+++ b/packages/ui/src/ui/components/common/Timeline/TimelinePicker/TimelinePicker.tsx
@@ -42,7 +42,7 @@ class TimeHotButton extends React.Component<TimeHotButtonProps> {
     onClick = () => {
         this.props.onClick(this.props.time);
     };
-    render() {
+    override render() {
         const {size, width, title, className, checked} = this.props;
         return (
             <Button
@@ -122,11 +122,11 @@ export class TimelinePicker extends React.Component<TimelinePickerProps, State> 
             };
         }
     }
-    state: State = {} as any;
+    override state: State = {} as any;
     _datepickerRef = React.createRef<HTMLDivElement>();
     _inputRef = React.createRef<EnterInput>();
 
-    componentDidUpdate() {
+    override componentDidUpdate() {
         if (this.state.opened && this._inputRef.current) {
             this._inputRef.current?.focus();
         }
@@ -282,7 +282,7 @@ export class TimelinePicker extends React.Component<TimelinePickerProps, State> 
             );
         }
     };
-    render() {
+    override render() {
         const {className, from, to, topShortcuts, hasDatePicker} = this.props;
         const {opened} = this.state;
         const picker = opened ? this.renderOpenedPicker() : this.renderClosedPicker();

--- a/packages/ui/src/ui/containers/ACL/ACL.tsx
+++ b/packages/ui/src/ui/containers/ACL/ACL.tsx
@@ -167,11 +167,11 @@ class ACL extends Component<Props> {
         );
     }
 
-    state = {
+    override state = {
         deleteItem: {} as {key?: string},
     };
 
-    componentDidMount() {
+    override componentDidMount() {
         const {path, idmKind, loadAclData} = this.props;
 
         if (path) {
@@ -179,7 +179,7 @@ class ACL extends Component<Props> {
         }
     }
 
-    componentDidUpdate(prevProps: Props) {
+    override componentDidUpdate(prevProps: Props) {
         const {path, idmKind, loadAclData} = this.props;
         if (prevProps.path !== path) {
             loadAclData({path, idmKind});
@@ -800,7 +800,7 @@ class ACL extends Component<Props> {
         );
     }
 
-    render() {
+    override render() {
         const {loading, loaded, className} = this.props;
         const initialLoading = loading && !loaded;
 

--- a/packages/ui/src/ui/containers/ACL/AclActions/AclActions.tsx
+++ b/packages/ui/src/ui/containers/ACL/AclActions/AclActions.tsx
@@ -63,7 +63,7 @@ export class AclActions extends Component<Props> {
         await loadAclData({path, idmKind});
     };
 
-    render() {
+    override render() {
         const {
             aclMode,
             path,

--- a/packages/ui/src/ui/containers/ACL/RequestPermissions/PermissionsControl/PermissionsControl.tsx
+++ b/packages/ui/src/ui/containers/ACL/RequestPermissions/PermissionsControl/PermissionsControl.tsx
@@ -43,7 +43,7 @@ export default class PermissionsControl extends Component<Props, State> {
         return isEmpty_(value);
     }
 
-    state: State = {};
+    override state: State = {};
 
     handleCheckboxChange = (
         permissionName: string,
@@ -81,7 +81,7 @@ export default class PermissionsControl extends Component<Props, State> {
         );
     }
 
-    render() {
+    override render() {
         const {choices, disabled, disabledChoices, error} = this.props;
 
         const mainChoices: Array<{item: Array<YTPermissionTypeUI>; isDisabled: boolean}> = [];

--- a/packages/ui/src/ui/containers/ACL/SubjectsControl/SubjectsControl.tsx
+++ b/packages/ui/src/ui/containers/ACL/SubjectsControl/SubjectsControl.tsx
@@ -21,7 +21,7 @@ export default class SubjectsControl extends React.Component<SubjectsControlProp
         return !value || !value.length;
     }
 
-    render() {
+    override render() {
         return UIFactory.renderAclSubjectsSuggestControl(this.props);
     }
 }

--- a/packages/ui/src/ui/containers/Block/Block.tsx
+++ b/packages/ui/src/ui/containers/Block/Block.tsx
@@ -194,7 +194,7 @@ class YTErrorBlockImpl extends React.Component<YTErrorBlockInternalProps> {
         );
     }
 
-    render() {
+    override render() {
         const {type, className, topMargin, bottomMargin, disableLogger, error} = this.props;
 
         return (

--- a/packages/ui/src/ui/containers/ClusterPageWrapper/ClusterPageWrapper.tsx
+++ b/packages/ui/src/ui/containers/ClusterPageWrapper/ClusterPageWrapper.tsx
@@ -9,7 +9,7 @@ import {odinRootPageInfo} from '../../pages/odin/lazy';
 import {hasOdinPage} from '../../config';
 
 export default class ClusterPageWrapper extends React.PureComponent {
-    render() {
+    override render() {
         return (
             <Switch>
                 {map_(UIFactory.getExtraRootPages(), ({pageId, reactComponent}, index) => {

--- a/packages/ui/src/ui/containers/ClustersMenu/ClustersMenuBody.tsx
+++ b/packages/ui/src/ui/containers/ClustersMenu/ClustersMenuBody.tsx
@@ -34,7 +34,7 @@ const b = block('cluster-menu');
 type Props = ConnectedProps<typeof connector>;
 
 class ClustersMenuBody extends React.Component<Props> {
-    componentDidMount() {
+    override componentDidMount() {
         const {fetchClusterVersions, fetchClusterAvailability, fetchClusterAuthStatus} = this.props;
 
         fetchClusterVersions();
@@ -266,7 +266,7 @@ class ClustersMenuBody extends React.Component<Props> {
         );
     }
 
-    render() {
+    override render() {
         const {viewMode, clusterFilter, clusters} = this.props;
         let regexp: RegExp | undefined;
         try {

--- a/packages/ui/src/ui/containers/Dialog/controls/BeforeDatePicker/BeforeDatePicker.tsx
+++ b/packages/ui/src/ui/containers/Dialog/controls/BeforeDatePicker/BeforeDatePicker.tsx
@@ -95,7 +95,7 @@ class BeforeDatePicker extends React.Component<IdmDatePickerProps, State> {
         return Object.keys(res).length > 0 ? res : null;
     }
 
-    state = {
+    override state = {
         viewType: null, // see ALLOWED_VIEW_TYPE
 
         period: null,
@@ -190,7 +190,7 @@ class BeforeDatePicker extends React.Component<IdmDatePickerProps, State> {
         onChange(date);
     }
 
-    render() {
+    override render() {
         const {className, onFocus, onBlur} = this.props;
         return (
             <FocusBlurContainer

--- a/packages/ui/src/ui/containers/Dialog/controls/BytesControl.tsx
+++ b/packages/ui/src/ui/containers/Dialog/controls/BytesControl.tsx
@@ -24,7 +24,7 @@ export default class BytesControl extends Component<Omit<NumberInputProps, 'form
         return value === undefined || value === ('' as any);
     }
 
-    render() {
+    override render() {
         const {value} = this.props;
         return (
             <NumberInput
@@ -56,7 +56,7 @@ export class NumberControl extends Component<NumberInputWithErrorProps> {
         return v?.error ? v?.error : undefined;
     }
 
-    render() {
+    override render() {
         const {value} = this.props;
         return (
             <NumberInputWithError

--- a/packages/ui/src/ui/containers/Dialog/controls/EditablePathList/EditablePathList.tsx
+++ b/packages/ui/src/ui/containers/Dialog/controls/EditablePathList/EditablePathList.tsx
@@ -49,7 +49,7 @@ export default class EditablePathList extends React.Component<Props> {
         onChange(newValue);
     };
 
-    render() {
+    override render() {
         const {value, defaultPath, placeholder} = this.props;
         const listItems = map_(sortBy_(value), (path) => {
             return {title: path};

--- a/packages/ui/src/ui/containers/Dialog/controls/RoleListControl/RoleListControl.tsx
+++ b/packages/ui/src/ui/containers/Dialog/controls/RoleListControl/RoleListControl.tsx
@@ -83,7 +83,7 @@ export default class RoleListControl extends React.Component<RoleListControlProp
         return type === 'users' ? <SubjectCard name={title} /> : title;
     };
 
-    render() {
+    override render() {
         const {className, value, placeholder, maxVisibleCount, allowedTypes} = this.props;
 
         const manyListsData = RoleListControl.prepareManyListData(value);

--- a/packages/ui/src/ui/containers/Dialog/controls/SelectWithSubItems/SelectWithSubItems.tsx
+++ b/packages/ui/src/ui/containers/Dialog/controls/SelectWithSubItems/SelectWithSubItems.tsx
@@ -30,7 +30,7 @@ export default class SelectWithSubItems extends Component<Props> {
         return !value || value.length === 0;
     }
 
-    render() {
+    override render() {
         const {className, value: input, items, labels, placeholder, subItemsMap = {}} = this.props;
         const [first, second] = input || [];
         const [label, subLabel] = labels || [];

--- a/packages/ui/src/ui/containers/Dialog/controls/SortableListControl/SortableListControl.tsx
+++ b/packages/ui/src/ui/containers/Dialog/controls/SortableListControl/SortableListControl.tsx
@@ -67,7 +67,7 @@ class SortableListControl extends Component<Props> {
         return Array.isArray(value) ? !value.length : true;
     }
 
-    state: State = {
+    override state: State = {
         items: this.props.value,
     };
 
@@ -84,7 +84,7 @@ class SortableListControl extends Component<Props> {
         });
     };
 
-    render() {
+    override render() {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const {value, onChange, error, ...rest} = this.props;
         const {items} = this.state;

--- a/packages/ui/src/ui/containers/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/ui/src/ui/containers/ErrorBoundary/ErrorBoundary.tsx
@@ -32,12 +32,12 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
         };
     }
 
-    state: State = {
+    override state: State = {
         hasError: false,
         error: undefined,
     };
 
-    componentDidUpdate() {
+    override componentDidUpdate() {
         const {hasError, error} = this.state;
 
         if (hasError && !this.props.disableRum) {
@@ -46,7 +46,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
         }
     }
 
-    componentDidCatch(error: any) {
+    override componentDidCatch(error: any) {
         if (!this.props.disableRum) {
             rumLogError(
                 {
@@ -58,7 +58,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> 
         this.props.onError?.(error);
     }
 
-    render() {
+    override render() {
         const {hasError, error} = this.state;
         const {children, compact, maxCompactMessageLength, inline} = this.props;
 

--- a/packages/ui/src/ui/containers/ErrorDetails/ErrorDetails.tsx
+++ b/packages/ui/src/ui/containers/ErrorDetails/ErrorDetails.tsx
@@ -125,7 +125,7 @@ class ErrorDetailsImpl extends React.Component<
         }
     }
 
-    state: State = {
+    override state: State = {
         showDetails: Boolean(this.props.defaultExpadedCount),
         currentTab: ErrorDetailsImpl.prepareDefaultTab(this.props),
     };
@@ -294,7 +294,7 @@ class ErrorDetailsImpl extends React.Component<
         );
     }
 
-    render() {
+    override render() {
         return (
             <div className={b()}>
                 {this.renderError()}

--- a/packages/ui/src/ui/containers/LoadDataHandler/LoadDataHandler.tsx
+++ b/packages/ui/src/ui/containers/LoadDataHandler/LoadDataHandler.tsx
@@ -17,7 +17,7 @@ interface LoadDataHandlerProps {
 }
 
 export default class LoadDataHandler extends Component<LoadDataHandlerProps> {
-    componentDidUpdate() {
+    override componentDidUpdate() {
         const {error, loaded, errorData} = this.props;
 
         if (error && loaded) {
@@ -37,7 +37,7 @@ export default class LoadDataHandler extends Component<LoadDataHandlerProps> {
         }
     }
 
-    render() {
+    override render() {
         const {alwaysShowError = false, error, errorData, loaded, children} = this.props;
 
         const initialLoading = !loaded;

--- a/packages/ui/src/ui/containers/MaintenancePage/MaintenancePage.tsx
+++ b/packages/ui/src/ui/containers/MaintenancePage/MaintenancePage.tsx
@@ -27,7 +27,7 @@ type Props = {
 };
 
 export class MaintenancePage extends React.Component<Props> {
-    render() {
+    override render() {
         const {maintenancePageEvent, onProceed} = this.props;
         if (!maintenancePageEvent) {
             return null;

--- a/packages/ui/src/ui/containers/ModalErrors/ModalErrors.tsx
+++ b/packages/ui/src/ui/containers/ModalErrors/ModalErrors.tsx
@@ -51,7 +51,7 @@ class ModalErrors extends React.Component<Props> {
         this.props.hideError(errorId);
     };
 
-    render() {
+    override render() {
         const {errors} = this.props;
         return errors.map(({id, error}) => {
             return <ModalError key={id} id={id} data={error} hide={this.hideError} />;

--- a/packages/ui/src/ui/containers/PathEditor/PathEditor.tsx
+++ b/packages/ui/src/ui/containers/PathEditor/PathEditor.tsx
@@ -124,7 +124,7 @@ export class PathEditor extends Component<PathEditorProps, PathEditorState> {
         return isEmpty_(res) ? null : res;
     }
 
-    state: PathEditorState;
+    override state: PathEditorState;
 
     private suggestionsList = React.createRef<HTMLDivElement>();
     private input = React.createRef<HTMLInputElement>();
@@ -143,7 +143,7 @@ export class PathEditor extends Component<PathEditorProps, PathEditorState> {
         };
     }
 
-    componentDidMount() {
+    override componentDidMount() {
         const {loadSuggestionsList, customFilter, cluster, autoFocus} = this.props;
         const {path} = this.state;
 
@@ -155,13 +155,13 @@ export class PathEditor extends Component<PathEditorProps, PathEditorState> {
         }
     }
 
-    componentDidUpdate(prevProps: PathEditorProps) {
+    override componentDidUpdate(prevProps: PathEditorProps) {
         if (prevProps.disabled && !this.props.disabled && this.input.current) {
             this._setFocus();
         }
     }
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         this.props.removeActiveRequests();
     }
 
@@ -405,7 +405,7 @@ export class PathEditor extends Component<PathEditorProps, PathEditorState> {
         );
     }
 
-    render() {
+    override render() {
         return (
             <div className={b(null, this.props.className)}>
                 {this.renderInput()}

--- a/packages/ui/src/ui/hocs/withSplit.tsx
+++ b/packages/ui/src/ui/hocs/withSplit.tsx
@@ -8,7 +8,7 @@ export default function withSplit<P>(Component: React.ComponentType<P>): React.C
     return class WithSplit extends React.Component<P> {
         static displayName = `WithSplit(${getDisplayName(Component)})`;
 
-        render() {
+        override render() {
             return ReactDOM.createPortal(
                 <Component {...this.props} />,
                 document.getElementById(SPLIT_PANE_ID)!,

--- a/packages/ui/src/ui/hocs/withVisible.tsx
+++ b/packages/ui/src/ui/hocs/withVisible.tsx
@@ -26,13 +26,13 @@ export default function withVisible<P extends WithVisibleProps>(Component: React
 
         static displayName = `WithVisible(${getDisplayName(Component)})`;
 
-        state = {visible: this.props.visible};
+        override state = {visible: this.props.visible};
 
         handleShow = () => this.setState({visible: true});
         handleClose = () => this.setState({visible: false});
         toggleVisible = () => this.setState((prevState) => ({visible: !prevState.visible}));
 
-        render() {
+        override render() {
             const {visible} = this.state;
 
             return (

--- a/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
+++ b/packages/ui/src/ui/pages/accounts/AccountQuota/AccountQuota.tsx
@@ -60,9 +60,9 @@ interface State {
 }
 
 class AccountQuotaEditor extends React.Component<Props & ReduxProps, State> {
-    state: State = {};
+    override state: State = {};
 
-    render() {
+    override render() {
         const {title, type, mediumType, currentAccount, activeAccount, accountsTree} = this.props;
         const {format} = ACCOUNT_RESOURCE_TYPES_DESCRIPTION[type];
         const {showEditor} = this.state;

--- a/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
+++ b/packages/ui/src/ui/pages/accounts/Accounts/Accounts.tsx
@@ -53,7 +53,7 @@ export class Accounts extends React.Component<
         lastVisitedTab: ACCOUNTS_DEFAULT_TAB,
     };
 
-    render() {
+    override render() {
         const {match, cluster, lastVisitedTab, activeAccount, allowUsageTab} = this.props;
         const showSettings = reduce_(
             AccountsTab,

--- a/packages/ui/src/ui/pages/accounts/tabs/general/AccountsTotal.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/AccountsTotal.tsx
@@ -144,7 +144,7 @@ export default class AccountsTotal extends Component<Props> {
         );
     }
 
-    render() {
+    override render() {
         return (
             <div className={b('disk-space')}>
                 <div className={b('disk-space-table')}>{this.renderNewTotals()}</div>

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/AccountCreateDialog.tsx
@@ -31,7 +31,7 @@ function isRootAccount(account: string) {
 }
 
 class AccountCreateDialog extends React.Component<ConnectedProps<typeof connector>> {
-    render() {
+    override render() {
         const {visible, newAccountInfo, activeAccount, currentUserName, isAdmin} = this.props;
 
         const {parentAccount, responsibles = []} = newAccountInfo;

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/ChunksContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/ChunksContent.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default class ChunksContent extends Component<Props> {
-    render() {
+    override render() {
         const {account} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/GeneralContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/GeneralContent.tsx
@@ -47,7 +47,7 @@ type ReduxProps = ConnectedProps<typeof connector>;
 type Props = ParentProps & ReduxProps;
 
 class GeneralContent extends React.Component<Props> {
-    state = {
+    override state = {
         abcId: undefined,
         abcTitle: '',
         // We have to use this property as 'key' of StaffSuggestControl to recreate the component,
@@ -126,7 +126,7 @@ class GeneralContent extends React.Component<Props> {
         loadEditedAccount(name);
     };
 
-    render() {
+    override render() {
         const {
             account: {parent},
         } = this.props;

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/MediumContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/MediumContent.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 class MediumContent extends Component<Props> {
-    state = {
+    override state = {
         showAllMediums: false,
     };
 
@@ -55,7 +55,7 @@ class MediumContent extends Component<Props> {
         ));
     }
 
-    render() {
+    override render() {
         const {account, mediumList} = this.props;
         const mediumTypesWithoutCache = mediumList.filter((item) => item !== 'cache');
         const [defined, rest] = partition_(

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/NodesContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/NodesContent.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export default class NodesContent extends Component<Props> {
-    render() {
+    override render() {
         const {account} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/TabletsContent.tsx
+++ b/packages/ui/src/ui/pages/accounts/tabs/general/Editor/content/TabletsContent.tsx
@@ -52,7 +52,7 @@ class TabletsContent extends Component<Props & ConnectedProps<typeof connector>>
         );
     }
 
-    render() {
+    override render() {
         const {allowTabletAccounting} = this.props;
         return (
             <div className="elements-section">

--- a/packages/ui/src/ui/pages/components/tabs/Proxies/ProxyActions/ProxyActions.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/Proxies/ProxyActions/ProxyActions.tsx
@@ -41,7 +41,7 @@ class ProxyActions extends React.Component<ReduxProps & Props> {
         });
     };
 
-    render() {
+    override render() {
         const {proxy} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/components/tabs/Proxies/ProxyCard/ProxyCard.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/Proxies/ProxyCard/ProxyCard.tsx
@@ -76,7 +76,7 @@ export class ProxyCard extends Component<ProxyCardProps> {
         isYpCluster: PropTypes.bool.isRequired,
     };
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
         this.props.handleClose();
     }
 
@@ -158,7 +158,7 @@ export class ProxyCard extends Component<ProxyCardProps> {
         );
     }
 
-    render() {
+    override render() {
         const {proxy, handleClose} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/components/tabs/Versions/VersionSummary.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/Versions/VersionSummary.tsx
@@ -66,7 +66,7 @@ class VersionsSummary extends React.Component<Props, State> {
         };
     }
 
-    componentDidUpdate(prevProps: Props, prevState: State) {
+    override componentDidUpdate(prevProps: Props, prevState: State) {
         const {currentVersions, showAll} = this.state;
         const {visibleColumns, checkedHideOffline} = this.props;
 
@@ -246,7 +246,7 @@ class VersionsSummary extends React.Component<Props, State> {
         return data.reverse();
     };
 
-    render() {
+    override render() {
         const {currentVersions, sortOrder} = this.state;
         const {items, loading, loaded, cluster, checkedHideOffline} = this.props;
         const monitoringLink = UIFactory.getVersionMonitoringLink(cluster);

--- a/packages/ui/src/ui/pages/components/tabs/Versions/VersionsV2.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/Versions/VersionsV2.tsx
@@ -238,7 +238,7 @@ class VersionsV2 extends React.Component<ReduxProps> {
         return res;
     }
 
-    render() {
+    override render() {
         const {details, loading, loaded} = this.props;
         const initialLoading = loading && !loaded;
 

--- a/packages/ui/src/ui/pages/components/tabs/nodes/MemoryProgress/MemoryProgress.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/MemoryProgress/MemoryProgress.tsx
@@ -79,7 +79,7 @@ class MemoryProgress extends React.Component<MemoryProgressProps & ReduxProps> {
         );
     }
 
-    render() {
+    override render() {
         return (
             <Tooltip className={block()} content={this.renderPopupContent()} placement={'auto'}>
                 <div>{this.renderProgress()}</div>

--- a/packages/ui/src/ui/pages/components/tabs/nodes/NodeActions/NodeActions.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/NodeActions/NodeActions.tsx
@@ -24,7 +24,7 @@ class NodeActions extends React.Component<NodeActionsProps> {
         });
     };
 
-    render() {
+    override render() {
         const {node, cluster} = this.props;
         const {url, title} = UIFactory.getComponentsNodeDashboardUrl({cluster, host: node.host});
 

--- a/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
+++ b/packages/ui/src/ui/pages/components/tabs/nodes/Nodes/Nodes.tsx
@@ -97,7 +97,7 @@ function NodesUpdater() {
 }
 
 class Nodes extends React.Component<ReduxProps & WithVisibleProps, State> {
-    state: State = {
+    override state: State = {
         preset: '',
         activeNodeHost: undefined,
         selectedColumns: this.props.selectedColumns,
@@ -350,7 +350,7 @@ class Nodes extends React.Component<ReduxProps & WithVisibleProps, State> {
         );
     }
 
-    render() {
+    override render() {
         const {visible} = this.props;
         const {preset} = this.state;
 

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/ComputationCanvas.ts
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/ComputationCanvas.ts
@@ -18,7 +18,7 @@ export class ComputationCanvasBlock extends YTGraphCanvasBlock<FlowGraphBlockIte
         return 'header' as const;
     }
 
-    renderBlock(mode: 'minimalistic' | 'schematic'): void {
+    override renderBlock(mode: 'minimalistic' | 'schematic'): void {
         this.drawBorder({backgroundTheme: this.state.backgroundTheme});
 
         if (mode === 'minimalistic') {
@@ -99,7 +99,7 @@ export class ComputationCanvasBlock extends YTGraphCanvasBlock<FlowGraphBlockIte
         });
     }
 
-    getAnchorPosition({index = 0}: TAnchor) {
+    override getAnchorPosition({index = 0}: TAnchor) {
         const {length = 0} = this.state.anchors ?? [];
 
         const {width, height} = this.getGeometry();
@@ -108,7 +108,8 @@ export class ComputationCanvasBlock extends YTGraphCanvasBlock<FlowGraphBlockIte
         return {y: height, x: step * (index + 1)};
     }
 
-    renderAnchor: YTGraphCanvasBlock<FlowGraphBlockItem<'computation'>>['renderAnchor'] = () => {
-        return NoopComponent.create();
-    };
+    override renderAnchor: YTGraphCanvasBlock<FlowGraphBlockItem<'computation'>>['renderAnchor'] =
+        () => {
+            return NoopComponent.create();
+        };
 }

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/SinkCanvas.tsx
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/SinkCanvas.tsx
@@ -4,7 +4,7 @@ import {type FlowGraphBlockItem} from '../FlowGraph';
 const PADDING = 10;
 
 export class SinkCanvasBlock extends YTGraphCanvasBlock<FlowGraphBlockItem<'sink'>> {
-    renderBlock(mode: 'minimalistic' | 'schematic'): void {
+    override renderBlock(mode: 'minimalistic' | 'schematic'): void {
         this.drawBorder({backgroundTheme: this.state.backgroundTheme});
 
         if (mode === 'minimalistic') {

--- a/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/StreamCanvas.ts
+++ b/packages/ui/src/ui/pages/flow/Flow/FlowGraph/renderers/StreamCanvas.ts
@@ -8,7 +8,7 @@ import {type FlowGraphBlockItem} from '../FlowGraph';
 const PADDING = 10;
 
 export class StreamCanvasBlock extends YTGraphCanvasBlock<FlowGraphBlockItem<'stream'>> {
-    renderBlock(mode: 'minimalistic' | 'schematic'): void {
+    override renderBlock(mode: 'minimalistic' | 'schematic'): void {
         this.drawBorder({backgroundTheme: this.state.backgroundTheme});
 
         if (mode === 'minimalistic') {
@@ -50,7 +50,7 @@ export class StreamCanvasBlock extends YTGraphCanvasBlock<FlowGraphBlockItem<'st
         });
     }
 
-    getAnchorPosition({index = 0}: TAnchor) {
+    override getAnchorPosition({index = 0}: TAnchor) {
         const {length = 0} = this.state.anchors ?? {};
 
         const {width} = this.getGeometry();
@@ -59,7 +59,8 @@ export class StreamCanvasBlock extends YTGraphCanvasBlock<FlowGraphBlockItem<'st
         return {y: 0, x: step * (index + 1)};
     }
 
-    renderAnchor: YTGraphCanvasBlock<FlowGraphBlockItem<'computation'>>['renderAnchor'] = () => {
-        return NoopComponent.create();
-    };
+    override renderAnchor: YTGraphCanvasBlock<FlowGraphBlockItem<'computation'>>['renderAnchor'] =
+        () => {
+            return NoopComponent.create();
+        };
 }

--- a/packages/ui/src/ui/pages/groups/GroupEditorDialog/GroupEditorDialog.tsx
+++ b/packages/ui/src/ui/pages/groups/GroupEditorDialog/GroupEditorDialog.tsx
@@ -92,7 +92,7 @@ class GroupEditorDialog extends React.Component<GroupsPageTableProps> {
             .then(() => {});
     };
 
-    render() {
+    override render() {
         const {visible, closeGroupEditorModal, groupName, idm, members, otherMembers, responsible} =
             this.props;
         return (

--- a/packages/ui/src/ui/pages/groups/GroupsPageFilters/GroupsPageFilters.tsx
+++ b/packages/ui/src/ui/pages/groups/GroupsPageFilters/GroupsPageFilters.tsx
@@ -22,7 +22,7 @@ type GroupsPageFiltersProps = {
 };
 
 class GroupsPageFilters extends React.Component<GroupsPageFiltersProps> {
-    render() {
+    override render() {
         const {className, groupFilter} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/groups/GroupsPageTable/GroupsPageTable.tsx
+++ b/packages/ui/src/ui/pages/groups/GroupsPageTable/GroupsPageTable.tsx
@@ -66,7 +66,7 @@ interface GroupsPageTableProps extends ConnectedProps<typeof connector> {
 }
 
 class GroupsPageTable extends React.Component<GroupsPageTableProps> {
-    componentDidMount() {
+    override componentDidMount() {
         const {fetchGroups} = this.props;
         fetchGroups();
     }
@@ -216,7 +216,7 @@ class GroupsPageTable extends React.Component<GroupsPageTableProps> {
         );
     }
 
-    render() {
+    override render() {
         const {className, error, showEditor} = this.props;
         return (
             <ErrorBoundary>

--- a/packages/ui/src/ui/pages/navigation/Navigation/PathEditorModal/CreateDirectoryModal/CreateDirectoryModal.tsx
+++ b/packages/ui/src/ui/pages/navigation/Navigation/PathEditorModal/CreateDirectoryModal/CreateDirectoryModal.tsx
@@ -23,11 +23,11 @@ type State = {
 type ReduxProps = ConnectedProps<typeof connector>;
 
 class CreateDirectoryModal extends React.Component<ReduxProps> {
-    state: State = {
+    override state: State = {
         recursive: false,
     };
 
-    render() {
+    override render() {
         const {popupVisible, creating, creatingPath, showError, errorMessage, error} = this.props;
 
         const modalTitle = i18n('title_create-directory');

--- a/packages/ui/src/ui/pages/navigation/Navigation/PathEditorModal/DeleteObjectModal/DeleteObjectModal.tsx
+++ b/packages/ui/src/ui/pages/navigation/Navigation/PathEditorModal/DeleteObjectModal/DeleteObjectModal.tsx
@@ -45,7 +45,7 @@ type DispatchProps = ResolveThunks<typeof mapDispatchToProps>;
 type DeleteObjectModalProps = OwnProps & StateProps & DispatchProps;
 
 export class DeleteObjectModal extends Component<DeleteObjectModalProps> {
-    componentDidUpdate(prevProps: DeleteObjectModalProps) {
+    override componentDidUpdate(prevProps: DeleteObjectModalProps) {
         const {visible, item, getRealPath, getRealPaths, multipleMode} = this.props;
 
         if (!prevProps.visible && visible) {
@@ -230,7 +230,7 @@ export class DeleteObjectModal extends Component<DeleteObjectModalProps> {
         );
     }
 
-    render() {
+    override render() {
         const {visible, closeDeleteModal, permanently, loading} = this.props;
         const theme = permanently ? 'outlined-danger' : 'action';
         const helpLinkUrl = UIFactory.docsUrls['common:regular_system_processes'];

--- a/packages/ui/src/ui/pages/navigation/content/MapNode/MapNodeToolbar/MapNodeToolbar.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/MapNode/MapNodeToolbar/MapNodeToolbar.tsx
@@ -101,7 +101,7 @@ type State = {
 };
 
 class MapNodeToolbarImpl extends React.PureComponent<MapNodeToolbarProps, State> {
-    state: State = {
+    override state: State = {
         uploadFileVisible: false,
         uploadTableVisible: false,
     };
@@ -135,7 +135,7 @@ class MapNodeToolbarImpl extends React.PureComponent<MapNodeToolbarProps, State>
         this.props.openCreateACOModal({path, namespace: 'queries'});
     };
 
-    render() {
+    override render() {
         const {
             setFilter,
             contentMode,

--- a/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManager.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManager.tsx
@@ -98,7 +98,7 @@ type ProgressState =
     {inProgress: false} | {inProgress: true; event: {total?: number; loaded: number}};
 
 class UploadManager extends React.Component<Props, State> {
-    state: State = {
+    override state: State = {
         file: null,
         fileType: 'json',
         progress: {inProgress: false},
@@ -537,7 +537,7 @@ class UploadManager extends React.Component<Props, State> {
         );
     }
 
-    render() {
+    override render() {
         const {visible, handleShow} = this.props;
         return (
             <React.Fragment>

--- a/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManagerCreate.tsx
+++ b/packages/ui/src/ui/pages/navigation/content/Table/UploadManager/UploadManagerCreate.tsx
@@ -73,7 +73,7 @@ const getExcelBaseUrl = (payload: {cluster: string}) => {
 };
 
 class UploadManagerCreateImpl extends React.Component<Props, State> {
-    state: State = {
+    override state: State = {
         name: '',
         file: null,
         fileType: 'xlsx',
@@ -98,7 +98,7 @@ class UploadManagerCreateImpl extends React.Component<Props, State> {
         );
     }
 
-    componentDidUpdate(_: Props, prevState: State) {
+    override componentDidUpdate(_: Props, prevState: State) {
         if (prevState.name !== this.state.name) {
             const alreadyUsed = this.checkNameAlreadyExist(this.state.name);
             this.setState({nameAlreadyUsed: alreadyUsed});
@@ -414,7 +414,7 @@ class UploadManagerCreateImpl extends React.Component<Props, State> {
         this.props.onClose();
     };
 
-    render() {
+    override render() {
         const {visible} = this.props;
         return (
             <React.Fragment>

--- a/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableModal.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableModal.tsx
@@ -539,7 +539,7 @@ class CreateTableModalContentImpl extends React.Component<Props> {
         return this.formValidator;
     }
 
-    render() {
+    override render() {
         const {
             className,
             parentDirectory,

--- a/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableSuggests/CreateTableSuggests.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableSuggests/CreateTableSuggests.tsx
@@ -34,7 +34,7 @@ class LockSuggest extends React.Component<Props> {
         onChange('string' === typeof value ? value : value.value);
     };
 
-    render() {
+    override render() {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const {className, value, onChange, children, suggestions, ...rest} = this.props;
 

--- a/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableTabField/CreateTableTabField.tsx
+++ b/packages/ui/src/ui/pages/navigation/modals/CreateTableModal/CreateTableTabField/CreateTableTabField.tsx
@@ -76,7 +76,7 @@ class ColumnsWrapper extends React.Component<Props & CWProps, CWState> {
         return isEmpty_(res) ? null : res;
     }
 
-    state: CWState = {
+    override state: CWState = {
         tabItems: [],
         orderedTabItems: [],
         keyColumns: {},
@@ -202,7 +202,7 @@ class ColumnsWrapper extends React.Component<Props & CWProps, CWState> {
         this.onOrderChanged(newTabItems, newIndex, oldIndex);
     };
 
-    render() {
+    override render() {
         const {activeTab, ...rest} = this.props;
         const {orderedTabItems} = this.state;
 
@@ -250,7 +250,7 @@ export default class CreateTableTabField extends React.Component<Props> {
         );
     }
 
-    render() {
+    override render() {
         const {className, activeTab, tabItems, ...rest} = this.props;
         const [tableSettings, ...restItems] = tabItems;
 

--- a/packages/ui/src/ui/pages/navigation/tabs/Schema/Schema.tsx
+++ b/packages/ui/src/ui/pages/navigation/tabs/Schema/Schema.tsx
@@ -92,7 +92,7 @@ type SchemaState = {
 };
 
 class Schema extends Component<SchemaProps> {
-    state: SchemaState;
+    override state: SchemaState;
 
     constructor(props: SchemaProps) {
         super(props);
@@ -103,7 +103,7 @@ class Schema extends Component<SchemaProps> {
         };
     }
 
-    componentDidMount() {
+    override componentDidMount() {
         this.loadExternalSchemaData();
     }
 
@@ -274,7 +274,7 @@ class Schema extends Component<SchemaProps> {
         );
     }
 
-    render() {
+    override render() {
         const {meta, schema} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/OperationDetail.tsx
@@ -175,7 +175,7 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
         return unipika.prepareSettings();
     }
 
-    componentDidMount() {
+    override componentDidMount() {
         const {operationId} = this.props.match.params;
         this.props.listOperationEvents(operationId);
     }
@@ -534,7 +534,7 @@ class OperationDetail extends React.Component<ReduxProps & RouteProps> {
         return <YTErrorBlock message={errorData.message} error={errorData.details} />;
     }
 
-    render() {
+    override render() {
         const {
             error,
             loading,

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Details/Details.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Details/Details.tsx
@@ -42,7 +42,7 @@ const block = cn('operation-details');
 type ReduxProps = ConnectedProps<typeof connector>;
 
 class Details extends Component<ReduxProps> {
-    state = {
+    override state = {
         isAbsoluteValue: true,
     };
 
@@ -211,7 +211,7 @@ class Details extends Component<ReduxProps> {
         );
     }
 
-    render() {
+    override render() {
         const {isVanillaGpuOperation} = this.props;
         return (
             <div className={block()}>

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Runtime/Runtime.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Runtime/Runtime.tsx
@@ -224,7 +224,7 @@ class Runtime extends Component<Props> {
         );
     }
 
-    render() {
+    override render() {
         const {runtime} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Tasks/Tasks.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/details/Tasks/Tasks.tsx
@@ -107,7 +107,7 @@ class Tasks extends React.Component<Props, State> {
         return isEmpty_(res) ? null : res;
     }
 
-    state: State = {
+    override state: State = {
         allowActions: false,
         expandedState: {},
 
@@ -255,7 +255,7 @@ class Tasks extends React.Component<Props, State> {
         return undefined;
     }
 
-    render() {
+    override render() {
         const {className, jobs, collapsibleSize, collapsed} = this.props;
         return !jobs?.items?.length ? null : (
             <CollapsibleSection

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/job-sizes/JobSizes/JobSizes.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/job-sizes/JobSizes/JobSizes.tsx
@@ -57,11 +57,11 @@ class JobSizes extends React.Component<Props, State> {
         };
     }
 
-    state: State = {
+    override state: State = {
         showEstimated: false,
     };
 
-    render() {
+    override render() {
         const {className} = this.props;
         return (
             <WithStickyToolbar

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/partition-sizes/PartitionSizes/PartitionSizes.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/partition-sizes/PartitionSizes/PartitionSizes.tsx
@@ -46,9 +46,9 @@ class PartitionSizes extends React.Component<ReduxProps, State> {
         };
     }
 
-    state: State = {};
+    override state: State = {};
 
-    render() {
+    override render() {
         const {data} = this.state;
         if (!data) {
             return null;

--- a/packages/ui/src/ui/pages/operations/OperationDetail/tabs/statistics/Statistics.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationDetail/tabs/statistics/Statistics.tsx
@@ -61,7 +61,7 @@ interface ItemState {
 type Props = {className?: string} & ConnectedProps<typeof connector>;
 
 export class Statistics extends Component<Props> {
-    componentWillUnmount() {
+    override componentWillUnmount() {
         this.expandTable();
     }
 
@@ -238,7 +238,7 @@ export class Statistics extends Component<Props> {
         );
     }
 
-    render() {
+    override render() {
         const {className, treeState, items} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/operations/OperationProgress/OperationProgress.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationProgress/OperationProgress.tsx
@@ -189,7 +189,7 @@ class OperationProgress extends Component<OperationProgressProps & ReduxProps> {
             </div>
         );
     }
-    render() {
+    override render() {
         const className = 'operation-progress';
         const {type} = this.props;
         return (

--- a/packages/ui/src/ui/pages/operations/OperationSelectFilter/OperationSelectFilter.tsx
+++ b/packages/ui/src/ui/pages/operations/OperationSelectFilter/OperationSelectFilter.tsx
@@ -63,7 +63,7 @@ export default class OperationSelectFilter<NameT extends string = string> extend
         return res;
     }
 
-    render() {
+    override render() {
         const {name, label, value = [], placeholder, multiple, ...props} = this.props;
 
         const placeHolder = 'function' === typeof placeholder ? placeholder(value) : placeholder;

--- a/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesNodeBlock.ts
+++ b/packages/ui/src/ui/pages/query-tracker/Plan/GraphEditor/QueriesNodeBlock.ts
@@ -154,7 +154,7 @@ export class QueriesCanvasBlock extends YTGraphCanvasBlock<QueriesNodeBlock> {
         this.drawIcon(icon, x + width - iconSide, y, iconSide, iconSide);
     }
 
-    protected drawBottomText(bottomText?: string) {
+    protected override drawBottomText(bottomText?: string) {
         if (!bottomText) return;
 
         const maxTextWidth = this.state.width * 3 - this.state.width * BOTTOM_TEXT_OFFSET_RATIO;
@@ -182,7 +182,7 @@ export class QueriesCanvasBlock extends YTGraphCanvasBlock<QueriesNodeBlock> {
         });
     }
 
-    protected drawCounter(total: number, mode?: ZoomMode) {
+    protected override drawCounter(total: number, mode?: ZoomMode) {
         const {x, y, height, width} = this.state;
 
         const counterX = x + width / 2;

--- a/packages/ui/src/ui/pages/scheduling/PoolQoutaEditor/PoolQuotaEditor.tsx
+++ b/packages/ui/src/ui/pages/scheduling/PoolQoutaEditor/PoolQuotaEditor.tsx
@@ -62,7 +62,7 @@ class PoolQuotaEditorControl extends React.Component<Props & ReduxProps> {
         return isEqual_(left, right);
     }
 
-    render() {
+    override render() {
         const {
             pool,
             format,

--- a/packages/ui/src/ui/pages/system/HttpProxies/HttpProxies.tsx
+++ b/packages/ui/src/ui/pages/system/HttpProxies/HttpProxies.tsx
@@ -51,7 +51,7 @@ class Proxies extends Component<ReduxProps> {
         );
     }
 
-    render() {
+    override render() {
         return (
             <React.Fragment>
                 <ProxiesUpdater />

--- a/packages/ui/src/ui/pages/system/RpcProxies/RpcProxies.tsx
+++ b/packages/ui/src/ui/pages/system/RpcProxies/RpcProxies.tsx
@@ -47,7 +47,7 @@ class RpcProxies extends Component<ReduxProps> {
         );
     }
 
-    render() {
+    override render() {
         return (
             <React.Fragment>
                 <RpcProxiesUpdater />

--- a/packages/ui/src/ui/pages/system/SystemCounters/SystemCounters.tsx
+++ b/packages/ui/src/ui/pages/system/SystemCounters/SystemCounters.tsx
@@ -160,7 +160,7 @@ class SystemCounters<Flags extends string> extends React.Component<SystemCounter
         );
     }
 
-    render() {
+    override render() {
         const countersFlags = this.renderCountersFlags();
         const countersStates = this.renderCountersStates();
         const counterTotal = this.renderCounterTotal();

--- a/packages/ui/src/ui/pages/system/SystemStateOverview/SystemStateOverview.tsx
+++ b/packages/ui/src/ui/pages/system/SystemStateOverview/SystemStateOverview.tsx
@@ -19,7 +19,7 @@ export type SystemStateOverviewProps<Flags extends string> = Partial<SystemState
 export default class SystemStateOverview<Flags extends string> extends React.Component<
     SystemStateOverviewProps<Flags>
 > {
-    render() {
+    override render() {
         const {stateOverview: _x, labels, ...rest} = this.props;
         if (!this.props.counters) {
             return null;

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTable.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTable.tsx
@@ -352,7 +352,7 @@ class BundlesTable extends React.Component<ReduxProps> {
         return this.column(columnName, true);
     }
 
-    render() {
+    override render() {
         const columns = this.props.columns.map((x) => Columns[x].call(this));
 
         const {data, total, loading, loaded} = this.props;

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTableInstruments.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/bundles/BundlesTableInstruments.tsx
@@ -23,7 +23,7 @@ class BundlesTableInstruments extends React.Component<Props & ReduxProps> {
         this.props.setTabletsFirstBundleAsActive();
     };
 
-    render() {
+    override render() {
         const {
             accountFilter,
             bundlesTableMode,

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsInstruments.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsInstruments.tsx
@@ -56,7 +56,7 @@ class CellsTableInstruments extends React.Component<Props & ReduxProps> {
         return filter_(hosts, (host = '') => host.indexOf(text) !== -1);
     };
 
-    render() {
+    override render() {
         const {className, idFilter, bundleFilter, activeBundle, activeBundleHosts} = this.props;
 
         return (

--- a/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
+++ b/packages/ui/src/ui/pages/tablet_cell_bundles/cells/CellsTable.tsx
@@ -231,7 +231,7 @@ class CellsTable extends React.Component<Props & ReduxProps> {
         return this.column(name, true);
     }
 
-    render() {
+    override render() {
         const columns = this.props.columns.map((x) => Columns[x].call(this));
 
         const {data, loading, loaded} = this.props;

--- a/packages/ui/src/ui/pages/users/UsersPageEditor/UsersPageEditor.tsx
+++ b/packages/ui/src/ui/pages/users/UsersPageEditor/UsersPageEditor.tsx
@@ -131,7 +131,7 @@ class UsersPageEditor extends React.Component<Props, State> {
         return [current].filter(({data}) => data.length);
     }
 
-    state: State = {};
+    override state: State = {};
 
     // eslint-disable-next-line react/sort-comp
     onAdd = async (form: FormApi<FormValues>) => {
@@ -221,7 +221,7 @@ class UsersPageEditor extends React.Component<Props, State> {
         return !this.props.username;
     }
 
-    render() {
+    override render() {
         const {
             className,
             showModal,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "@gravity-ui/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "noImplicitOverride": true,
     "target": "ES2018",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
   },
   "include": [
       ".storybook/*",


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/vZhnlb3V7q3BoZ
<!-- nda-end --> ## Summary by Sourcery

Enable strict override checking across the frontend TypeScript packages.

Enhancements:
- Enable TypeScript noImplicitOverride checks across the components and UI packages and annotate overridden React and graph component members accordingly.
- Align the UI server TypeScript configuration with the package configuration while preserving its server-specific compiler settings.