### PR TITLE
fix(unipika): resolve root-relative URLs before wrapping in referrer …

### DIFF
--- a/packages/ui/src/ui/common/thor/unipika-settings.ts
+++ b/packages/ui/src/ui/common/thor/unipika-settings.ts
@@ -32,8 +32,13 @@ const makeNormalizeUrl = createSelector(
         if (!hideReferrerUrl) {
             return undefined;
         }
+
         return function normalizeUrl(url?: string) {
-            return `${hideReferrerUrl}?${encodeURIComponent(url!)}`;
+            const targetUrl = url?.startsWith('/')
+                ? new URL(url, window.location.origin).href
+                : url;
+
+            return `${hideReferrerUrl}?${encodeURIComponent(String(targetUrl))}`;
         };
     },
 );


### PR DESCRIPTION
<!-- nda-start -->
https://nda.ya.ru/t/IikKp1vL7qLZbs
<!-- nda-end -->…redirect [YTFRONT-5896]

## Summary by Sourcery

Bug Fixes:
- Resolve root-relative URLs against the current origin before encoding them in referrer-protection redirects.